### PR TITLE
TASK-57156 Improve documents sorting display in folder view

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -322,8 +322,8 @@ public class JCRDocumentsUtil {
       String owner = node.getProperty(NodeTypeConstants.EXO_OWNER).getString();
       documentNode.setCreatorId(getUserIdentityId(identityManager, owner));
     }
-    if (node.hasProperty(NodeTypeConstants.EXO_LAST_MODIFIED_DATE)) {
-      long modifiedDate = node.getProperty(NodeTypeConstants.EXO_LAST_MODIFIED_DATE)
+    if (node.hasProperty(NodeTypeConstants.EXO_DATE_MODIFIED)) {
+      long modifiedDate = node.getProperty(NodeTypeConstants.EXO_DATE_MODIFIED)
                               .getDate()
                               .getTimeInMillis();
       documentNode.setModifiedDate(modifiedDate);

--- a/documents-webapp/src/main/webapp/skin/less/documents.less
+++ b/documents-webapp/src/main/webapp/skin/less/documents.less
@@ -9,6 +9,12 @@
     .v-alert {
       z-index: 9999;
     }
+    .documents-tree-item .documents-breadcrumb-element {
+      .v-btn__content {
+        overflow: hidden;
+        flex: 1 1 auto;
+      }
+    }
     .inputSpaceName {
       box-shadow: none!important;
       border: none!important;
@@ -77,24 +83,14 @@
       }
     }
 
-    .document-breadcrumb-wrapper {
-      max-width: 95% !important;
-      width: 95% !important;
-  
-      .document-long-path {
-        .long-path-first-item {
-          max-width: 100px;
-          min-width: 60px;
-        }
-  
-        .long-path-second-item {
-          max-width: 42px;
-        }
-  
-        .long-path-third-item {
-          max-width: 50%;
-          min-width: 60px;
-        }
+    .documents-breadcrumb-wrapper {
+      max-width: 100% !important;
+
+      #breadCrumb-link {
+        font-size: 20px !important;
+      }
+      #breadCrumb-link-move {
+        font-size: 12px !important;
       }
     }
 
@@ -185,13 +181,6 @@
       .action-menu-item:hover {
         background-color: #e4e5e7;
       }
-      #breadCrumb-link {
-        font-size: 20px !important;
-      }
-      #breadCrumb-link-move {
-        font-size: 12px !important;
-        max-width: 100px;
-      }
       .action-menu-item {
         min-height: 30px !important;
 
@@ -200,22 +189,6 @@
         }
         .v-icon.mdi-form-textbox, .v-icon.fa-download  {
           padding-right: 4px;
-        }
-      }
-      .documentInfoDrawer {
-        .v-list-item {
-          min-height: 30px!important;
-        }
-        .v-list-item__content {
-          padding: 10px 0;
-        }
-        .fileName {
-          max-width: 320px;
-          word-wrap: break-word;
-          display: inline-block;
-        }
-        .fileDetails {
-          font-size: 14px;
         }
       }
       .loadingClassMobile {
@@ -238,7 +211,6 @@
           }
         }
       }
-
 
       .documents-table,.documents-folder-table {
         tbody {
@@ -316,6 +288,22 @@
       }
     }
   }
+  .documentInfoDrawer {
+    .v-list-item {
+      min-height: 30px!important;
+    }
+    .v-list-item__content {
+      padding: 10px 0;
+    }
+    .fileName {
+      max-width: 320px;
+      word-wrap: break-word;
+      display: inline-block;
+    }
+    .fileDetails {
+      font-size: 14px;
+    }
+  }
 
   .documents-header-left-action {
     #addItemMenu {
@@ -384,13 +372,6 @@
       }
     }
 
-    .documents-table {
-      tbody {
-        .v-data-table__mobile-table-row > :first-child {
-          display: none;
-        }
-      }
-    }
     .v-data-table__wrapper {
       padding-bottom: 28px;
 
@@ -425,7 +406,6 @@
         .attachment {
           i {
             width: 7vw;
-            font-size: 32px !important;
           }
 
           .document-title {
@@ -435,8 +415,6 @@
       }
 
       .v-data-table__mobile-table-row {
-        display: inline-flex;
-
         .document-time {
           text-align: left;
           margin-left: 16px;

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -8,20 +8,23 @@
       <div v-if="searchResult">
         <documents-header
           :files-size="files.length" 
+          :selected-view="selectedView"
           class="py-2" />
         <documents-no-result-body
           :is-mobile="isMobile" />
       </div>
-      <div v-else-if="!filesLoad && !loadingFiles && selectedView == 'folder' ">
+      <div v-else-if="!filesLoad && !loading && selectedView == 'folder' ">
         <documents-header
           :files-size="files.length" 
+          :selected-view="selectedView"
           class="py-2" />
         <documents-no-body-folder
           :is-mobile="isMobile" />
       </div>
-      <div v-else-if="!filesLoad && !loadingFiles">
+      <div v-else-if="!filesLoad && !loading">
         <documents-header
           :files-size="files.length" 
+          :selected-view="selectedView"
           class="py-2" />
         <documents-no-body
           :is-mobile="isMobile" />
@@ -29,8 +32,10 @@
       <div v-else>
         <documents-header
           :files-size="files.length" 
+          :selected-view="selectedView"
           class="py-2" />
         <documents-body
+          v-if="optionsLoaded"
           :view-extension="selectedViewExtension"
           :files="files"
           :groups-sizes="groupsSizes"
@@ -40,12 +45,16 @@
           :has-more="hasMore"
           :sort-field="sortField"
           :ascending="ascending"
+          :initialized="initialized"
           :loading="loading"
           :query="query"
           :primary-filter="primaryFilter" />
         <exo-document-notification-alerts />
       </div>
     </div>
+    <documents-visibility-drawer />
+    <documents-move-drawer />
+    <documents-info-drawer />
     <v-alert
       v-model="alert"
       :type="alertType"
@@ -55,6 +64,7 @@
     <folder-treeview-drawer
       ref="folderTreeDrawer" />
     <documents-app-reminder />
+    <documents-actions-menu-mobile />
   </v-app>
 </template>
 <script>
@@ -66,14 +76,16 @@ export default {
     query: null,
     fileName: null,
     userId: null,
-    sortField: 'name',
-    isFavorits: false,
-    ascending: true,
+    sortField: 'lastUpdated',
+    isFavorites: false,
+    ascending: false,
     parentFolderId: null,
     pageSize: 50,
     files: [],
     offset: 0,
     limit: 0,
+    optionsLoaded: false,
+    initialized: false,
     loading: false,
     hasMore: false,
     viewExtensions: {},
@@ -111,11 +123,8 @@ export default {
       return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm';
     },
     searchResult(){
-      return ((this.query && this.query.length) || this.isFavorits) && !this.files.length;
+      return ((this.query && this.query.length) || this.isFavorites) && !this.files.length;
     },
-    loadingFiles(){
-      return this.loading;
-    }
   },
   created() {
     document.addEventListener(`extension-${this.extensionApp}-${this.extensionType}-updated`, this.refreshViewExtensions);
@@ -151,10 +160,22 @@ export default {
     this.$root.$on('show-alert', message => {
       this.displayMessage(message);
     });
-    this.getDocumentDataFromUrl();
-    this.refreshFiles().then(() => {
-      this.watchDocumentPreview();
-    }).finally(() => this.$root.$applicationLoaded());
+    this.getDocumentDataFromUrl()
+      .finally(() => {
+        this.checkDefaultViewOptions();
+        this.optionsLoaded = true;
+        this.refreshFiles()
+          .then(() => {
+            this.watchDocumentPreview();
+            if (this.selectedView === 'folder') {
+              this.$nextTick().then(() => this.$root.$emit('update-breadcrumb', this.folderPath));
+            }
+          })
+          .finally(() => {
+            this.initialized = true;
+            this.$root.$applicationLoaded();
+          });
+      });
   },
   destroyed() {
     document.removeEventListener(`extension-${this.extensionApp}-${this.extensionType}-updated`, this.refreshViewExtensions);
@@ -169,6 +190,7 @@ export default {
       this.sortField = sortField;
       this.ascending = ascending;
 
+      this.files = [];
       this.refreshFiles();
     },
     search(query) {
@@ -181,9 +203,9 @@ export default {
         path = window.location.pathname;
       }
       if (eXo.env.portal.spaceName){
-        const pathParts  = path.split( `${eXo.env.portal.selectedNodeUri.toLowerCase()}/`);
-        if (pathParts.length>1){
-          this.folderPath = pathParts[1];
+        const index = path.indexOf('/Documents/');
+        if (index !== -1) {
+          this.folderPath = path.substring(index + '/Documents/'.length);
           this.selectedView = 'folder';
         }
       } else {
@@ -209,7 +231,7 @@ export default {
         .duplicateDocument(this.parentFolderId,this.ownerId)
         .then( () => {
           this.parentFolderId=null;
-          this.getFolderPath();
+          this.getFolderPath(this.folderPath);
           this.refreshFiles();
           if (documents.folder){
             this.$root.$emit('show-alert', {type: 'success',message: this.$t('documents.alert.success.label.duplicateFolder')});
@@ -241,10 +263,11 @@ export default {
       if (parentFolder.sourceID){
         this.parentFolderId = parentFolder.sourceID; 
       }
+      this.files = [];
       this.refreshFiles();
       this.$root.$emit('set-breadcrumb', parentFolder);
       let folderPath ='';
-      if (eXo.env.portal.spaceName){
+      if (eXo.env.portal.spaceName) {
         let newParentPath = parentFolder.path;
         newParentPath = newParentPath.replace(`/spaces/${eXo.env.portal.spaceGroup}`, `/spaces/${eXo.env.portal.spaceGroup}/${eXo.env.portal.spaceName}`);
         const nodeUri = eXo.env.portal.selectedNodeUri.replace('/documents', '/Documents');
@@ -273,7 +296,6 @@ export default {
           }
           window.history.pushState(parentFolder.name, parentFolder.title, `${window.location.pathname.split('/Public')[0]}/Public${folderPath}?view=folder`);
         }
-      
       }
     },
     loadMore() {
@@ -281,11 +303,22 @@ export default {
       this.refreshFiles(this.primaryFilter);
     },
     changeView(view) {
-      this.selectedView=view;
-      if (view.toLowerCase() !== 'folder'){
-        this.parentFolderId=null;
-      }
-      this.refreshFiles(this.primaryFilter);
+      const realPageUrlIndex = window.location.href.toLowerCase().indexOf(eXo.env.portal.selectedNodeUri.toLowerCase()) + eXo.env.portal.selectedNodeUri.length;
+      const url = new URL(window.location.href.substring(0, realPageUrlIndex));
+      url.searchParams.set('view', view);
+      window.history.replaceState('documents', 'Documents', url.toString());
+
+      this.selectedView = view;
+      this.parentFolderId = null;
+      this.folderPath = null;
+      this.files = [];
+      this.checkDefaultViewOptions();
+      this.refreshFiles(this.primaryFilter)
+        .finally(() => {
+          if (this.selectedView === 'folder') {
+            this.$nextTick().then(() => this.$root.$emit('update-breadcrumb'));
+          }
+        });
     },
     openHome() {
       this.parentFolderId=null;  
@@ -326,21 +359,22 @@ export default {
       if (this.userId) {
         filter.userId = this.userId;
       }
-      if (this.ascending) {
-        filter.ascending = this.sortField === 'favorite' ? false : true;
+      if (this.sortField === 'favorite') {
+        filter.ascending = this.ascending = false;
+      } else {
+        filter.ascending = this.ascending;
       }
       if (filterPrimary && filterPrimary==='favorites') {
-        this.isFavorits = true;
+        this.isFavorites = true;
       }
       if (filterPrimary && filterPrimary==='all') {
-        this.isFavorits  =  false;
+        this.isFavorites  =  false;
       }
-      filter.favorites = this.isFavorits;
+      filter.favorites = this.isFavorites;
       const expand = this.selectedViewExtension.filePropertiesExpand || 'modifier,creator,owner,metadatas';
       this.limit = this.limit || this.pageSize;
       this.loading = true;
-      return this.$documentFileService
-        .getDocumentItems(filter, this.offset, this.limit + 1, expand)
+      return this.$documentFileService.getDocumentItems(filter, this.offset, this.limit + 1, expand)
         .then(files => {
           this.files = this.sortField === 'favorite' ? files && files.slice(this.offset, this.limit).sort((file1, file2) => {
             if (file1.favorite === false && file2.favorite === true) {
@@ -353,15 +387,23 @@ export default {
           }) || [] : files && files.slice(this.offset, this.limit) || [];
           this.files = deleted ? this.files.filter(doc => doc.id !== documentId) : this.files;
           this.hasMore = files && files.length > this.limit;
-          if (this.fileName){
-            const result = files.filter(file => file.name===this.fileName);
-            if (result.length>0){
+          if (this.fileName) {
+            const result = files.filter(file => file?.path.endsWith(`/${this.fileName}`));
+            if (result.length > 0) {
               this.showPreview(result[0].id);
             }
           }
-
         })
         .finally(() => this.loading = false);
+    },
+    checkDefaultViewOptions() {
+      if (this.selectedView === 'folder') {
+        this.sortField = 'name';
+        this.ascending = true;
+      } else if (this.selectedView === 'timeline') {
+        this.sortField = 'lastUpdated';
+        this.ascending = false;
+      }
     },
     refreshViewExtensions() {
       const extensions = extensionRegistry.loadExtensions(this.extensionApp, this.extensionType);
@@ -388,6 +430,7 @@ export default {
         if (!documentPreviewContainer && self.previewMode) {
           // Quit preview mode
           self.previewMode = false;
+          self.fileName = null;
           window.history.pushState('', '', eXo.env.server.portalBaseURL);
         } else if (documentPreviewContainer && !self.previewMode) {
           // Enter preview mode
@@ -405,7 +448,7 @@ export default {
       const ownerId = eXo.env.portal.spaceIdentityId || eXo.env.portal.userIdentityId;
       this.$documentFileService.getNewName(ownerId,this.parentFolderId,this.folderPath,'new folder') 
         .then( newName => {
-          const newFolder={
+          const newFolder = {
             'id': -1,
             'name': newName,
             'folder': true
@@ -419,18 +462,14 @@ export default {
     createFolder(name){
       const ownerId = eXo.env.portal.spaceIdentityId || eXo.env.portal.userIdentityId;
       this.$documentFileService.createFolder(ownerId,this.parentFolderId,this.folderPath,name)
-        .then( () => {
-          this.refreshFiles();
-        })
+        .then(() => this.refreshFiles())
         .catch(e => console.error(e))
         .finally(() => this.loading = false);
     },
     renameDocument(file,name){
       const ownerId = eXo.env.portal.spaceIdentityId || eXo.env.portal.userIdentityId;
       this.$documentFileService.renameDocument(ownerId,file.id,name)
-        .then( () => {
-          this.refreshFiles();
-        })
+        .then(() => this.refreshFiles())
         .catch(e => console.error(e))
         .finally(() => this.loading = false);
     },
@@ -444,9 +483,7 @@ export default {
     },
     saveVisibility(file){
       this.$documentFileService.saveVisibility(file)
-        .then( () => {
-          this.refreshFiles();
-        })
+        .then(() => this.refreshFiles())
         .catch(e => console.error(e))
         .finally(() => this.loading = false);
     },
@@ -498,12 +535,20 @@ export default {
     getDocumentDataFromUrl() {
       const currentUrlSearchParams = window.location.search;
       const queryParams = new URLSearchParams(currentUrlSearchParams);
+      if (!eXo.env.portal.spaceName && queryParams.has('userId')) {
+        this.userId = queryParams.get('userId');
+      }
       if (queryParams.has('documentPreviewId')) {
         this.loading = true;
         this.previewMode = true;
         const documentPreviewId = queryParams.get('documentPreviewId');
         this.selectedView = 'folder';
-        this.showPreview(documentPreviewId);
+        return this.showPreview(documentPreviewId)
+          .then(attachment => {
+            if (attachment?.path) {
+              this.selectFile(attachment.path);
+            }
+          });
       }
       if (queryParams.has('folderId')) {
         this.parentFolderId = queryParams.get('folderId');
@@ -511,38 +556,35 @@ export default {
       }
       if (queryParams.has('path')) {
         this.selectedView = 'folder';
-        let nodePath = queryParams.get('path');
-        const lastpart = nodePath.substring(nodePath.lastIndexOf('/')+1,nodePath.length);
-        if (lastpart.includes('.')){
-          this.fileName = lastpart;
-          nodePath = nodePath.substring(0,nodePath.lastIndexOf('/'));
-        }
-        this.getFolderPath(nodePath);
-      } else if (this.selectedView === 'folder') {
-        this.getFolderPath();
-      }
-      if (queryParams.has('view')) {
-        const view = queryParams.get('view');
-        if (view.toLowerCase() === 'folder'){
-          this.selectedView='folder';
-        } else {
-          this.parentFolderId=null;
-          this.selectedView='timeline';
-          const pathParts = window.location.pathname.toLowerCase().split(eXo.env.portal.selectedNodeUri.toLowerCase());
-          window.history.pushState('documents', 'Documents', `${pathParts[0]}${eXo.env.portal.selectedNodeUri}?view=timeline`);
-        }
-      }
-      if (!eXo.env.portal.spaceName && queryParams.has('userId')) {
-        const userId = queryParams.get('userId');
-        this.userId=userId;
+        const path = queryParams.get('path') || '';
+        this.selectFile(path);
       } else {
-        this.userId=null;
+        const path = window.location.pathname;
+        const pathParts  = path.split( `${eXo.env.portal.selectedNodeUri.toLowerCase()}/`);
+        if (pathParts.length > 1) {
+          this.folderPath = pathParts[1];
+          this.selectedView = 'folder';
+        }
+        if (queryParams.has('view')) {
+          const view = queryParams.get('view');
+          if (view.toLowerCase() === 'folder'){
+            this.selectedView = 'folder';
+          } else {
+            this.parentFolderId = null;
+            this.folderPath = null;
+            this.selectedView ='timeline';
+          }
+        }
+        if (this.selectedView === 'folder') {
+          this.getFolderPath(this.folderPath);
+        }
       }
+      return this.$nextTick();
     },
     onBrowserNavChange() {
       this.getDocumentDataFromUrl();
-      this.refreshFiles();
-      this.$root.$emit('update-breadcrumb');
+      this.refreshFiles()
+        .finally(() => this.$root.$emit('update-breadcrumb'));
     },
     displayMessage(message) {
       this.message = message.message;
@@ -550,8 +592,18 @@ export default {
       this.alert = true;
       window.setTimeout(() => this.alert = false, 5000);
     },
+    selectFile(path) {
+      const parentDriveFolder = eXo.env.portal.spaceName && '/Documents/' || '/Private/';
+      const nodePath = path.substring(path.indexOf(parentDriveFolder) + parentDriveFolder.length);
+      const nodePathParts = nodePath.split('/');
+
+      this.selectedView = 'folder';
+      this.fileName = nodePathParts.pop();
+      this.folderPath = nodePathParts.join('/');
+      return this.getFolderPath(this.folderPath);
+    },
     showPreview(documentPreviewId) {
-      this.$attachmentService.getAttachmentById(documentPreviewId)
+      return this.$attachmentService.getAttachmentById(documentPreviewId)
         .then(attachment => {
           documentPreview.init({
             doc: {
@@ -572,6 +624,7 @@ export default {
             showComments: false,
             showOpenInFolderButton: false,
           });
+          return attachment;
         })
         .catch(e => console.error(e))
         .finally(() => this.loading = false);

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsBody.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsBody.vue
@@ -23,6 +23,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    initialized: {
+      type: Boolean,
+      default: false,
+    },
     offset: {
       type: Number,
       default: () => 0,
@@ -64,6 +68,7 @@ export default {
         ascending: this.ascending,
         pageSize: this.pageSize,
         sortField: this.sortField,
+        initialized: this.initialized,
         loading: this.loading,
         offset: this.offset,
         limit: this.limit,

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsNoBodyFolder.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsNoBodyFolder.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="documents-body">
-    <documents-breadcrumb class="pa-6 pe-1 pl-1" />
     <div class="ma-4 d-flex documents-no-body flex-column justify-center text-center text-color">
       <v-img
         :src="emptyDocs"

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/CopyLinkMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/CopyLinkMenuAction.vue
@@ -48,6 +48,7 @@ export default {
           'view': this.viewTab
         }
       }));
+      this.$root.$emit('close-file-action-menu');
     },
     getDocumentView() {
       const currentUrlSearchParams = window.location.search;

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DeleteMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DeleteMenuAction.vue
@@ -26,9 +26,7 @@ export default {
   methods: {
     deleteAction() {
       this.$root.$emit('confirm-document-deletion', this.file);
-      if ( this.isMobile ) {
-        this.$root.$emit('close-file-action-menu');
-      }
+      this.$root.$emit('close-file-action-menu');
       const deleteDelay = 6;
       this.$documentFileService.deleteDocument(this.file.path, this.file.id, this.file.favorite, deleteDelay);
     }

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DetailsMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DetailsMenuAction.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="clickable mx-2"
-    @click="$root.$emit('open-info-drawer',file.id)">
+    @click="displayDetails">
     <v-icon
       size="13"
       class="pe-1 iconStyle">
@@ -27,9 +27,9 @@ export default {
     },
   },
   methods: {
-    editNameMode(){
-      this.$root.$emit('update-file-name', this.file);
-      if ( this.isMobile ) {
+    displayDetails(){
+      this.$root.$emit('open-info-drawer', this.file);
+      if (this.isMobile) {
         this.$root.$emit('close-file-action-menu');
       }
     }

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/FavoriteMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/FavoriteMenuAction.vue
@@ -38,7 +38,7 @@ export default {
       return this.file && this.file.id;
     },
     spaceId() {
-      return eXo.env.portal.spaceId;
+      return eXo.env.portal.spaceId || 0;
     },
     isMobile() {
       return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm';

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/VisibilityMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/VisibilityMenuAction.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="clickable ma-auto pt-1 mx-2"
-    @click="$root.$emit('open-visibility-drawer',file)">
+    @click="changeVisibility">
     <v-icon
       size="13"
       class="pe-1 iconStyle">
@@ -26,6 +26,14 @@ export default {
     isMobile() {
       return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm';
     },
+  },
+  methods: {
+    changeVisibility(){
+      this.$root.$emit('open-visibility-drawer', this.file);
+      if (this.isMobile) {
+        this.$root.$emit('close-file-action-menu');
+      }
+    }
   },
 };
 </script>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenuMobile.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenuMobile.vue
@@ -23,13 +23,8 @@
 <script>
 
 export default {
-  props: {
-    file: {
-      type: Object,
-      default: null,
-    }
-  },
   data: () => ({
+    file: null,
     menuExtensionApp: 'DocumentMenu',
     menuExtensionType: 'menuActionMenu',
     menuExtensions: {},
@@ -53,11 +48,13 @@ export default {
     }
   },
   created() {
-    document.addEventListener(`extension-${this.menuExtensionApp}-${this.menuExtensionType}-updated`, this.refreshMenuExtensions);
-    this.refreshMenuExtensions();
+    this.$root.$on('open-file-action-menu', this.open);
+    this.$root.$on('close-file-action-menu', this.close);
   },
   methods: {
-    open() {
+    open(file) {
+      this.file = file;
+      this.refreshMenuExtensions();
       this.$refs.documentActionsMobileMenu.open();
     },
     close() {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
@@ -7,7 +7,7 @@
     <template slot="title">
       {{ $t('documents.drawer.details.title') }}
     </template>
-    <template slot="content">
+    <template v-if="file" slot="content">
       <v-list-item>
         <v-list-item-content class="ma-1">
           <a class="text-center not-clickable d-flex align-center">
@@ -17,7 +17,7 @@
               class="fileName font-weight-bold text-color ms-2 px-2">
               {{ file.name }}
             </span>
-            <documents-favorite-action :file="file" />
+            <documents-favorite-action v-if="!file.folder" :file="file" />
             <v-spacer />
           </a>
         </v-list-item-content>
@@ -79,28 +79,6 @@
 <script>
 
 export default {
-  props: {
-    file: {
-      type: Object,
-      default: null,
-    },
-    icon: {
-      type: Array,
-      default: null,
-    },
-    fileName: {
-      type: String,
-      default: '',
-    },
-    fileType: {
-      type: String,
-      default: '',
-    },
-    isMobile: {
-      type: Boolean,
-      default: false,
-    },
-  },
   data: () => ({
     fullDateFormat: {
       year: 'numeric',
@@ -110,6 +88,10 @@ export default {
       minute: '2-digit',
     },
     currentUser: eXo.env.portal.userName,
+    file: null,
+    fileName: null,
+    fileType: null,
+    icon: null,
   }),
   computed: {
     iconColor(){
@@ -143,16 +125,24 @@ export default {
     identityCreated(){
       if (!(this.file && this.file.creatorIdentity)) {return '';}
       return this.currentUser === this.file.creatorIdentity.remoteId ? this.$t('documents.drawer.details.me') : this.file.creatorIdentity.name;
-
     },
-
+    isMobile() {
+      return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm';
+    },
+  },
+  created() {
+    this.$root.$on('open-info-drawer', this.open);
+    this.$root.$on('close-info-drawer', this.close);
   },
   methods: {
-    open() {
+    open(file, fileName, fileType, icon) {
+      this.file = file;
+      this.fileName = fileName;
+      this.fileType = fileType;
+      this.icon = icon;
       this.$refs.documentInfoDrawer.open();
     },
     close() {
-      this.$root.$emit('close-info-drawer',this.file.id);
       this.$refs.documentInfoDrawer.close();
     },
   }

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsMoveSpaces.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsMoveSpaces.vue
@@ -93,9 +93,11 @@ export default {
   },
   watch: {
     spaceModel () {
-      if (this.$refs.select && this.$refs.select.isMenuActive) {
-        setTimeout(() => {
-          this.$refs.select.isMenuActive = false;
+      if (this.$refs?.select?.isMenuActive) {
+        window.setTimeout(() => {
+          if (this.$refs?.select?.isMenuActive) {
+            this.$refs.select.isMenuActive = false;
+          }
         }, 50);
       }
     },
@@ -110,9 +112,11 @@ export default {
     this.getSpaces();
     this.spaceModel = this.space;
     $(document).on('mousedown', () => {
-      if (this.$refs.select.isMenuActive) {
+      if (this.$refs?.select?.isMenuActive) {
         window.setTimeout(() => {
-          this.$refs.select.isMenuActive = false;
+          if (this.$refs?.select?.isMenuActive) {
+            this.$refs.select.isMenuActive = false;
+          }
         }, 200);
       }
     });

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsVisibilityDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsVisibilityDrawer.vue
@@ -22,7 +22,7 @@
       @closed="close"
       right>
       <template slot="title">
-        {{ visibilityTitle }}
+        <span :title="visibilityTitle" class="text-truncate">{{ visibilityTitle }}</span>
       </template>
       <template slot="content">
         <v-list-item>
@@ -150,15 +150,12 @@
   </div>
 </template>
 <script>
-
 export default {
-  
   data: () => ({
     ownerIdentity: [],
     file: { 'acl': {
       'visibilityChoice': 'ALL_MEMBERS'
     }},
-    fileName: '',
     collaborators: [],
     searchOptions: {
       currentUser: '',
@@ -170,7 +167,7 @@ export default {
       return eXo.env.portal.spaceName && [`space:${eXo.env.portal.spaceName}`] || [];
     },
     visibilityTitle(){
-      return this.$t('documents.label.visibilityTitle').replace('{0}', this.fileName);
+      return this.$t('documents.label.visibilityTitle', {0: this.file?.name});
     },
     visibilityLabel(){
       return [
@@ -239,6 +236,11 @@ export default {
       this.collaborators = null;
     },
   },
+  created() {
+    this.$root.$on('open-visibility-drawer', file => {
+      this.open(file);
+    });
+  },
   methods: {
     mapCollaborator(collaborator) {
       const fullName = collaborator.profile
@@ -264,12 +266,11 @@ export default {
           if (elements[i].innerText.includes(this.$t('documents.label.visibility.collaborator.info'))){
             elements[i].style.left = '880px';
           }
-        }      }, 100);
-
+        }
+      }, 100);
     },
-    open(file,fileName) {
-      this.file=file;
-      this.fileName=fileName;
+    open(file) {
+      this.file = file;
       this.$userService.getUser(this.file.creatorIdentity.remoteId).then(user => {
         this.ownerIdentity = user;
       });

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/action/DocumentFavoriteAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/action/DocumentFavoriteAction.vue
@@ -27,7 +27,7 @@ export default {
       return this.file && this.file.id;
     },
     spaceId() {
-      return eXo.env.portal.spaceId;
+      return eXo.env.portal.spaceId || 0;
     },
   },
   created() {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFavoriteCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFavoriteCell.vue
@@ -25,7 +25,7 @@ export default {
       return this.file && this.file.id;
     },
     spaceId() {
-      return eXo.env.portal.spaceId;
+      return eXo.env.portal.spaceId || 0;
     },
     isMobile() {
       return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm';

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsInfoDetailsCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsInfoDetailsCell.vue
@@ -10,7 +10,7 @@
           <v-icon
             class="text-sub-title d-none mx-0 px-0"
             size="16"
-            @click="$emit('open-info-drawer')"
+            @click="$root.$emit('open-info-drawer', file)"
             v-bind="attrs"
             v-on="on">
             fa-info-circle
@@ -21,7 +21,6 @@
         {{ documentInfoActionTooltip }}
       </span>
     </v-tooltip>
-    <documents-info-drawer ref="documentInfoDrawer" :file="file" />
   </div>
 </template>
 
@@ -37,9 +36,6 @@ export default {
       default: null,
     },
   },
-  data: () => ({
-
-  }),
   computed: {
     fileId() {
       return this.file && this.file.id;
@@ -47,12 +43,6 @@ export default {
     documentInfoActionTooltip() {
       return this.$t('documents.label.show.details');
     },
-
-  },
-  methods: {
-    openInfoDetailsDrawer(){
-      this.$refs.documentInfoDrawer.open();
-    }
   },
 };
 </script>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsLastUpdatedCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsLastUpdatedCell.vue
@@ -32,7 +32,7 @@ export default {
       return this.file && (this.file.modifiedDate || this.file.createdDate) || '';
     },
     isMobile() {
-      return this.$vuetify.breakpoint.name === 'xs';
+      return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm';
     },
   },
 };

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -1,25 +1,27 @@
 <template>
-  <div class="documents-breadcrumb-wrapper">
-    <div v-if="documentsBreadcrumb && documentsBreadcrumb.length <= 4" class="documentss-tree-items d-flex">
-      <v-icon
-        class="text-sub-title pe-2"
-        size="16"
+  <div v-if="documentsBreadcrumbToDisplay.length" class="documents-breadcrumb-wrapper">
+    <div class="documents-tree-items d-flex align-center">
+      <v-btn
+        icon
+        small
+        class="me-2"
         @click="openTreeFolderDrawer()">
-        fas fa-sitemap
-      </v-icon>
+        <v-icon class="text-sub-title" size="16">
+          fas fa-sitemap
+        </v-icon>
+      </v-btn>
       <div
-        v-for="(documents, index) in documentsBreadcrumb"
+        v-for="(documents, index) in documentsBreadcrumbToDisplay"
         :key="index"
-        :class="documentsBreadcrumb && documentsBreadcrumb.length === 1 && 'single-path-element' || ''"
-        class="documentss-tree-item d-flex text-truncate"
-        :style="`max-width: ${100 / (documentsBreadcrumb.length)}%`">
+        :class="documentsBreadcrumbToDisplay.length === 1 && 'single-path-element' || ''"
+        class="documents-tree-item d-flex text-truncate">
         <v-tooltip max-width="300" bottom>
           <template #activator="{ on, attrs }">
             <v-btn
               height="20px"
               min-width="45px"
-              class="pa-0"
-              :class="documentsBreadcrumb[documentsBreadcrumb.length-1].id === actualFolderId && 'clickable' || ''"
+              class="pa-0 flex-shrink-1 text-truncate documents-breadcrumb-element"
+              :class="documentsBreadcrumbToDisplay[documentsBreadcrumbToDisplay.length-1].id === actualFolderId && 'clickable' || ''"
               text
               v-bind="attrs"
               v-on="on"
@@ -27,83 +29,17 @@
               <a
                 class="caption text-truncate"
                 :id="move ? 'breadCrumb-link-move' : 'breadCrumb-link'"
-                :class="index < documentsBreadcrumb.length-1 && 'path-clickable text-sub-title' || 'text-color not-clickable'">{{ getName(documents.name) }}</a>
+                :class="index < documentsBreadcrumbToDisplay.length-1 && 'path-clickable text-sub-title' || 'text-color not-clickable'">{{ getName(documents.name) }}</a>
             </v-btn>
           </template>
           <span class="caption breadcrumbName">{{ getName(documents.name) }}</span>
         </v-tooltip>
         <v-icon
-          v-if="index < documentsBreadcrumb.length-1"
+          v-if="index < documentsBreadcrumbToDisplay.length-1"
           :size="move ? 12 : 14"
-          :class="move ? 'px-1' : 'px3'">
+          :class="move ? 'px-1' : 'px-3'">
           fa-chevron-right
         </v-icon>
-      </div>
-    </div>
-    <div v-else class="documentss-tree-items documentss-long-path d-flex align-center">
-      <div class="documentss-tree-item long-path-first-item d-flex text-truncate">
-        <v-tooltip max-width="300" bottom>
-          <template #activator="{ on, attrs }">
-            <a
-              :id="move ? 'breadCrumb-link-move' : 'breadCrumb-link'"
-              class="caption text-sub-title text-truncate path-clickable"
-              :class="documentsBreadcrumb[documentsBreadcrumb.length-1].id === actualFolderId && 'clickable' || ''"
-              v-bind="attrs"
-              v-on="on"
-              @click="openFolder(documentsBreadcrumb[0])">{{ documentsBreadcrumb && documentsBreadcrumb.length && documentsBreadcrumb[0].name }}</a>
-          </template>
-          <span class="caption">{{ documentsBreadcrumb && documentsBreadcrumb.length && documentsBreadcrumb[0].name }}</span>
-        </v-tooltip>
-        <v-icon :size="move ? 12 : 14" :class="move ? 'px-1' : 'px3'">fa-chevron-right</v-icon>
-      </div>
-      <div class="documentss-tree-item long-path-second-item d-flex">
-        <v-tooltip bottom>
-          <template #activator="{ on, attrs }">
-            <v-icon
-              v-bind="attrs"
-              v-on="on"
-              class="text-sub-title"
-              size="24">
-              mdi-dots-horizontal
-            </v-icon>
-          </template>
-          <p
-            v-for="(documents, index) in documentsBreadcrumb"
-            :key="index"
-            class="mb-0">
-            <span v-if="index > 0 && index < documentsBreadcrumb.length-2" class="caption"><v-icon :size="move ? 12 : 14" :class="move ? 'tooltip-chevron px-1' : 'tooltip-chevron px3'">fa-chevron-right</v-icon> {{ getName(documents.name) }}</span>
-          </p>
-        </v-tooltip>
-        <v-icon :class="move ? 'clickable px-1' : 'clickable px3'" :size="move ? 12 : 14">fa-chevron-right</v-icon>
-      </div>
-      <div class="documentss-tree-item long-path-third-item d-flex text-truncate">
-        <v-tooltip max-width="300" bottom>
-          <template #activator="{ on, attrs }">
-            <a
-              :id="move ? 'breadCrumb-link-move' : 'breadCrumb-link'"
-              class="caption text-sub-title text-truncate path-clickable"
-              :class="documentsBreadcrumb[documentsBreadcrumb.length-1].id === actualFolderId && 'clickable' || ''"
-              v-bind="attrs"
-              v-on="on"
-              @click="openFolder(documentsBreadcrumb[documentsBreadcrumb.length-2])">{{ documentsBreadcrumb[documentsBreadcrumb.length-2].name }}</a>
-          </template>
-          <span class="caption">{{ documentsBreadcrumb[documentsBreadcrumb.length-2].name }}</span>
-        </v-tooltip>
-        <v-icon :size="move ? 12 : 14" :class="move ? 'px-1' : 'px3'">fa-chevron-right</v-icon>
-      </div>
-      <div class="documentss-tree-item d-flex text-truncate">
-        <v-tooltip max-width="300" bottom>
-          <template #activator="{ on, attrs }">
-            <a
-              :id="move ? 'breadCrumb-link-move' : 'breadCrumb-link'"
-              class="caption text-truncate"
-              :class="documentsBreadcrumb[documentsBreadcrumb.length-1].id === actualFolderId && 'text-color' || 'clickable'"
-              v-bind="attrs"
-              v-on="on"
-              @click="openFolder(documentsBreadcrumb[documentsBreadcrumb.length-1])">{{ documentsBreadcrumb[documentsBreadcrumb.length-1].name }}</a>
-          </template>
-          <span class="caption">{{ documentsBreadcrumb[documentsBreadcrumb.length-1].name }}</span>
-        </v-tooltip>
       </div>
     </div>
   </div>
@@ -113,7 +49,7 @@ export default {
   props: {
     documentsBreadcrumb: {
       type: Array,
-      default: () => null
+      default: () => [],
     },
     showIcon: {
       type: Boolean,
@@ -125,26 +61,46 @@ export default {
     },
   },
   data: () => ({
+    id: Math.random().toString(16),
     actualFolderId: '',
     folderPath: '',
     currentFolderPath: '',
     ownerId: eXo.env.portal.spaceIdentityId || eXo.env.portal.userIdentityId
   }),
-  created() {
-    this.$root.$on('set-breadcrumb', data => {
-      this.folderPath='';
-      if (data){
-        this.actualFolderId = data.id;
-        this.getBreadCrumbs(); 
+  computed: {
+    documentsBreadcrumbToDisplay() {
+      if (!this.documentsBreadcrumb || this.documentsBreadcrumb.length <= 4) {
+        return this.documentsBreadcrumb || [];
+      } else {
+        const length = this.documentsBreadcrumb.length;
+        const documentsBreadcrumbToDisplay = [this.documentsBreadcrumb[0], ... this.documentsBreadcrumb.slice(length - 3, length)];
+        documentsBreadcrumbToDisplay[1] = Object.assign({}, documentsBreadcrumbToDisplay[1], {
+          name: '...',
+        });
+        return documentsBreadcrumbToDisplay;
       }
-    });
+    },
+  },
+  created() {
+    this.$root.$on('set-breadcrumb', this.setBreadcrumb);
     this.$root.$on('update-breadcrumb', this.updateBreadcrumb);
     this.$root.$on('open-folder', this.openFolder);
-    this.getDocumentDataFromUrl();   
+  },
+  beforeDestroy() {
+    this.$root.$off('set-breadcrumb', this.setBreadcrumb);
+    this.$root.$off('update-breadcrumb', this.updateBreadcrumb);
+    this.$root.$off('open-folder', this.openFolder);
   },
   methods: {
+    setBreadcrumb(folder) {
+      this.folderPath = '';
+      if (folder) {
+        this.actualFolderId = folder.id;
+        this.getBreadCrumbs(); 
+      }
+    },
     openFolder(folder) {
-      if (folder.name==='Private'){
+      if (folder.name === 'Private'){
         this.$root.$emit('document-open-home');
         this.folderPath='';
         this.actualFolderId ='';
@@ -165,71 +121,68 @@ export default {
       }
       return name;
     },
-
     getDocumentDataFromUrl() {
       const currentUrlSearchParams = window.location.search;
       const queryParams = new URLSearchParams(currentUrlSearchParams);
-      if (queryParams.has('folderId')) {
+      if (queryParams.has('path')) {
+        const parentDriveFolder = eXo.env.portal.spaceName && '/Documents/' || '/Private/';
+        const path = queryParams.get('path') || '';
+        const nodePath = path.substring(path.indexOf(parentDriveFolder) + parentDriveFolder.length);
+        const nodePathParts = nodePath.split('/');
+        this.getFolderPath(nodePathParts.join('/'));
+      } else if (queryParams.has('folderId')) {
         this.actualFolderId = queryParams.get('folderId');
-        this.selectedView = 'folder';
         this.getBreadCrumbs();
-      } else  if (queryParams.has('path')) {
-        let nodePath = queryParams.get('path');
-        const lastpart = nodePath.substring(nodePath.lastIndexOf('/')+1,nodePath.length);
-        if (lastpart.includes('.')){
-          this.fileName = lastpart;
-          nodePath = nodePath.substring(0,nodePath.lastIndexOf('/'));
-        }
-        this.getFolderPath(nodePath);
-        this.selectedView = 'folder';
       } else {
         this.getFolderPath();
       }
     },
-
     getFolderPath(path){
-      if (!path){
+      if (path) {
+        this.folderPath = path;
+      } else {
         path = window.location.pathname;
-      }
-      this.actualFolderId= '';
-      this.folderPath= '';
-      this.currentFolderPath= '';
-      if (eXo.env.portal.spaceName){
         const pathParts  = path.split( `${eXo.env.portal.selectedNodeUri.toLowerCase()}/`);
-        if (pathParts.length>1){
+        if (pathParts.length > 1) {
           this.folderPath = pathParts[1];
         }
-      } else {
-        if (path.includes('/Private')){
-          const pathParts  = path.split('/Private');
-          if (pathParts.length>1){
-            this.folderPath = `Private${pathParts[1]}`;
+        if (!eXo.env.portal.spaceName) {
+          if (path.includes('/Private/')){
+            const pathParts  = path.split('/Private');
+            if (pathParts.length > 1){
+              this.folderPath = `Private${pathParts[1]}`;
+            }
           }
-        }
-        if (path.includes('/Public')){
-          const pathParts  = path.split('/Public');
-          if (pathParts.length>1){
-            this.folderPath = `Public${pathParts[1]}`;
+          if (path.includes('/Public')) {
+            const pathParts  = path.split('/Public');
+            if (pathParts.length > 1) {
+              this.folderPath = `Public${pathParts[1]}`;
+            }
           }
         }
       }
+      this.actualFolderId = '';
+      this.currentFolderPath = '';
       this.getBreadCrumbs();
     },
 
     getBreadCrumbs() {
       return this.$documentFileService
         .getBreadCrumbs(this.actualFolderId,this.ownerId,this.folderPath)
-        .then(breadCrumbs => {this.documentsBreadcrumb = breadCrumbs;
-          this.actualFolderId = this.documentsBreadcrumb[this.documentsBreadcrumb.length-1].id;
-          this.currentFolderPath = this.documentsBreadcrumb[this.documentsBreadcrumb.length-1].path;
+        .then(breadCrumbs => {
+          this.documentsBreadcrumb = breadCrumbs;
+          this.actualFolderId = this.documentsBreadcrumb[this.documentsBreadcrumb.length - 1].id;
+          this.currentFolderPath = this.documentsBreadcrumb[this.documentsBreadcrumb.length - 1].path;
           this.$root.$emit('set-current-folder', this.documentsBreadcrumb[this.documentsBreadcrumb.length - 1]);
         })
         .finally(() => this.loading = false);
     },
-
-    updateBreadcrumb() {
-      this.getDocumentDataFromUrl();
-      this.getBreadCrumbs();  
+    updateBreadcrumb(folderPath) {
+      if (folderPath) {
+        this.getFolderPath(folderPath);
+      } else {
+        this.getDocumentDataFromUrl();
+      }
     },
   }
 };

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/FolderTreeViewDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/FolderTreeViewDrawer.vue
@@ -34,36 +34,32 @@
 <script>
 
 export default {
-  props: {
-  },
   data: () => ({
     ownerId: eXo.env.portal.spaceIdentityId || eXo.env.portal.userIdentityId,
     items: [],
   }),
   computed: {
     openLevel() {
-      return this.items && this.items.length && [this.items[0].name];
+      return this.items && this.items.length && [this.items[0].name] || [];
     },
   },
   methods: {
     open() {
       this.retrieveNoteTree();
-      this.$refs.folderBreadcrumb.open();
+      this.$refs.folderBreadcrumb?.open();
     },
     close() {
-      this.$refs.folderBreadcrumb.close();
+      this.$refs.folderBreadcrumb?.close();
     },
     openFolder(folder){
       this.$root.$emit('open-folder', folder);
     },
     retrieveNoteTree(){
-      this.$documentFileService
-        .getFullTreeData(this.ownerId).then(data => {
-          if (data) {
-            this.items = [];
-            this.items = data;
-          }
-        });
+      this.items = [];
+      this.$refs.folderBreadcrumb?.startLoading();
+      this.$documentFileService.getFullTreeData(this.ownerId)
+        .then(data => this.items = data || [])
+        .finally(() => this.$refs.folderBreadcrumb?.endLoading());
     }
   }
 };

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/DocumentsHeader.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/DocumentsHeader.vue
@@ -1,10 +1,13 @@
 <template>
-  <div class="d-flex flex-row">
-    <documents-header-left />
-    <v-spacer v-show="!canShowMobileFilter" />
-    <documents-header-center v-show="!canShowMobileFilter" />
-    <v-spacer v-show="!canShowMobileFilter" />
-    <documents-header-right />
+  <div>
+    <div class="d-flex flex-row">
+      <documents-header-left :selected-view="selectedView" />
+      <v-spacer v-show="!canShowMobileFilter" />
+      <documents-header-center v-show="!canShowMobileFilter" :selected-view="selectedView" />
+      <v-spacer v-show="!canShowMobileFilter" />
+      <documents-header-right />
+    </div>
+    <documents-breadcrumb v-if="selectedView === 'folder'" class="py-4 px-1" />
   </div>
 </template>
 
@@ -14,7 +17,11 @@ export default {
     filesSize: {
       type: Number,
       default: 0
-    }
+    },
+    selectedView: {
+      type: String,
+      default: '',
+    },
   },
   data: () => ({
     showMobileFilter: false,

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/DocumentsHeaderLeft.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/DocumentsHeaderLeft.vue
@@ -1,5 +1,6 @@
 <template>
   <extension-registry-components
+    :params="params"
     name="DocumentsHeaderLeft"
     type="documents-header-left"
     class="d-flex flex-no-wrap documents-header-left-actions"
@@ -7,3 +8,20 @@
     element="div"
     element-class="ma-lg-0 documents-header-left-action" />
 </template>
+<script>
+export default {
+  props: {
+    selectedView: {
+      type: String,
+      default: '',
+    },
+  },
+  computed: {
+    params() {
+      return {
+        selectedView: this.selectedView,
+      };
+    },
+  },
+};
+</script>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsAddNewFile.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsAddNewFile.vue
@@ -72,34 +72,26 @@
 </template>
 <script>
 export default {
+  props: {
+    selectedView: {
+      type: String,
+      default: '',
+    },
+  },
   data: () => ({
     showMobileFilter: false,
     addMenu: false,
     waitTimeUntilCloseMenu: 200,
-    isFolderView: false,
   }),
   computed: {
     isMobile() {
       return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm';
     },
+    isFolderView() {
+      return this.selectedView === 'folder';
+    },
   },
   created() {
-    this.$root.$on('document-change-view', this.changeView);
-    const currentUrlSearchParams = window.location.search;
-    const queryParams = new URLSearchParams(currentUrlSearchParams);
-    if (queryParams.has('folderId')) {
-      this.isFolderView = true;
-    } else if (queryParams.has('view')) {
-      const view = queryParams.get('view');
-      if (view.toLowerCase() === 'folder'){
-        this.isFolderView = true;
-      } 
-    } else {
-      const pathParts  = eXo.env.server.portalBaseURL.toLowerCase().split(eXo.env.portal.selectedNodeUri.toLowerCase());
-      if (pathParts.length>1 && pathParts[1]){
-        this.isFolderView = true;
-      }
-    }
     $(document).on('mousedown', () => {
       if (this.addMenu) {
         window.setTimeout(() => {
@@ -133,9 +125,6 @@ export default {
     addFolder() {
       this.$root.$emit('documents-add-folder');
       this.hideAddMenuMobile();
-    },
-    changeView(view) {
-      this.isFolderView = view==='folder';
     },
     displayAddMenuMobile() {
       if (this.isMobile){

--- a/documents-webapp/webpack.watch.js
+++ b/documents-webapp/webpack.watch.js
@@ -4,9 +4,10 @@ const { merge } = require('webpack-merge');
 const webpackProductionConfig = require('./webpack.prod.js');
 
 module.exports = merge(webpackProductionConfig, {
-  mode: 'development',
   output: {
     path: '/exo-server/webapps/documents-portlet/',
     filename: 'js/[name].bundle.js'
-  }
+  },
+  mode: 'development',
+  devtool: 'eval-source-map'
 });


### PR DESCRIPTION
Prior to this change :
1/ Renamed document isn't displayed in top of files list (when sorting by `Last Update Time`) even when the modification date display is refreshed
2/ Folder/File grouping isn't made on Mobile View in folder view
3/ Recent documents view wasn't displayed in Mobile

This fix will :
1/ Revert https://github.com/exoplatform/documents/commit/522b2385d0cfe78851d8198e7ef730053c9716e9 to propose a new solution without affecting sort. In fact, this commit had modified the retrieved field to use a different field that was updated when renaming node. the fix was about changing the field used for sort, when renaming the file instead.
2/ Enable sorting even in Mobile so that grouping parameter is taken into consideration
3/ Delete a useless `display: none` added that affected the display of data table in Mobile view
4/ Remake default sort used for timeline view, lastupdate descending
5/ Reduce icon size for symlink in Mobile view
6/ Fix margin for first column in Mobile & Desktop for timeline & folder view
7/ Stabilize Breadcrumb usage in Folder view and Tree view
8/ Stabilize File Preview access from stream
9/ Optimize performances of rendered components
10/ Avoid duplicating event listeners when switching from a view to another