### PR TITLE
TASK-57220: Added document from quick file creation is not saved in the right destination 

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -153,6 +153,7 @@ export default {
     this.$root.$on('document-search', this.search);
     this.$root.$on('save-visibility', this.saveVisibility);
     this.$root.$on('documents-sort', this.sort);
+    this.$root.$on('documents-open-attachments-drawer', this.openDrawer);
     this.$root.$on('documents-filter', filter => {
       this.primaryFilter = filter;
       this.refreshFiles(this.primaryFilter);

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsNoBody.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsNoBody.vue
@@ -49,7 +49,7 @@ export default {
   },
   methods: {
     openDrawer() {
-      document.dispatchEvent(new CustomEvent('open-attachments-app-drawer'));
+      this.$root.$emit('documents-open-attachments-drawer');
     },
   }
 };

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsNoBodyFolder.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsNoBodyFolder.vue
@@ -63,7 +63,7 @@ export default {
       this.$root.$emit('documents-add-folder');
     },
     openDrawer() {
-      document.dispatchEvent(new CustomEvent('open-attachments-app-drawer'));
+      this.$root.$emit('documents-open-attachments-drawer');
     },
   }
 };


### PR DESCRIPTION
Prior to this change, when add a document from quick file creation, the attachments drawer is opened without specified configuration to allow save the file in the right destination.
This PR should make sure to open the attachments drawer with the right config specified in the root component of the documents app