### PR TITLE
TASK-56287: Do not remind me from switch old app docs pop up remove switch button of old/new doc app from user

### DIFF
--- a/documents-webapp/src/main/webapp/WEB-INF/conf/documents/features-flags-configuration.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/conf/documents/features-flags-configuration.xml
@@ -95,6 +95,19 @@
         </init-params>
     </component>
 
+    <component>
+        <key>IntroduceSwitchOldDocAppFeatureProperties</key>
+        <type>org.exoplatform.container.ExtendedPropertyConfigurator</type>
+        <init-params>
+            <properties-param>
+                <name>IntroduceSwitchOldDocAppFeatureProperties</name>
+                <description>Introduce Switch to old Document App Feature enablement flag</description>
+                <property name="exo.feature.IntroduceSwitchOldDocApp.enabled"
+                          value="${exo.feature.IntroduceSwitchOldDocApp.enabled:false}"/>
+            </properties-param>
+        </init-params>
+    </component>
+
     <external-component-plugins>
         <target-component>org.exoplatform.groovyscript.text.TemplateService</target-component>
         <component-plugin>
@@ -119,7 +132,7 @@
             <type>org.exoplatform.documents.plugin.DocumentsFeaturePlugin</type>
         </component-plugin>
         <component-plugin>
-            <name>SwitchOldDocuments</name>
+            <name>IntroduceSwitchOldDocApp</name>
             <set-method>addFeaturePlugin</set-method>
             <type>org.exoplatform.documents.plugin.DocumentsFeaturePlugin</type>
         </component-plugin>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsAppReminder.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsAppReminder.vue
@@ -1,7 +1,7 @@
 <template>
   <v-main>
     <changes-reminder :reminder="introduceNewDocAppReminder" />
-    <changes-reminder :reminder="switchOldDocAppReminder" />
+    <changes-reminder :reminder="introduceSwitchOldAppReminder" />
   </v-main>
 </template>
 
@@ -15,8 +15,8 @@ export default {
         img: '/documents-portlet/images/newdocapp.png',
         description: this.$t('documents.reminder.newDocApp.Dialog.message'),
       },
-      switchOldDocAppReminder: {
-        name: 'SwitchOldDocuments',
+      introduceSwitchOldAppReminder: {
+        name: 'IntroduceSwitchOldDocApp',
         title: this.$t('documents.reminder.oldDocSwitch.dialog.title'),
         img: '/documents-portlet/images/switcholdapp.gif',
         description: this.$t('documents.reminder.oldDocSwitch.Dialog.message'),


### PR DESCRIPTION
prior to this change, the switch old doc app popup was depending on swicthOldDocument feature flag, which disable it when click on do not remind, this fix should create a separate flag for the switch old doc popup