### PR TITLE
Task-54482: Add missing listener to update activity cache when attachments renamed

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/listener/AttachmentsActivityCacheUpdater.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/listener/AttachmentsActivityCacheUpdater.java
@@ -1,0 +1,24 @@
+package org.exoplatform.documents.listener;
+
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.social.core.storage.api.ActivityStorage;
+import org.exoplatform.social.core.storage.cache.CachedActivityStorage;
+
+public class AttachmentsActivityCacheUpdater extends Listener<String, String> {
+
+  private CachedActivityStorage cachedActivityStorage;
+
+  public AttachmentsActivityCacheUpdater(ActivityStorage activityStorage) {
+    if (activityStorage instanceof CachedActivityStorage) {
+      this.cachedActivityStorage = (CachedActivityStorage) activityStorage;
+    }
+  }
+
+  @Override
+  public void onEvent(Event<String, String> event) throws Exception {
+    if (cachedActivityStorage != null && event.getData() != null) {
+      cachedActivityStorage.clearActivityCachedByAttachmentId(event.getData());
+    }
+  }
+}

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
@@ -26,6 +26,7 @@ import static org.powermock.api.mockito.PowerMockito.doThrow;
 
 import org.exoplatform.documents.rest.util.RestUtils;
 import org.exoplatform.documents.service.DocumentFileService;
+import org.exoplatform.services.listener.ListenerService;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
@@ -83,6 +84,8 @@ public class DocumentFileRestTest {
 
   private JCRDeleteFileStorage jcrDeleteFileStorage;
 
+  private ListenerService listenerService;
+
   @Before
   public void setUp() {
     spaceService = mock(SpaceService.class);
@@ -92,12 +95,14 @@ public class DocumentFileRestTest {
     authenticator = mock(Authenticator.class);
     documentFileStorage = mock(DocumentFileStorage.class);
     jcrDeleteFileStorage = mock(JCRDeleteFileStorage.class);
+    listenerService = mock(ListenerService.class);
     documentFileService = new DocumentFileServiceImpl(documentFileStorage,
                                                       jcrDeleteFileStorage,
                                                       authenticator,
                                                       spaceService,
                                                       identityManager,
-                                                      identityRegistry);
+                                                      identityRegistry,
+                                                      listenerService);
     documentFileRest = new DocumentFileRest(documentFileService, spaceService, identityManager, metadataService);
   }
 

--- a/documents-webapp/src/main/webapp/WEB-INF/conf/documents/documents-service-configuration.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/conf/documents/documents-service-configuration.xml
@@ -20,4 +20,13 @@
     </component-plugin>
   </external-component-plugins>
 
+  <external-component-plugins>
+    <target-component>org.exoplatform.services.listener.ListenerService</target-component>
+    <component-plugin>
+      <name>rename_file_event</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.documents.listener.AttachmentsActivityCacheUpdater</type>
+    </component-plugin>
+  </external-component-plugins>
+
 </configuration>


### PR DESCRIPTION
ISSUE : When user post a short message on space using existing uploads and rename the original file , the title of document not updated in activity stream.
FIX : add missing listener to clear cache activity related to document updated.