### PR TITLE
Task-57178: Fix add folder  button on documents app

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsNoBodyFolder.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsNoBodyFolder.vue
@@ -19,7 +19,8 @@
           <span class="ps-1">{{ addFolderLabel }}</span>
           <v-icon
             size="13"
-            class="pe-1 text-sub-title">
+            class="pe-1 text-sub-title"
+            @click="addFolder()">
             fas fa-folder
           </v-icon>
           <span class="ps-1">{{ addDocumentLabel }}</span>
@@ -58,6 +59,9 @@ export default {
     },
   },
   methods: {
+    addFolder() {
+      this.$root.$emit('documents-add-folder');
+    },
     openDrawer() {
       document.dispatchEvent(new CustomEvent('open-attachments-app-drawer'));
     },


### PR DESCRIPTION
ISSUE : when user goes to space > document > folder tab and check add folder button , the dd folder button not working .
FIX : create new folder .