### PR TITLE
Task-57136: Translate terms when creating / duplicating files

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
@@ -141,7 +141,7 @@ public interface DocumentFileService {
    *           documents of the designated parentFolderId
    * @throws ObjectNotFoundException when folderId doesn't exisits
    */
-  AbstractNode duplicateDocument(long ownerId,String fileId, long authenticatedUserId) throws IllegalAccessException, ObjectNotFoundException;
+  AbstractNode duplicateDocument(long ownerId,String fileId,String prefixClone, long authenticatedUserId) throws IllegalAccessException, ObjectNotFoundException;
 
   /**
    * Move the given node.

--- a/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
@@ -112,7 +112,7 @@ public interface DocumentFileStorage {
    *           documents of the designated parentFolderId
    * @throws ObjectNotFoundException when folderId doesn't exisits
    */
-  AbstractNode duplicateDocument(long ownerId, String fileId, Identity aclIdentity) throws IllegalAccessException, ObjectNotFoundException;
+  AbstractNode duplicateDocument(long ownerId, String fileId, String prefixClone, Identity aclIdentity) throws IllegalAccessException, ObjectNotFoundException;
 
   /**
    * Move the given node.

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
@@ -288,6 +288,9 @@ public class DocumentFileRest implements ResourceContainer {
                                 @ApiParam(value = "File technical identifier", required = false)
                                 @QueryParam("fileId")
                                         String fileId,
+                                @ApiParam(value = "File prefix Clone", required = false)
+                                @QueryParam("prefixClone")
+                                        String prefixClone,
                                 @ApiParam(value = "File properties to expand.", required = false)
                                 @QueryParam("expand")
                                          String expand) {
@@ -297,7 +300,7 @@ public class DocumentFileRest implements ResourceContainer {
     }
     long userIdentityId = RestUtils.getCurrentUserIdentityId(identityManager);
     try {
-      AbstractNode abstractNode = documentFileService.duplicateDocument(ownerId, fileId, userIdentityId);
+      AbstractNode abstractNode = documentFileService.duplicateDocument(ownerId, fileId, prefixClone, userIdentityId);
       AbstractNodeEntity abstractNodeEntity = EntityBuilder.toDocumentItemEntity(documentFileService,
               identityManager,
               spaceService,

--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -216,8 +216,8 @@ public class DocumentFileServiceImpl implements DocumentFileService {
   }
 
   @Override
-  public AbstractNode duplicateDocument(long ownerId, String fileId, long authenticatedUserId) throws IllegalAccessException, ObjectNotFoundException {
-    return documentFileStorage.duplicateDocument(ownerId, fileId, getAclUserIdentity(authenticatedUserId));
+  public AbstractNode duplicateDocument(long ownerId, String fileId, String prefixClone, long authenticatedUserId) throws IllegalAccessException, ObjectNotFoundException {
+    return documentFileStorage.duplicateDocument(ownerId, fileId, prefixClone, getAclUserIdentity(authenticatedUserId));
   }
 
   @Override

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
@@ -596,19 +596,19 @@ public class DocumentFileRestTest {
     file2.setMimeType(":file");
     file2.setSize(50);
 
-    when(documentFileStorage.duplicateDocument(2,"oldFile",userID)).thenReturn(file2);
+    when(documentFileStorage.duplicateDocument(2,"oldFile", "copy of",userID)).thenReturn(file2);
 
 
     Response response1 = documentFileRest.duplicateDocument(null,
-            null,"");
+            null,"copy of","");
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response1.getStatus());
 
-    Response response2 = documentFileRest.duplicateDocument(Long.valueOf(2),"oldFile","");
+    Response response2 = documentFileRest.duplicateDocument(Long.valueOf(2),"oldFile", "copy of","");
 
     assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response2.getStatus());
 
     when(identityManager.getOrCreateUserIdentity(username)).thenReturn(currentIdentity);
-    Response response3 = documentFileRest.duplicateDocument(Long.valueOf(2),"oldFile","");
+    Response response3 = documentFileRest.duplicateDocument(Long.valueOf(2),"oldFile", "copy of","");
     assertEquals(Response.Status.OK.getStatusCode(), response3.getStatus());
     AbstractNodeEntity fileNode = (AbstractNodeEntity) response3.getEntity();
     assertEquals(fileNode.getName(), "Copy of oldFile");

--- a/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
+++ b/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
@@ -115,3 +115,4 @@ documents.reminder.newDocApp.Dialog.message=Quickly access documents that space 
 documents.reminder.newDocApp.dialog.title=Quick access to recent documents
 documents.reminder.oldDocSwitch.dialog.title=Welcome to the new Documents app
 documents.reminder.oldDocSwitch.Dialog.message=Discover our brand-new application to manage and consult your documents. We offer you a more modern and simplified working experience that we will continue to improve in the next versions according to your feedback. Until then, should miss anything, you can always switch back to the old application. 
+documents.label.prefix.clone=copy of

--- a/documents-webapp/src/main/resources/locale/portlet/Documents_fr.properties
+++ b/documents-webapp/src/main/resources/locale/portlet/Documents_fr.properties
@@ -115,3 +115,4 @@ documents.reminder.newDocApp.Dialog.message=Acc\u00E9dez rapidement aux document
 documents.reminder.newDocApp.dialog.title=Acc\u00E8s rapide aux documents r\u00E9cents
 documents.reminder.oldDocSwitch.dialog.title=Bienvenue dans la nouvelle application Documents
 documents.reminder.oldDocSwitch.Dialog.message=D\u00E9couvrez notre toute nouvelle application pour g\u00E9rer et consulter vos documents. Nous vous proposons une exp\u00E9rience de travail plus moderne et simplifi\u00E9e que nous continuerons \u00E0 am\u00E9liorer dans les prochaines versions selon vos retours. D'ici l\u00E0, si quelque chose vous manque, vous pouvez toujours revenir \u00E0 l'ancienne application. 
+documents.label.prefix.clone=copie de

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -125,6 +125,9 @@ export default {
     searchResult(){
       return ((this.query && this.query.length) || this.isFavorites) && !this.files.length;
     },
+    prefixClone(){
+      return this.$t('documents.label.prefix.clone');
+    },
   },
   created() {
     document.addEventListener(`extension-${this.extensionApp}-${this.extensionType}-updated`, this.refreshViewExtensions);
@@ -217,7 +220,7 @@ export default {
     duplicateDocument(documents){
       this.parentFolderId = documents.id;
       return this.$documentFileService
-        .duplicateDocument(this.parentFolderId,this.ownerId)
+        .duplicateDocument(this.parentFolderId,this.ownerId,this.prefixClone)
         .then( () => {
           this.parentFolderId=null;
           this.getFolderPath(this.folderPath);

--- a/documents-webapp/src/main/webapp/vue-app/documents/js/DocumentFileService.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/js/DocumentFileService.js
@@ -78,7 +78,7 @@ export function getFullTreeData(ownerId, folderId) {
   });
 }
 
-export function duplicateDocument(fileId,ownerId) {
+export function duplicateDocument(fileId,ownerId,prefixClone) {
   const formData = new FormData();
 
   if (fileId) {
@@ -86,6 +86,9 @@ export function duplicateDocument(fileId,ownerId) {
   }
   if (ownerId) {
     formData.append('ownerId', ownerId);
+  }
+  if (prefixClone) {
+    formData.append('prefixClone', prefixClone);
   }
   const params = new URLSearchParams(formData).toString();
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/documents/duplicate?${params}`, {


### PR DESCRIPTION
Add i18n prifix clone in order to translate terms when duplicating files.
Add unit test
Decrease the complexity of methode duplicateItem

(cherry picked from commit 8e8138a9e9f45dd714f407d791d655d5196a7afd)