### PR TITLE
TASK-57821: changed the event launched when clicking on the document icon

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsNoBodyFolder.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsNoBodyFolder.vue
@@ -63,7 +63,7 @@ export default {
       this.$root.$emit('documents-add-folder');
     },
     openDrawer() {
-      document.dispatchEvent(new CustomEvent('open-attachments-app-drawer'));
+      this.$root.$emit('documents-open-drawer');
     },
   }
 };


### PR DESCRIPTION
ISSUE: when a folder has no files and we click on the document icon to open the drawer to add or upload a file, the files get added in the root folder 
FIX: changed the event to open the attachment drawer