### PR TITLE
TASK-57530 fix breadcrumb related to a symlink folder

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -313,10 +313,6 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         folderId = ((NodeImpl) node).getIdentifier();
       } else {
         node = getNodeByIdentifier(session, folderId);
-        if(node.isNodeType(NodeTypeConstants.EXO_SYMLINK)){
-          String sourceNodeId = node.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString();
-          node = getNodeByIdentifier(session, sourceNodeId);
-        }
       }
       if (StringUtils.isNotBlank(folderPath)) {
         node = getNodeByPath(node, folderPath, sessionProvider);


### PR DESCRIPTION
Problem: when clicking on symlink folder, the BreadCrumb item which contains the name folder is replaced with the path of the original folder.on technical side, the problem was in the implementation inside function getBrBreadCrumb() in JCRDocumentFileStorage class.if the type of the node was Symlink ,the breadCrumb of source node was returned to be displayed in front.
Fix: remove the part of code which check on Symlink node to avoid replacing it with original node, then return the correct BreadCrumb Items of current folder.
(cherry-picked from https://github.com/exoplatform/documents/commit/efbbdc09e89c47dd9d05abde2d00b0070834b09c )