### PR TITLE
TASK-57510 Fix creating new folder

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents-extensions/components/DocumentsFavoriteItem.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents-extensions/components/DocumentsFavoriteItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-list-item class="clickable" @click="openPreview">
+  <v-list-item class="clickable" @click="openPreview()">
     <v-list-item-icon class="me-3 my-auto">
       <v-icon size="22" class="icon-default-color"> fas fa-folder-open </v-icon>
     </v-list-item-icon>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -208,21 +208,9 @@ export default {
           this.folderPath = path.substring(index + '/Documents/'.length);
           this.selectedView = 'folder';
         }
-      } else {
-        if (path.includes('/Private')){
-          const pathParts  = path.split('/Private');
-          if (pathParts.length>1){
-            this.folderPath = `Private${pathParts[1]}`;
-            this.selectedView = 'folder';
-          }
-        }
-        if (path.includes('/Public')){
-          const pathParts  = path.split('/Public');
-          if (pathParts.length>1){
-            this.folderPath = `Public${pathParts[1]}`;
-            this.selectedView = 'folder';
-          }
-        } 
+      } else if (path.includes('Private/')) {
+        this.folderPath = path.substring(path.indexOf('Private/') + 'Private/'.length);
+        this.selectedView = 'folder';
       }
     },
     duplicateDocument(documents){

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsNoBodyFolder.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsNoBodyFolder.vue
@@ -26,7 +26,7 @@
           <v-icon
             size="13"
             class="pe-1 text-sub-title"
-            @click="openDrawer">
+            @click="openDrawer()">
             fas fa-file-alt
           </v-icon>
         </div>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/CopyLinkMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/CopyLinkMenuAction.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="clickable pt-1 mx-2"
-    @click="copyLink">
+    @click="copyLink()">
     <v-icon
       size="13"
       class="pe-1 iconStyle">

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DeleteMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DeleteMenuAction.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="clickable mx-2"
-    @click="deleteAction">
+    @click="deleteAction()">
     <v-icon
       size="13"
       class="pe-1 iconStyle">

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DetailsMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DetailsMenuAction.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="clickable mx-2"
-    @click="displayDetails">
+    @click="displayDetails()">
     <v-icon
       size="13"
       class="pe-1 iconStyle">

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DownloadMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DownloadMenuAction.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="downloadDocumentNewApp clickable mx-2"
-    @click="download">
+    @click="download()">
     <v-icon
       size="13"
       class="pe-1 iconStyle">

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DuplicateMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DuplicateMenuAction.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="clickable pt-1 mx-2"
-    @click="duplicate">
+    @click="duplicate()">
     <v-icon
       size="13"
       class="pe-1 iconStyle">

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/EditMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/EditMenuAction.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="clickable mx-2"
-    @click="editFile">
+    @click="editFile()">
     <v-icon
       size="13"
       dark

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/MoveMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/MoveMenuAction.vue
@@ -17,7 +17,7 @@
 <template>
   <div
     class="clickable pt-1 mx-2"
-    @click="moveDocument">
+    @click="moveDocument()">
     <v-icon
       size="13"
       class="pe-1 iconStyle">

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/RenameMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/RenameMenuAction.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="clickable pt-1 mx-2"
-    @click="editNameMode">
+    @click="editNameMode()">
     <v-icon
       size="13"
       class="pe-1 iconStyle">

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/VisibilityMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/VisibilityMenuAction.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="clickable ma-auto pt-1 mx-2"
-    @click="changeVisibility">
+    @click="changeVisibility()">
     <v-icon
       size="13"
       class="pe-1 iconStyle">

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsAllUsersVisibilityDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsAllUsersVisibilityDrawer.vue
@@ -47,12 +47,12 @@
         <v-spacer />
         <v-btn
           class="btn me-2"
-          @click="close">
+          @click="close()">
           {{ $t('documents.label.visibility.cancel') }}
         </v-btn>
         <v-btn
           class="btn btn-primary"
-          @click="saveVisibility">
+          @click="saveVisibility()">
           {{ $t('documents.label.visibility.save') }}
         </v-btn>
       </div>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsMoveDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsMoveDrawer.vue
@@ -74,7 +74,7 @@
       <div class="d-flex">
         <v-spacer />
         <v-btn
-          @click="close"
+          @click="close()"
           class="btn ml-2">
           {{ $t('documents.move.drawer.button.cancel') }}
         </v-btn>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsVisibilityDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsVisibilityDrawer.vue
@@ -133,12 +133,12 @@
           <v-spacer />
           <v-btn
             class="btn me-2"
-            @click="close">
+            @click="close()">
             {{ $t('documents.label.visibility.cancel') }}
           </v-btn>
           <v-btn
             class="btn btn-primary"
-            @click="saveVisibility">
+            @click="saveVisibility()">
             {{ $t('documents.label.visibility.save') }}
           </v-btn>
         </div>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -16,7 +16,7 @@
       <div class="width-full">
         <div
           v-if="!editNameMode"
-          @click="openPreview"
+          @click="openPreview()"
           class="document-title clickable hover-underline d-inline-flex"
           :title="file.name">
           <div
@@ -67,7 +67,7 @@
               :size="isMobile ? 14 : 18"
               class="clickable text-sub-title"
               :class="editNameMode ? '' : 'button-document-action'"
-              @click="displayActionMenu">
+              @click="displayActionMenu()">
               mdi-dots-vertical
             </v-icon>
           </v-btn>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentAddNewMobile.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentAddNewMobile.vue
@@ -5,7 +5,7 @@
     <template slot="content">
       <v-list dense>
         <v-list-item
-          @click="addFolder"
+          @click="addFolder()"
           class="px-2">
           <v-icon
             size="19"
@@ -15,7 +15,7 @@
           <span v-if="!isMobile" class="body-2 text-color">{{ $t('documents.button.addNewFolder') }}</span>
         </v-list-item>
         <v-list-item
-          @click="openDrawer"
+          @click="openDrawer()"
           class="px-2">
           <v-icon
             size="19"

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsAddNewFile.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsAddNewFile.vue
@@ -5,7 +5,7 @@
         v-if="!isFolderView"
         :id="isMobile ? 'addItemMenuMobile' : 'addItemMenu'"
         class="btn btn-primary primary px-2 py-0"
-        @click="openDrawer">
+        @click="openDrawer()">
         <v-icon
           id="addBtn"
           dark>
@@ -18,7 +18,7 @@
         :id="isMobile ? 'addItemMenu mobile' : 'addItemMenu'"
         class="btn btn-primary primary px-2 py-0"
         :key="postKey"
-        @click="openAddItemMenu">
+        @click="openAddItemMenu()">
         <v-icon
           size="13"
           id="addBtn"
@@ -36,7 +36,7 @@
         offset-y
         down>
         <v-list-item
-          @click="addFolder"
+          @click="addFolder()"
           class="px-2 add-menu-list-item">
           <v-icon
             size="13"
@@ -46,7 +46,7 @@
           <span v-if="!isMobile" class="body-2 text-color menu-text ps-1">{{ $t('documents.button.addNewFolder') }}</span>
         </v-list-item>
         <v-list-item
-          @click="openDrawer"
+          @click="openDrawer()"
           class="px-2 add-menu-list-item">
           <v-icon
             size="13"

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsFilterInput.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsFilterInput.vue
@@ -4,7 +4,7 @@
       size="16"
       class="inputDocumentsFilter text-sub-title pa-1 my-auto mt-2"
       v-show="isMobile && !showMobileFilter"
-      @click="mobileFilter">
+      @click="mobileFilter()">
       fas fa-filter
     </v-icon>
     <v-text-field


### PR DESCRIPTION
Prior to this change, when browsing to Personal Drive 'Documents/AnotherFolder' folder, the user can't add a folder under it. This fix ensures to compute the correct parent path in personal drive case. In addition, the method calls inside events has been modified to avoid JS errors when the JS isn't correctly bound to the execution context which is due to referring 'this' object to a different object than the current Vue component.