### PR TITLE
Task-55212: Information last update isn't updated after rename document

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -322,8 +322,8 @@ public class JCRDocumentsUtil {
       String owner = node.getProperty(NodeTypeConstants.EXO_OWNER).getString();
       documentNode.setCreatorId(getUserIdentityId(identityManager, owner));
     }
-    if (node.hasProperty(NodeTypeConstants.EXO_DATE_MODIFIED)) {
-      long modifiedDate = node.getProperty(NodeTypeConstants.EXO_DATE_MODIFIED)
+    if (node.hasProperty(NodeTypeConstants.EXO_LAST_MODIFIED_DATE)) {
+      long modifiedDate = node.getProperty(NodeTypeConstants.EXO_LAST_MODIFIED_DATE)
                               .getDate()
                               .getTimeInMillis();
       documentNode.setModifiedDate(modifiedDate);


### PR DESCRIPTION

Prior to this fix, when user try to update any document after rename, the Information "last update" isn't updated,
With this fix, we will be able to return the last updated date  with   EXO_LAST_MODIFIED_DATE propertie.
