### PR TITLE
TASK-57411 : Miss padding left for column name desktop / mobile

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderView.vue
@@ -18,7 +18,7 @@
       disable-pagination
       disable-filtering
       :class="loading && !items.length ? 'loadingClass' : ''"
-      class="documents-folder-table border-box-sizing">
+      class="documents-folder-table border-box-sizing ms-8">
       <template
         v-for="header in extendedCells"
         #[`item.${header.value}`]="{item}">


### PR DESCRIPTION

TASK-57411 : Miss padding left for column name desktop / mobile (#355)