### PR TITLE
Task-57552: Decoding the document title in the favorite list

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents-extensions/components/DocumentsFavoriteItem.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents-extensions/components/DocumentsFavoriteItem.vue
@@ -47,7 +47,7 @@ export default {
     this.$attachmentService.getAttachmentById(this.id)
       .then(file => { 
         this.file = file;
-        this.documentTitle = file.title;
+        this.documentTitle = decodeURI(file.title);
         const updaterFullName = file && file.updater && file.updater.profile && file.updater.profile.fullname || '';
         const updateDate = new Date(file.updated);
         const updateDateInfo = this.$dateUtil.formatDateObjectToDisplay(updateDate, this.dateFormat);


### PR DESCRIPTION
ISSUE: If user upload file with a ( ' ) character in the documents app of a space and  add the document to favorites , The document name is encoded in the favorite list.
FIX : Decode the document Title .