### PR TITLE
TASK-57485: fix sorting folders by name in folder view

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderView.vue
@@ -19,6 +19,7 @@
       disable-filtering
       :class="loading && !items.length ? 'loadingClass' : ''"
       class="documents-folder-table border-box-sizing ms-8">
+      <template slot="group.header"><div /></template>
       <template
         v-for="header in extendedCells"
         #[`item.${header.value}`]="{item}">
@@ -89,6 +90,9 @@ export default {
   data: () => ({
     lang: eXo.env.portal.language,
     options: {},
+    grouping: true,
+    groupBy: ['folder'],
+    groupDesc: [true],
     headerExtensionApp: 'Documents',
     headerExtensionType: 'timelineViewHeader',
     headerExtensions: {},


### PR DESCRIPTION
Prior to this change, sorting by name is not working properly. In fact, the folders and files are sorted and aren't grouped.
To fix this, the `v-data-table` grouping has been enabled to apply sort options depending on document type (two types: a folder or a file). Additionally, a `slot` to disable the display of `group.header` has been defined.