### PR TITLE
TASK-57175: Adjust transferRules boolean values check

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
@@ -29,14 +29,14 @@ export default {
     desktopOnlyExtensions: ['edit'],
     editExtensions: 'edit',
     fileOnlyExtension: ['download','favorite','visibility'],
-    sharedDocumentStatus: false,
-    downloadDocumentStatus: false
+    sharedDocumentSuspended: true,
+    downloadDocumentSuspended: true
   }),
   created() {
     document.addEventListener(`extension-${this.menuExtensionApp}-${this.menuExtensionType}-updated`, this.refreshMenuExtensions);
     this.$transferRulesService.getDocumentsTransferRules().then(rules => {
-      this.sharedDocumentStatus = rules.sharedDocumentStatus === 'true';
-      this.downloadDocumentStatus = rules.downloadDocumentStatus === 'true';
+      this.sharedDocumentSuspended = rules.sharedDocumentStatus === 'true';
+      this.downloadDocumentSuspended = rules.downloadDocumentStatus === 'true';
       this.refreshMenuExtensions();
     });
   },
@@ -60,10 +60,10 @@ export default {
     },
     checkTransferRules(extension) {
       if (extension.id === 'download') {
-        return this.downloadDocumentStatus;
+        return !this.downloadDocumentSuspended;
       }
       if (extension.id === 'visibility') {
-        return this.sharedDocumentStatus;
+        return !this.sharedDocumentSuspended;
       }
       return true;
     },


### PR DESCRIPTION
Prior to this change, transferRules on download and share are true when they are suspended while i used them differently in my last commit.
This PR should adjust the use of the values and disabled the options when they have true settings values (means suspended)