### PR TITLE
TASK-55810: Documents are not added in folder with uppercase name

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -316,7 +316,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       }
       String homePath = "";
       if (node != null) {
-        String nodeName= node.hasProperty(NodeTypeConstants.EXO_NAME) ? node.getProperty(NodeTypeConstants.EXO_NAME).getString() : node.getName();
+        String nodeName= node.hasProperty(NodeTypeConstants.EXO_TITLE) ? node.getProperty(NodeTypeConstants.EXO_TITLE).getString() : node.getName();
         parents.add(new BreadCrumbItem(((NodeImpl) node).getIdentifier(), nodeName, node.getPath()));
         if (node.getPath().contains(SPACE_PATH_PREFIX)) {
           String[] pathParts = node.getPath().split(SPACE_PATH_PREFIX)[1].split("/");
@@ -335,14 +335,14 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
             if(node.getName().equals(USER_PUBLIC_ROOT_NODE)){
               node = getIdentityRootNode(spaceService, nodeHierarchyCreator, username, ownerIdentity, sessionProvider);
               if (node != null) {
-                nodeName= node.hasProperty(NodeTypeConstants.EXO_NAME) ? node.getProperty(NodeTypeConstants.EXO_NAME).getString() : node.getName();
+                nodeName= node.hasProperty(NodeTypeConstants.EXO_TITLE) ? node.getProperty(NodeTypeConstants.EXO_TITLE).getString() : node.getName();
                 parents.add(new BreadCrumbItem(((NodeImpl) node).getIdentifier(), nodeName, node.getPath()));
               }
               break;
             } else{
               node = node.getParent();
               if (node != null) {
-                nodeName= node.hasProperty(NodeTypeConstants.EXO_NAME) ? node.getProperty(NodeTypeConstants.EXO_NAME).getString() : node.getName();
+                nodeName= node.hasProperty(NodeTypeConstants.EXO_TITLE) ? node.getProperty(NodeTypeConstants.EXO_TITLE).getString() : node.getName();
                 parents.add(new BreadCrumbItem(((NodeImpl) node).getIdentifier(), nodeName, node.getPath()));
               }
             }

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -78,6 +78,7 @@ export default {
     hasMore: false,
     viewExtensions: {},
     currentFolderPath: '',
+    currentFolder: null,
     groupsSizes: {
       'thisDay': 0,
       'thisWeek': 0,
@@ -138,7 +139,7 @@ export default {
     this.$root.$on('confirm-document-deletion', this.deleteDocument);
     this.$root.$on('undo-delete-document', this.undoDeleteDocument);
     this.$root.$on('documents-open-drawer', this.openDrawer);
-    this.$root.$on('set-current-folder-url', this.setFolderUrl);
+    this.$root.$on('set-current-folder', this.setCurrentFolder);
     this.$root.$on('cancel-add-folder', this.cancelAddFolder);
     this.$root.$on('document-search', this.search);
     this.$root.$on('save-visibility', this.saveVisibility);
@@ -459,7 +460,7 @@ export default {
         if (pathparts.length>1){
           attachmentAppConfiguration= {
             'sourceApp': 'NEW.APP',
-            'defaultFolder': decodeURI(pathparts[1]),
+            'defaultFolder': this.extractDefaultFolder(pathparts[1]),
             'defaultDrive': {
               isSelected: true,
               name: `.spaces.${eXo.env.portal.spaceGroup}`,
@@ -475,7 +476,7 @@ export default {
         if (pathparts.length>1){
           attachmentAppConfiguration= {
             'sourceApp': 'NEW.APP',
-            'defaultFolder': decodeURI(pathparts[1]),
+            'defaultFolder': this.extractDefaultFolder(pathparts[1]),
             'defaultDrive': {
               isSelected: true,
               name: 'Personal Documents',
@@ -486,8 +487,13 @@ export default {
       }
       document.dispatchEvent(new CustomEvent('open-attachments-app-drawer', {detail: attachmentAppConfiguration}));
     },
-    setFolderUrl(url) {
-      this.currentFolderPath=url;
+    extractDefaultFolder(targetPath) {
+      const path = decodeURI(targetPath);
+      const folderName = path && path.substring(path.lastIndexOf('/'));
+      return folderName && path.replace(folderName, `/${this.currentFolder.name}`);
+    },
+    setCurrentFolder(folder) {
+      this.currentFolder = folder;
     },
     getDocumentDataFromUrl() {
       const currentUrlSearchParams = window.location.search;

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsMoveDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsMoveDrawer.vue
@@ -113,10 +113,8 @@ export default {
     },
   },
   created() {
-    this.$root.$on('set-current-folder-url', data => {
-      if (data){
-        this.currentFolderPath = data;
-      }
+    this.$root.$on('set-current-folder', data => {
+      this.currentFolderPath = data && data.path;
     });
     this.$root.$on('current-space',data => {
       const ownerId = data ? data.identity.id : null;

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -222,7 +222,7 @@ export default {
         .then(breadCrumbs => {this.documentsBreadcrumb = breadCrumbs;
           this.actualFolderId = this.documentsBreadcrumb[this.documentsBreadcrumb.length-1].id;
           this.currentFolderPath = this.documentsBreadcrumb[this.documentsBreadcrumb.length-1].path;
-          this.$root.$emit('set-current-folder-url', this.currentFolderPath);
+          this.$root.$emit('set-current-folder', this.documentsBreadcrumb[this.documentsBreadcrumb.length - 1]);
         })
         .finally(() => this.loading = false);
     },


### PR DESCRIPTION
ISSUE: When open the attachment drawer in default folder param was taking node name as value while the attachment drawer using the title to search the target folder inside its drive or its parent folder.
FIX: This PR should make sure to send the folder title instead of name in the attachmentdrawer configurations