### PR TITLE
Task-56789: Edit option is displayed for Non supported OO files

### DIFF
--- a/documents-api/pom.xml
+++ b/documents-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.documents</groupId>
     <artifactId>documents-parent</artifactId>
-    <version>1.1.x-SNAPSHOT</version>
+    <version>1.1.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>documents-api</artifactId>
   <name>eXo Documents - API</name>

--- a/documents-packaging/pom.xml
+++ b/documents-packaging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.documents</groupId>
     <artifactId>documents-parent</artifactId>
-    <version>1.1.x-SNAPSHOT</version>
+    <version>1.1.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>documents-packaging</artifactId>
   <packaging>pom</packaging>

--- a/documents-services/pom.xml
+++ b/documents-services/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.documents</groupId>
     <artifactId>documents-parent</artifactId>
-    <version>1.1.x-SNAPSHOT</version>
+    <version>1.1.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>documents-services</artifactId>
   <name>eXo Documents - Services</name>

--- a/documents-storage-jcr/pom.xml
+++ b/documents-storage-jcr/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.documents</groupId>
     <artifactId>documents-parent</artifactId>
-    <version>1.1.x-SNAPSHOT</version>
+    <version>1.1.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>documents-storage-jcr</artifactId>
   <name>eXo Documents - Storage JCR Implementation</name>

--- a/documents-webapp/pom.xml
+++ b/documents-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.documents</groupId>
     <artifactId>documents-parent</artifactId>
-    <version>1.1.x-SNAPSHOT</version>
+    <version>1.1.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>documents-webapp</artifactId>
   <packaging>war</packaging>

--- a/documents-webapp/src/main/webapp/skin/less/documents.less
+++ b/documents-webapp/src/main/webapp/skin/less/documents.less
@@ -100,10 +100,10 @@
 
     .documentViewTabs {
          .v-tab.v-tab--active {
-           border: 1px solid var(--allPagesPrimaryColor, #578dc9) !important;
+           border: 1px solid var(--allPagesPrimaryColor, #476A9C) !important;
            background-color: var(--allPagesTabNormalLinkBackground, #f0f4f7) !important;
            .tabIcon{
-             color: var(--allPagesPrimaryColor, #578dc9) !important;
+             color: var(--allPagesPrimaryColor, #476A9C) !important;
              }
          }
          .v-tabs-slider-wrapper {
@@ -579,22 +579,22 @@
     height: 26px !important;
     color: #f6f7fa;
     background-color: #477ab3;
-    background-image: -moz-linear-gradient(top, #578dc9, #2f5e92);
+    background-image: -moz-linear-gradient(top, #476A9C, #2f5e92);
     background-image: -webkit-gradient(
       linear,
       0 0,
       0 100%,
-      from(#578dc9),
+      from(#476A9C),
       to(#2f5e92)
     );
-    background-image: -webkit-linear-gradient(top, #578dc9, #2f5e92);
-    background-image: -o-linear-gradient(top, #578dc9, #2f5e92);
-    background-image: linear-gradient(to bottom, #578dc9, #2f5e92);
+    background-image: -webkit-linear-gradient(top, #476A9C, #2f5e92);
+    background-image: -o-linear-gradient(top, #476A9C, #2f5e92);
+    background-image: linear-gradient(to bottom, #476A9C, #2f5e92);
     background-repeat: repeat-x;
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff578dc9', endColorstr='#ff2f5e92', GradientType=0);
-    -webkit-box-shadow: inset 0px 3px 5px #578dc9;
-    -moz-box-shadow: inset 0px 3px 5px #578dc9;
-    box-shadow: inset 0px 3px 5px #578dc9;
+    -webkit-box-shadow: inset 0px 3px 5px #476A9C;
+    -moz-box-shadow: inset 0px 3px 5px #476A9C;
+    box-shadow: inset 0px 3px 5px #476A9C;
     -webkit-border-top-left-radius: 9px;
     -moz-border-radius-topleft: 9px;
     border-top-left-radius: 9px;
@@ -603,7 +603,7 @@
     border-bottom-left-radius: 9px;
     height: 57px;
     border-radius: 100px;
-    background-color: #578dc9;
+    background-color: #476A9C;
     -webkit-transform: translateX(-190px);
     -ms-transform: translateX(-190px);
     transform: translateX(-190px);

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
@@ -18,7 +18,11 @@ export default {
     file: {
       type: Object,
       default: null,
-    }
+    },
+    fileType: {
+      type: String,
+      default: null
+    },
   },
   data: () => ({
     menuExtensionApp: 'DocumentMenu',
@@ -27,7 +31,8 @@ export default {
     mobileOnlyExtensions: ['favorite','details'],
     desktopOnlyExtensions: ['edit'],
     editExtensions: 'edit',
-    fileOnlyExtension: ['download','favorite','visibility']
+    fileOnlyExtension: ['download','favorite','visibility'],
+    fileExtensionsEditable: ['.docx','.pptx','.xlsx']
   }),
   created() {
     document.addEventListener(`extension-${this.menuExtensionApp}-${this.menuExtensionType}-updated`, this.refreshMenuExtensions);
@@ -43,8 +48,7 @@ export default {
       return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm';
     },
     fileCanEdit(){
-      const type = this.file && this.file.mimeType || '';
-      return ( type.includes('word') || type.includes('presentation') || type.includes('sheet') );
+      return this.fileExtensionsEditable.includes(this.fileType) ;
     }
   },
   methods: {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -83,7 +83,8 @@
             close-on-click
             absolute>
             <documents-actions-menu
-              :file="file" />
+              :file="file"
+              :file-type="fileType" />
           </v-menu>
         </template>
         <span>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -142,7 +142,7 @@ export default {
       if (this.file && this.file.folder){
         return {
           class: 'fas fa-folder',
-          color: '#578DC9',
+          color: '#476A9C',
         };
       }
       const type = this.file && this.file.mimeType || '';
@@ -199,7 +199,7 @@ export default {
       } else {
         return {
           class: 'fas fa-file',
-          color: '#578DC9',
+          color: '#476A9C',
         };
       }
     },

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderView.vue
@@ -18,7 +18,7 @@
       disable-pagination
       disable-filtering
       :class="loading && !items.length ? 'loadingClass' : ''"
-      class="documents-folder-table border-box-sizing">
+      class="documents-folder-table border-box-sizing ms-8">
       <template
         v-for="header in extendedCells"
         #[`item.${header.value}`]="{item}">

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.exoplatform.documents</groupId>
   <artifactId>documents-parent</artifactId>
-  <version>1.1.x-SNAPSHOT</version>
+  <version>1.1.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo Documents - Parent POM</name>
   <modules>
@@ -27,9 +27,9 @@
   </scm>
   <properties>
     <!-- 3rd party libraries versions -->
-    <org.exoplatform.social.version>6.4.x-SNAPSHOT</org.exoplatform.social.version>
-    <org.exoplatform.platform-ui.version>6.4.x-SNAPSHOT</org.exoplatform.platform-ui.version>
-    <addon.exo.jcr.version>6.4.x-SNAPSHOT</addon.exo.jcr.version>
+    <org.exoplatform.social.version>6.4.x-maintenance-SNAPSHOT</org.exoplatform.social.version>
+    <org.exoplatform.platform-ui.version>6.4.x-maintenance-SNAPSHOT</org.exoplatform.platform-ui.version>
+    <addon.exo.jcr.version>6.4.x-maintenance-SNAPSHOT</addon.exo.jcr.version>
     <!-- Sonar properties -->
     <sonar.organization>exoplatform</sonar.organization>
   </properties>


### PR DESCRIPTION

Prior to this fix, Edit option is displayed for odp extension that is not supported OO files, since the mimeType of odp file includes 'presentation'.
With this fix, we will be sure to display Edit option only for '.docx,.pptx,.xlsx' extension.
