### PR TITLE
TASK-56068: Sort by date is not working in folder view 

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -146,9 +146,7 @@ public class JCRDocumentsUtil {
                                            Session session,
                                            NodeIterator nodeIterator,
                                            Identity aclIdentity,
-                                           SpaceService spaceService,
-                                           int offset,
-                                           int limit) {
+                                           SpaceService spaceService) {
     List<AbstractNode> fileNodes = new ArrayList<>();
     while (nodeIterator.hasNext()) {
       Node node = nodeIterator.nextNode();
@@ -184,21 +182,8 @@ public class JCRDocumentsUtil {
         LOG.warn("Error getting Folder Node for search result with path {}", node, e);
       }
     }
-    Collections.sort(fileNodes, new Comparator<AbstractNode>(){
-      public int compare(AbstractNode s1, AbstractNode s2) {
-        return s1.getName().compareToIgnoreCase(s2.getName());
-      }
-    });
-    Collections.sort(fileNodes, new Comparator<AbstractNode>(){
-      public int compare(AbstractNode n1, AbstractNode n2) {
-        return Boolean.compare(n2.isFolder(),n1.isFolder());
-      }
-    });
 
-    if(limit < fileNodes.size()){
-      return fileNodes.subList(offset,limit);
-    }
-    return fileNodes.subList(offset,fileNodes.size());
+    return fileNodes;
   }
 
   public static FolderNode toFolderNode(IdentityManager identityManager,


### PR DESCRIPTION

ISSUE: when getting folders with sort filter in parameter but without a query field or the filter field is not favorites, then no sort is applied on the jcr query to get nodes.
FIX: This PR should make sure to create an sql query with different filter items to allow getting ordered nodes depends on the sort field