### PR TITLE
Task-50788: Make sure to display a shareable document preview link.

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -9,7 +9,7 @@
       <documents-body
         :view-extension="selectedViewExtension"
         :files="files"
-        :groupsSizes="groupsSizes"
+        :groups-sizes="groupsSizes"
         :page-size="pageSize"
         :offset="offset"
         :limit="limit"
@@ -71,8 +71,8 @@ export default {
     this.$root.$on('document-search', this.search);
     this.$root.$on('documents-sort', this.sort);
     
-    const currentUrlPath = window.location.search;
-    const queryParams = new URLSearchParams(currentUrlPath);
+    const currentUrlSearchParams = window.location.search;
+    const queryParams = new URLSearchParams(currentUrlSearchParams);
     if (queryParams.has('documentPreviewId')) {
       this.loading = true;
       this.previewMode = true;

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -44,6 +44,7 @@ export default {
       'beforeThisYear': 0,
     },
     selectedView: null,
+    previewMode: false,
   }),
   computed: {
     selectedViewExtension() {
@@ -62,11 +63,41 @@ export default {
 
     this.$root.$on('documents-refresh-files', this.refreshFilesEvent);
     this.getDocumentGroupSizes();
-    this.refreshFiles().finally(() => this.$root.$applicationLoaded());
+    this.refreshFiles().then(() => {
+      this.watchDocumentPreview();
+    }).finally(() => this.$root.$applicationLoaded());
 
     this.$root.$on('document-load-more', this.loadMore);
     this.$root.$on('document-search', this.search);
     this.$root.$on('documents-sort', this.sort);
+    
+    const currentUrlPath = window.location.search;
+    const queryParams = new URLSearchParams(currentUrlPath);
+    if (queryParams.has('documentPreviewId')) {
+      this.loading = true;
+      this.previewMode = true;
+      const documentPreviewId = queryParams.get('documentPreviewId');
+      this.$attachmentService.getAttachmentById(documentPreviewId)
+        .then(attachment => {
+          documentPreview.init({
+            doc: {
+              id: documentPreviewId,
+              repository: 'repository',
+              workspace: 'collaboration',
+              path: attachment.path,
+              title: attachment.title,
+              icon: attachment.icon,
+              size: attachment.size,
+              openUrl: attachment.openUrl,
+              downloadUrl: attachment.downloadUrl,
+            },
+            author: attachment.updater,
+            showComments: false,
+          });
+        })
+        .catch(e => console.error(e))
+        .finally(() => this.loading = false);
+    }
   },
   destroyed() {
     document.removeEventListener(`extension-${this.extensionApp}-${this.extensionType}-updated`, this.refreshViewExtensions);
@@ -154,6 +185,30 @@ export default {
       if (changed) {
         this.viewExtensions = Object.assign({}, this.viewExtensions);
       }
+    },
+    watchDocumentPreview() {
+      const self = this;
+      const bodyElement = document.body;
+
+      const config = {childList: true, subtree: true};
+
+      const callback = function () {
+        const documentPreviewContainer = document.getElementById('documentPreviewContainer');
+        if (!documentPreviewContainer && self.previewMode) {
+          // Quit preview mode
+          self.previewMode = false;
+          window.history.pushState('', '', eXo.env.server.portalBaseURL);
+        } else if (documentPreviewContainer && !self.previewMode) {
+          // Enter preview mode
+          self.previewMode = true;
+        }
+      };
+
+      // Create an observer instance linked to the callback function
+      const observer = new MutationObserver(callback);
+
+      // Start observing the target node for configured mutations
+      observer.observe(bodyElement, config);
     },
   },
 };

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -115,7 +115,10 @@ export default {
           });
         })
         .catch(e => console.error(e))
-        .finally(() => this.loading = false);
+        .finally(() => {
+          window.history.pushState('', '', `${eXo.env.server.portalBaseURL}?documentPreviewId=${this.file.id}`);
+          this.loading = false;
+        });
     },
   },
 };


### PR DESCRIPTION
Issue: Since the documentPreview is an external module, we can not catch the changes when the preview mode is exited.
Solution: these changes make sure to watch the preview document container presence in the DOM using the MutationObserver: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver