### PR TITLE
Task-57172: Documents - After deleting a file double refresh is needed to make it dispappear from the list

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -130,6 +130,11 @@ export default {
     },
   },
   created() {
+    // Ensure that localStorage doesn't contain a deleted document
+    window.setTimeout(() => {
+      localStorage.removeItem('deletedDocument');
+    }, 10000);
+
     document.addEventListener(`extension-${this.extensionApp}-${this.extensionType}-updated`, this.refreshViewExtensions);
 
     window.addEventListener('popstate', e => {this.onBrowserNavChange(e);});


### PR DESCRIPTION
Fix : Ensure that localStorage doesn't contain a deleted document when reloading the page
(cherry picked from commit c22f5a8a37677f3f4572daa75ed7a7732bd46998)