### PR TITLE
TASK-57242: Can't edit uploaded pptx files in document app

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -344,7 +344,7 @@ public class JCRDocumentsUtil {
 
   public static void retrieveFileContentProperties(Node content, FileNode fileNode) throws RepositoryException {
     if (content.hasProperty(NodeTypeConstants.DC_DESCRIPTION)) {
-      fileNode.setDescription(content.getProperty(NodeTypeConstants.DC_DESCRIPTION).getString());
+      fileNode.setDescription(content.getProperty(NodeTypeConstants.DC_DESCRIPTION).getValues()[0].getString());
     }
     if (content.hasProperty(NodeTypeConstants.JCR_MIME_TYPE)) {
       fileNode.setMimeType(content.getProperty(NodeTypeConstants.JCR_MIME_TYPE).getString());


### PR DESCRIPTION
Prior to this change, PPtx file are not editable because of a wrong way of extracting of the multivalued jcr:content/dc:description property which caused a javax.jcr.ValueFormatException.
THis PR should make sure to correctly extract this property to avoid the exception