### PR TITLE
Task-57305: Fix moving a folder to another space

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsMoveDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsMoveDrawer.vue
@@ -99,6 +99,7 @@ export default {
     spaceName: eXo.env.portal.spaceName,
     userName: eXo.env.portal.userName,
     fileName: '',
+    groupId: '',
     space: []
   }),
   computed: {
@@ -120,6 +121,7 @@ export default {
       const ownerId = data ? data.identity.id : null;
       this.items = [];
       this.space = data;
+      this.groupId = data.groupId;
       this.documentsBreadcrumbDestination = [{
         name: 'Documents'
       }];
@@ -164,7 +166,8 @@ export default {
         });
     },
     moveDocument(){
-      this.$root.$emit('documents-move', this.ownerId, this.file.id, this.folder.path);
+      const destinationPath = this.folder && this.folder.path ? this.folder.path:`/Groups${this.groupId}/Documents`;
+      this.$root.$emit('documents-move', this.ownerId, this.file.id, destinationPath);
       this.close();
     },
   }


### PR DESCRIPTION
Before this change, when you don't choose a destination, we can't move a folder to another space.
To solve this problem, by default we add the parent document to allow moving this folder.