### PR TITLE
TASK-57156 Improve documents sorting display in folder view

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -559,6 +559,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       if (!node.hasProperty(NodeTypeConstants.EXO_TITLE)) {
         node.addMixin(NodeTypeConstants.EXO_RSS_ENABLE);
       }
+      node.save();
 
       Node parent = node.getParent();
       String srcPath = node.getPath();

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -322,8 +322,8 @@ public class JCRDocumentsUtil {
       String owner = node.getProperty(NodeTypeConstants.EXO_OWNER).getString();
       documentNode.setCreatorId(getUserIdentityId(identityManager, owner));
     }
-    if (node.hasProperty(NodeTypeConstants.EXO_LAST_MODIFIED_DATE)) {
-      long modifiedDate = node.getProperty(NodeTypeConstants.EXO_LAST_MODIFIED_DATE)
+    if (node.hasProperty(NodeTypeConstants.EXO_DATE_MODIFIED)) {
+      long modifiedDate = node.getProperty(NodeTypeConstants.EXO_DATE_MODIFIED)
                               .getDate()
                               .getTimeInMillis();
       documentNode.setModifiedDate(modifiedDate);

--- a/documents-webapp/src/main/webapp/skin/less/documents.less
+++ b/documents-webapp/src/main/webapp/skin/less/documents.less
@@ -384,13 +384,6 @@
       }
     }
 
-    .documents-table {
-      tbody {
-        .v-data-table__mobile-table-row > :first-child {
-          display: none;
-        }
-      }
-    }
     .v-data-table__wrapper {
       padding-bottom: 28px;
 

--- a/documents-webapp/src/main/webapp/skin/less/documents.less
+++ b/documents-webapp/src/main/webapp/skin/less/documents.less
@@ -9,6 +9,12 @@
     .v-alert {
       z-index: 9999;
     }
+    .documents-tree-item .documents-breadcrumb-element {
+      .v-btn__content {
+        overflow: hidden;
+        flex: 1 1 auto;
+      }
+    }
     .inputSpaceName {
       box-shadow: none!important;
       border: none!important;

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsMoveDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsMoveDrawer.vue
@@ -150,9 +150,10 @@ export default {
       this.destinationFolderId=folder.id;
       return this.$documentFileService
         .getBreadCrumbs(this.destinationFolderId,this.ownerId,this.folderPath)
-        .then(breadCrumbs => {this.documentsBreadcrumbDestination = breadCrumbs;
-          this.destinationFolderId = this.documentsBreadcrumbDestination[this.documentsBreadcrumbDestination.length-1].id;
-          this.destinationFolderPath = this.documentsBreadcrumbDestination[this.documentsBreadcrumbDestination.length-1].path;
+        .then(breadCrumbs => {
+          this.documentsBreadcrumbDestination = breadCrumbs;
+          this.destinationFolderId = this.documentsBreadcrumbDestination[this.documentsBreadcrumbDestination.length - 1].id;
+          this.destinationFolderPath = this.documentsBreadcrumbDestination[this.documentsBreadcrumbDestination.length - 1].path;
         })
         .finally(() => this.loading = false);
     },

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="documentsBreadcrumb && documentsBreadcrumb.length" class="documents-breadcrumb-wrapper">
-    <div v-if="documentsBreadcrumb.length <= 4" class="documentss-tree-items d-flex">
+    <div v-if="documentsBreadcrumb.length <= 4" class="documents-tree-items d-flex">
       <v-icon
         class="text-sub-title pe-2"
         size="16"
@@ -11,14 +11,14 @@
         v-for="(documents, index) in documentsBreadcrumb"
         :key="index"
         :class="documentsBreadcrumb && documentsBreadcrumb.length === 1 && 'single-path-element' || ''"
-        class="documentss-tree-item d-flex text-truncate"
+        class="documents-tree-item d-flex text-truncate"
         :style="`max-width: ${100 / (documentsBreadcrumb.length)}%`">
         <v-tooltip max-width="300" bottom>
           <template #activator="{ on, attrs }">
             <v-btn
               height="20px"
               min-width="45px"
-              class="pa-0"
+              class="pa-0 flex-shrink-1 text-truncate documents-breadcrumb-element"
               :class="documentsBreadcrumb[documentsBreadcrumb.length-1].id === actualFolderId && 'clickable' || ''"
               text
               v-bind="attrs"
@@ -40,8 +40,8 @@
         </v-icon>
       </div>
     </div>
-    <div v-else class="documentss-tree-items documentss-long-path d-flex align-center">
-      <div class="documentss-tree-item long-path-first-item d-flex text-truncate">
+    <div v-else class="documents-tree-items documents-long-path d-flex align-center">
+      <div class="documents-tree-item long-path-first-item d-flex text-truncate">
         <v-tooltip max-width="300" bottom>
           <template #activator="{ on, attrs }">
             <a
@@ -49,14 +49,15 @@
               class="caption text-sub-title text-truncate path-clickable"
               :class="documentsBreadcrumb[documentsBreadcrumb.length-1].id === actualFolderId && 'clickable' || ''"
               v-bind="attrs"
-              v-on="on"
-              @click="openFolder(documentsBreadcrumb[0])">{{ documentsBreadcrumb && documentsBreadcrumb.length && documentsBreadcrumb[0].name }}</a>
+              v-on="on">
+              {{ documentsBreadcrumb && documentsBreadcrumb.length && documentsBreadcrumb[0].name }}
+            </a>
           </template>
           <span class="caption">{{ documentsBreadcrumb && documentsBreadcrumb.length && documentsBreadcrumb[0].name }}</span>
         </v-tooltip>
         <v-icon :size="move ? 12 : 14" :class="move ? 'px-1' : 'px-3'">fa-chevron-right</v-icon>
       </div>
-      <div class="documentss-tree-item long-path-second-item d-flex">
+      <div class="documents-tree-item long-path-second-item d-flex">
         <v-tooltip bottom>
           <template #activator="{ on, attrs }">
             <v-icon
@@ -76,7 +77,7 @@
         </v-tooltip>
         <v-icon :class="move ? 'clickable px-1' : 'clickable px-3'" :size="move ? 12 : 14">fa-chevron-right</v-icon>
       </div>
-      <div v-if="documentsBreadcrumb && documentsBreadcrumb.length > 1" class="documentss-tree-item long-path-third-item d-flex text-truncate">
+      <div v-if="documentsBreadcrumb && documentsBreadcrumb.length > 1" class="documents-tree-item long-path-third-item d-flex text-truncate">
         <v-tooltip max-width="300" bottom>
           <template #activator="{ on, attrs }">
             <a
@@ -91,7 +92,7 @@
         </v-tooltip>
         <v-icon :size="move ? 12 : 14" :class="move ? 'px-1' : 'px-3'">fa-chevron-right</v-icon>
       </div>
-      <div class="documentss-tree-item d-flex text-truncate">
+      <div class="documents-tree-item d-flex text-truncate">
         <v-tooltip max-width="300" bottom>
           <template #activator="{ on, attrs }">
             <a

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="documents-breadcrumb-wrapper">
-    <div v-if="documentsBreadcrumb && documentsBreadcrumb.length <= 4" class="documentss-tree-items d-flex">
+  <div v-if="documentsBreadcrumb && documentsBreadcrumb.length" class="documents-breadcrumb-wrapper">
+    <div v-if="documentsBreadcrumb.length <= 4" class="documentss-tree-items d-flex">
       <v-icon
         class="text-sub-title pe-2"
         size="16"
@@ -35,7 +35,7 @@
         <v-icon
           v-if="index < documentsBreadcrumb.length-1"
           :size="move ? 12 : 14"
-          :class="move ? 'px-1' : 'px3'">
+          :class="move ? 'px-1' : 'px-3'">
           fa-chevron-right
         </v-icon>
       </div>
@@ -54,7 +54,7 @@
           </template>
           <span class="caption">{{ documentsBreadcrumb && documentsBreadcrumb.length && documentsBreadcrumb[0].name }}</span>
         </v-tooltip>
-        <v-icon :size="move ? 12 : 14" :class="move ? 'px-1' : 'px3'">fa-chevron-right</v-icon>
+        <v-icon :size="move ? 12 : 14" :class="move ? 'px-1' : 'px-3'">fa-chevron-right</v-icon>
       </div>
       <div class="documentss-tree-item long-path-second-item d-flex">
         <v-tooltip bottom>
@@ -71,25 +71,25 @@
             v-for="(documents, index) in documentsBreadcrumb"
             :key="index"
             class="mb-0">
-            <span v-if="index > 0 && index < documentsBreadcrumb.length-2" class="caption"><v-icon :size="move ? 12 : 14" :class="move ? 'tooltip-chevron px-1' : 'tooltip-chevron px3'">fa-chevron-right</v-icon> {{ getName(documents.name) }}</span>
+            <span v-if="index > 0 && index < documentsBreadcrumb.length-2" class="caption"><v-icon :size="move ? 12 : 14" :class="move ? 'tooltip-chevron px-1' : 'tooltip-chevron px-3'">fa-chevron-right</v-icon> {{ getName(documents.name) }}</span>
           </p>
         </v-tooltip>
-        <v-icon :class="move ? 'clickable px-1' : 'clickable px3'" :size="move ? 12 : 14">fa-chevron-right</v-icon>
+        <v-icon :class="move ? 'clickable px-1' : 'clickable px-3'" :size="move ? 12 : 14">fa-chevron-right</v-icon>
       </div>
-      <div class="documentss-tree-item long-path-third-item d-flex text-truncate">
+      <div v-if="documentsBreadcrumb && documentsBreadcrumb.length > 1" class="documentss-tree-item long-path-third-item d-flex text-truncate">
         <v-tooltip max-width="300" bottom>
           <template #activator="{ on, attrs }">
             <a
               :id="move ? 'breadCrumb-link-move' : 'breadCrumb-link'"
               class="caption text-sub-title text-truncate path-clickable"
-              :class="documentsBreadcrumb[documentsBreadcrumb.length-1].id === actualFolderId && 'clickable' || ''"
+              :class="documentsBreadcrumb[documentsBreadcrumb.length - 1].id === actualFolderId && 'clickable' || ''"
               v-bind="attrs"
               v-on="on"
-              @click="openFolder(documentsBreadcrumb[documentsBreadcrumb.length-2])">{{ documentsBreadcrumb[documentsBreadcrumb.length-2].name }}</a>
+              @click="openFolder(documentsBreadcrumb[documentsBreadcrumb.length - 2])">{{ documentsBreadcrumb[documentsBreadcrumb.length - 2].name }}</a>
           </template>
-          <span class="caption">{{ documentsBreadcrumb[documentsBreadcrumb.length-2].name }}</span>
+          <span class="caption">{{ documentsBreadcrumb[documentsBreadcrumb.length - 2].name }}</span>
         </v-tooltip>
-        <v-icon :size="move ? 12 : 14" :class="move ? 'px-1' : 'px3'">fa-chevron-right</v-icon>
+        <v-icon :size="move ? 12 : 14" :class="move ? 'px-1' : 'px-3'">fa-chevron-right</v-icon>
       </div>
       <div class="documentss-tree-item d-flex text-truncate">
         <v-tooltip max-width="300" bottom>
@@ -219,9 +219,10 @@ export default {
     getBreadCrumbs() {
       return this.$documentFileService
         .getBreadCrumbs(this.actualFolderId,this.ownerId,this.folderPath)
-        .then(breadCrumbs => {this.documentsBreadcrumb = breadCrumbs;
-          this.actualFolderId = this.documentsBreadcrumb[this.documentsBreadcrumb.length-1].id;
-          this.currentFolderPath = this.documentsBreadcrumb[this.documentsBreadcrumb.length-1].path;
+        .then(breadCrumbs => {
+          this.documentsBreadcrumb = breadCrumbs;
+          this.actualFolderId = this.documentsBreadcrumb[this.documentsBreadcrumb.length - 1].id;
+          this.currentFolderPath = this.documentsBreadcrumb[this.documentsBreadcrumb.length - 1].path;
           this.$root.$emit('set-current-folder', this.documentsBreadcrumb[this.documentsBreadcrumb.length - 1]);
         })
         .finally(() => this.loading = false);

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderView.vue
@@ -18,15 +18,16 @@
       disable-pagination
       disable-filtering
       :class="loading && !items.length ? 'loadingClass' : ''"
-      class="documents-folder-table border-box-sizing ms-8">
-      <template slot="group.header"><div /></template>
+      class="documents-folder-table border-box-sizing">
+      <template slot="group.header"><span></span></template>
       <template
         v-for="header in extendedCells"
         #[`item.${header.value}`]="{item}">
         <documents-table-cell
           :key="header.value"
           :extension="header.cellExtension"
-          :file="item" />
+          :file="item"
+          class="ms-0 ms-sm-8" />
       </template>
       <template v-if="hasMore" slot="footer">
         <v-flex class="d-flex py-2 border-box-sizing mb-1">

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderView.vue
@@ -12,7 +12,6 @@
       :groupable="grouping"
       :group-by="groupBy"
       :group-desc="groupDesc"
-      :disable-sort="isMobile"
       :loading-text="loadingLabel"
       hide-default-footer
       disable-pagination
@@ -27,7 +26,7 @@
           :key="header.value"
           :extension="header.cellExtension"
           :file="item"
-          class="ms-0 ms-sm-8" />
+          class="ms-8" />
       </template>
       <template v-if="hasMore" slot="footer">
         <v-flex class="d-flex py-2 border-box-sizing mb-1">
@@ -166,7 +165,7 @@ export default {
       let changed = false;
       extensions.forEach(extension => {
         if (extension.id && (!this.headerExtensions[extension.id] || this.headerExtensions[extension.id] !== extension)) {
-          if (!this.isMobile || this.isMobile && !this.mobileUnfriendlyExtensions.includes(extension.id)) {
+          if (!this.isMobile || (this.isMobile && !this.mobileUnfriendlyExtensions.includes(extension.id))) {
             this.headerExtensions[extension.id] = extension;
             changed = true;
           }

--- a/documents-webapp/webpack.watch.js
+++ b/documents-webapp/webpack.watch.js
@@ -4,9 +4,10 @@ const { merge } = require('webpack-merge');
 const webpackProductionConfig = require('./webpack.prod.js');
 
 module.exports = merge(webpackProductionConfig, {
-  mode: 'development',
   output: {
     path: '/exo-server/webapps/documents-portlet/',
     filename: 'js/[name].bundle.js'
-  }
+  },
+  mode: 'development',
+  devtool: 'eval-source-map'
 });


### PR DESCRIPTION
Prior to this change : 
1/ Renamed document isn't displayed in top of files list (when sorting by `Last Update Time`) even when the modification date display is refreshed
2/ Folder/File grouping isn't made on Mobile View in folder view
3/ Recent documents view wasn't displayed in Mobile

This fix will :
1/ Revert https://github.com/exoplatform/documents/commit/522b2385d0cfe78851d8198e7ef730053c9716e9 to propose a new solution without affecting sort. In fact, this commit had modified the retrieved field to use a different field that was updated when renaming node. the fix was about changing the field used for sort, when renaming the file instead.
2/ Enable sorting even in Mobile so that grouping parameter is taken into consideration
3/ Delete a useless `display: none` added that affected the display of data table in Mobile view