### PR TITLE
TASK-57175: fix user can download files in the document application even if the transfer rule to disable file downloads in set

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
@@ -32,7 +32,11 @@ export default {
   }),
   created() {
     document.addEventListener(`extension-${this.menuExtensionApp}-${this.menuExtensionType}-updated`, this.refreshMenuExtensions);
-    Vue.prototype.$transferRulesService.getTransfertRulesDownloadDocumentStatus().then(data=>{this.downloadEnabled = data;this.refreshMenuExtensions();});
+    this.$transferRulesService.getTransfertRulesDownloadDocumentStatus()
+      .then(data=> {
+        this.downloadEnabled = data;
+        this.refreshMenuExtensions();
+      });
   },
   computed: {
     params() {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
@@ -21,6 +21,7 @@ export default {
     }
   },
   data: () => ({
+    downloadEnabled: true,
     menuExtensionApp: 'DocumentMenu',
     menuExtensionType: 'menuActionMenu',
     menuExtensions: {},
@@ -31,7 +32,7 @@ export default {
   }),
   created() {
     document.addEventListener(`extension-${this.menuExtensionApp}-${this.menuExtensionType}-updated`, this.refreshMenuExtensions);
-    this.refreshMenuExtensions();
+    Vue.prototype.$transferRulesService.getTransfertRulesDownloadDocumentStatus().then(data=>{this.downloadEnabled = data;this.refreshMenuExtensions();});
   },
   computed: {
     params() {
@@ -63,7 +64,12 @@ export default {
           if (((!this.isMobile && !this.mobileOnlyExtensions.includes(extension.id))
               || (this.isMobile && !this.desktopOnlyExtensions.includes(extension.id)))
           && (!this.file.folder || (this.file.folder && !this.fileOnlyExtension.includes(extension.id)))) {
-            this.menuExtensions[extension.id] = extension;
+            if (extension.id === 'download' && !this.downloadEnabled){
+              return;
+            }
+            else {
+              this.menuExtensions[extension.id] = extension;
+            } 
             changed = true;
           }
         }

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
@@ -33,8 +33,8 @@ export default {
   created() {
     document.addEventListener(`extension-${this.menuExtensionApp}-${this.menuExtensionType}-updated`, this.refreshMenuExtensions);
     this.$transferRulesService.getTransfertRulesDownloadDocumentStatus()
-      .then(data=> {
-        this.downloadEnabled = data;
+      .then(enabled=> {
+        this.downloadEnabled = enabled;
         this.refreshMenuExtensions();
       });
   },


### PR DESCRIPTION
ISSUE: the user the documents for a space and clicks the details of a document, he's able to download it even if an administrator has enabled the 'Suspend temporarily documents download' transfer rule
FIX: the user can no longer download the file if this rule is set