### PR TITLE
Task-57047 : Access To Folder of a document from the preview mode

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -610,7 +610,7 @@ export default {
               path: attachment.path,
               title: attachment.title,
               openUrl: attachment.openUrl,
-              breadCrumb: attachment.previewBreadcrumb,
+              breadCrumb: this.$utilsDocument.getFolderpreviewPathFrombreadCrumb(Object.assign({}, attachment.previewBreadcrumb)),
               size: attachment.size,
               downloadUrl: attachment.downloadUrl,
             },

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -257,7 +257,7 @@ export default {
                 title: decodeURI(attachment.title),
                 downloadUrl: attachment.downloadUrl,
                 openUrl: attachment.openUrl,
-                breadCrumb: attachment.previewBreadcrumb,
+                breadCrumb: this.$utilsDocument.getFolderpreviewPathFrombreadCrumb(Object.assign({}, attachment.previewBreadcrumb)),
                 fileInfo: this.fileInfo(),
                 size: attachment.size,
               },

--- a/documents-webapp/src/main/webapp/vue-app/documents/js/Utils.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/js/Utils.js
@@ -1,16 +1,33 @@
+function getFolderPath(path){
+  if (eXo.env.portal.spaceName){
+    const index = path.indexOf('/Documents');
+    if (index !== -1){
+      return path.substring(index+10);
+    }
+  } else {
+    if (path.includes('/Private')){
+      const index  = path.indexOf('/Private');
+      if (index !== -1){
+        return path.substring(index);
+              
+      }
+    }
+    if (path.includes('/Public')){
+      const index = path.indexOf('/Public');
+      if (index !== -1){
+        return path.substring(index);
+      }
+    } 
+  }
+}
 export function getFolderpreviewPathFrombreadCrumb(breadCrumb){
-  let ParentpathFolder ='';
-  let isSource = true;
+
   for (const folderName in breadCrumb){
     const portalBaseURL= breadCrumb[folderName].slice(0,breadCrumb[folderName].indexOf('?'));
-    const pathFolder = `${portalBaseURL}/${ParentpathFolder}${folderName}`;
+    const path = getFolderPath(decodeURIComponent(breadCrumb[folderName].slice(breadCrumb[folderName].indexOf('?')+1,breadCrumb[folderName].indexOf('&'))));
+    const pathFolder = `${portalBaseURL}${path}`;
     breadCrumb[folderName]=pathFolder ;
-    ParentpathFolder = `${folderName}/` ;
-    if (isSource){
-      breadCrumb[folderName]= portalBaseURL;
-      ParentpathFolder = '';
-      isSource= false ;
-    }
   }
   return breadCrumb;
 }
+

--- a/documents-webapp/src/main/webapp/vue-app/documents/js/Utils.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/js/Utils.js
@@ -1,0 +1,16 @@
+export function getFolderpreviewPathFrombreadCrumb(breadCrumb){
+  let ParentpathFolder ='';
+  let isSource = true;
+  for (const folderName in breadCrumb){
+    const portalBaseURL= breadCrumb[folderName].slice(0,breadCrumb[folderName].indexOf('?'));
+    const pathFolder = `${portalBaseURL}/${ParentpathFolder}${folderName}`;
+    breadCrumb[folderName]=pathFolder ;
+    ParentpathFolder = `${folderName}/` ;
+    if (isSource){
+      breadCrumb[folderName]= portalBaseURL;
+      ParentpathFolder = '';
+      isSource= false ;
+    }
+  }
+  return breadCrumb;
+}

--- a/documents-webapp/src/main/webapp/vue-app/documents/main.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/main.js
@@ -2,9 +2,16 @@ import './initComponents.js';
 import './extensions.js';
 
 import * as documentFileService from './js/DocumentFileService.js';
+import * as utils from './js/Utils.js';
 if (!Vue.prototype.$documentFileService) {
   window.Object.defineProperty(Vue.prototype, '$documentFileService', {
     value: documentFileService,
+  });
+}
+
+if (!Vue.prototype.$utilsDocument) {
+  window.Object.defineProperty(Vue.prototype, '$utilsDocument', {
+    value: utils,
   });
 }
 


### PR DESCRIPTION
ISSUE :When opening a file preview from the Recent tab of Drives app or other emplacements(attached file to an article),  then clicking on any folder from the path displayed at the bottom left corner of the document preview,  we can't access directly to this selected folder.
FIX : get the folder path from the breadcrumbPreview attachments. 