### PR TITLE
TASK-57797: Hide system folders and files (#421)

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/model/DocumentNodeFilter.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/model/DocumentNodeFilter.java
@@ -35,4 +35,6 @@ public abstract class DocumentNodeFilter {
 
   private String           userId;
 
+  private boolean          includeHiddenFiles;
+
 }

--- a/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
@@ -47,7 +47,8 @@ public interface DocumentFileService {
                                       DocumentNodeFilter filter,
                                       int offset,
                                       int limit,
-                                      long userIdentityId) throws IllegalAccessException, ObjectNotFoundException;
+                                      long userIdentityId,
+                                      boolean showHiddenFiles) throws IllegalAccessException, ObjectNotFoundException;
 
   /**
    * Retrieves a list of accessible files, for a selected user, by applying the

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2021 eXo Platform SAS
- *  
+ *
  *  This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <gnu.org/licenses>.
  */
@@ -116,7 +116,10 @@ public class DocumentFileRest implements ResourceContainer {
                                    int offset,
                                    @ApiParam(value = "Limit of results to return", required = false, defaultValue = "10")
                                    @QueryParam("limit")
-                                   int limit) {
+                                   int limit,
+                                   @ApiParam(value = "showHiddenFiles of results to return", required = false, defaultValue = "false")
+                                   @QueryParam("showHiddenFiles")
+                                   boolean showHiddenFiles) {
 
     if (ownerId == null && StringUtils.isBlank(parentFolderId)) {
       return Response.status(Status.BAD_REQUEST).entity("either_ownerId_or_folderId_is_mandatory").build();
@@ -135,8 +138,7 @@ public class DocumentFileRest implements ResourceContainer {
       filter.setUserId(userId);
       filter.setAscending(ascending);
       filter.setSortField(DocumentSortField.getFromAlias(sortField));
-
-      List<AbstractNode> documents = documentFileService.getDocumentItems(listingType, filter, offset, limit, userIdentityId);
+      List<AbstractNode> documents = documentFileService.getDocumentItems(listingType, filter, offset, limit, userIdentityId,showHiddenFiles);
       List<AbstractNodeEntity> documentEntities = EntityBuilder.toDocumentItemEntities(documentFileService,
                                                                                        identityManager,
                                                                                        spaceService,

--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -80,7 +80,8 @@ public class DocumentFileServiceImpl implements DocumentFileService {
                                              DocumentNodeFilter filter,
                                              int offset,
                                              int limit,
-                                             long userIdentityId) throws IllegalAccessException,
+                                             long userIdentityId,
+                                             boolean showHiddenFiles) throws IllegalAccessException,
                                                                   ObjectNotFoundException {
     if (filter == null) {
       throw new IllegalArgumentException("File filter is mandatory");
@@ -95,6 +96,7 @@ public class DocumentFileServiceImpl implements DocumentFileService {
           throw new IllegalArgumentException("filter must be an instance of DocumentTimelineFilter");
         }
         DocumentTimelineFilter timelinefilter = (DocumentTimelineFilter) filter;
+        timelinefilter.setIncludeHiddenFiles(showHiddenFiles);
         if (timelinefilter.getOwnerId() == null || timelinefilter.getOwnerId() <= 0) {
           throw new IllegalArgumentException("OwnerId is mandatory");
         }
@@ -105,6 +107,7 @@ public class DocumentFileServiceImpl implements DocumentFileService {
           throw new IllegalArgumentException("filter must be an instance of DocumentFolderFilter");
         }
         DocumentFolderFilter folderFilter = (DocumentFolderFilter) filter;
+        folderFilter.setIncludeHiddenFiles(showHiddenFiles);
         if (StringUtils.isBlank(folderFilter.getParentFolderId())&&(folderFilter.getOwnerId() == null || folderFilter.getOwnerId() <= 0)) {
           throw new IllegalArgumentException("ParentFolderId or OwnerId is mandatory");
         }

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
@@ -178,10 +178,11 @@ public class DocumentFileRestTest {
                                                            null,
                                                            false,
                                                            0,
-                                                           0);
+                                                           0,
+                                                           false);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response1.getStatus());
 
-    Response response2 = documentFileRest.getDocumentItems(currentOwnerId, null,null, null, null,null, false, "", null, false, 0, 0);
+    Response response2 = documentFileRest.getDocumentItems(currentOwnerId, null,null, null, null,null, false, "", null, false, 0, 0,false);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response2.getStatus());
 
     Response response3 = documentFileRest.getDocumentItems(currentOwnerId,
@@ -195,12 +196,13 @@ public class DocumentFileRestTest {
                                                            null,
                                                            false,
                                                            0,
-                                                           0);
+                                                           0,
+                                                           false);
     assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response3.getStatus());
 
     when(identityManager.getOrCreateUserIdentity(username)).thenReturn(currentIdentity);
     List<AbstractNode> files_ = new ArrayList<>();
-    files_ = documentFileService.getDocumentItems(FileListingType.TIMELINE, filter, 0, 0, Long.valueOf(currentIdentity.getId()));
+    files_ = documentFileService.getDocumentItems(FileListingType.TIMELINE, filter, 0, 0, Long.valueOf(currentIdentity.getId()),false);
 
     FileNodeEntity nodeEntity = new FileNodeEntity();
     nodeEntity.setLinkedFileId("1");
@@ -240,7 +242,8 @@ public class DocumentFileRestTest {
                                                            null,
                                                            false,
                                                            0,
-                                                           0);
+                                                           0,
+                                                           false);
     assertEquals(Response.Status.OK.getStatusCode(), response4.getStatus());
     List<FileNodeEntity> filesNodeEntity = new ArrayList<>();
     filesNodeEntity = (List<FileNodeEntity>) response4.getEntity();
@@ -467,10 +470,11 @@ public class DocumentFileRestTest {
                                                            null,
                                                            false,
                                                            0,
-                                                           0);
+                                                           0,
+                                                           false);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response1.getStatus());
 
-    Response response2 = documentFileRest.getDocumentItems(currentOwnerId, "2", null, FileListingType.FOLDER, null,null, false, "", null, false, 0, 0);
+    Response response2 = documentFileRest.getDocumentItems(currentOwnerId, "2", null, FileListingType.FOLDER, null,null, false, "", null, false, 0, 0,false);
     assertEquals(Response.Status.OK.getStatusCode(), response2.getStatus());
 
     Response response3 = documentFileRest.getDocumentItems(currentOwnerId,
@@ -484,7 +488,8 @@ public class DocumentFileRestTest {
                                                            null,
                                                            false,
                                                            0,
-                                                           0);
+                                                           0,
+                                                           false);
     assertEquals(Response.Status.OK.getStatusCode(), response3.getStatus());
 
     List<FolderNodeEntity> foldersNodeEntity = new ArrayList<>();

--- a/documents-services/src/test/java/org/exoplatform/documents/service/DocumentFileServiceTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/service/DocumentFileServiceTest.java
@@ -127,38 +127,38 @@ public class DocumentFileServiceTest {
     org.exoplatform.services.security.Identity userID = new org.exoplatform.services.security.Identity(userName);
     DocumentTimelineFilter filter = null;
     Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-      documentFileService.getDocumentItems(FileListingType.TIMELINE, null, 0, 0, Long.valueOf(currentIdentity.getId()));
+      documentFileService.getDocumentItems(FileListingType.TIMELINE, null, 0, 0, Long.valueOf(currentIdentity.getId()),false);
     });
     assertEquals(exception.getMessage(), "File filter is mandatory");
 
     filter = new DocumentTimelineFilter(0L);
     DocumentTimelineFilter finalFilter1 = filter;
     exception = assertThrows(IllegalArgumentException.class, () -> {
-      documentFileService.getDocumentItems(FileListingType.TIMELINE, finalFilter1, 0, 0, Long.valueOf(currentIdentity.getId()));
+      documentFileService.getDocumentItems(FileListingType.TIMELINE, finalFilter1, 0, 0, Long.valueOf(currentIdentity.getId()),false);
     });
     assertEquals(exception.getMessage(), "OwnerId is mandatory");
 
     filter = new DocumentTimelineFilter(Long.valueOf(currentIdentity.getId()));
     DocumentTimelineFilter finalFilter = filter;
     exception = assertThrows(IllegalAccessException.class, () -> {
-      documentFileService.getDocumentItems(FileListingType.TIMELINE, finalFilter, 0, 0, 0);
+      documentFileService.getDocumentItems(FileListingType.TIMELINE, finalFilter, 0, 0, 0,false);
     });
     assertEquals(exception.getMessage(), "User Identity is mandatory");
 
     DocumentFolderFilter docFilter = new DocumentFolderFilter("", "", 0L);
     DocumentFolderFilter finalDocFilter = docFilter;
     exception = assertThrows(IllegalArgumentException.class, () -> {
-      documentFileService.getDocumentItems(FileListingType.TIMELINE, finalDocFilter, 0, 0, Long.valueOf(currentIdentity.getId()));
+      documentFileService.getDocumentItems(FileListingType.TIMELINE, finalDocFilter, 0, 0, Long.valueOf(currentIdentity.getId()),false);
     });
     assertEquals(exception.getMessage(), "filter must be an instance of DocumentTimelineFilter");
 
     exception = assertThrows(IllegalArgumentException.class, () -> {
-      documentFileService.getDocumentItems(FileListingType.FOLDER, finalFilter, 0, 0, Long.valueOf(currentIdentity.getId()));
+      documentFileService.getDocumentItems(FileListingType.FOLDER, finalFilter, 0, 0, Long.valueOf(currentIdentity.getId()),false);
     });
     assertEquals(exception.getMessage(), "filter must be an instance of DocumentFolderFilter");
 
     exception = assertThrows(IllegalArgumentException.class, () -> {
-      documentFileService.getDocumentItems(FileListingType.FOLDER, finalDocFilter, 0, 0, Long.valueOf(currentIdentity.getId()));
+      documentFileService.getDocumentItems(FileListingType.FOLDER, finalDocFilter, 0, 0, Long.valueOf(currentIdentity.getId()),false);
     });
     assertEquals(exception.getMessage(), "ParentFolderId or OwnerId is mandatory");
 
@@ -188,7 +188,7 @@ public class DocumentFileServiceTest {
 
     when(documentFileStorage.getFilesTimeline(filter, spaceID, 0, 0)).thenReturn(files);
     List<AbstractNode> files_ = new ArrayList<>();
-    files_ = documentFileService.getDocumentItems(FileListingType.TIMELINE, filter, 0, 0, Long.parseLong(currentIdentity.getId()));
+    files_ = documentFileService.getDocumentItems(FileListingType.TIMELINE, filter, 0, 0, Long.parseLong(currentIdentity.getId()),false);
     assertEquals(files_.size(), 4);
   }
 

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -99,6 +99,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     List<FileNode> files = null;
     String username = aclIdentity.getUserId();
     Long ownerId = filter.getOwnerId();
+    boolean showHiddenFiles = filter.isIncludeHiddenFiles();
     org.exoplatform.social.core.identity.model.Identity ownerIdentity = identityManager.getIdentity(String.valueOf(ownerId));
     if (ownerIdentity == null) {
       throw new ObjectNotFoundException("Owner Identity with id : " + ownerId + " isn't found");
@@ -122,13 +123,13 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         Query jcrQuery = session.getWorkspace().getQueryManager().createQuery(statement, Query.SQL);
         QueryResult queryResult = jcrQuery.execute();
         NodeIterator nodeIterator = queryResult.getNodes();
-        files = toFileNodes(identityManager, nodeIterator, aclIdentity, session, spaceService, offset, limit);
+        files = toFileNodes(identityManager, nodeIterator, aclIdentity, session, spaceService,showHiddenFiles, offset, limit);
 
         statement = getTimeLineQueryStatement(rootPath, NodeTypeConstants.EXO_SYMLINK, sortField, sortDirection);
         jcrQuery = session.getWorkspace().getQueryManager().createQuery(statement, Query.SQL);
         queryResult = jcrQuery.execute();
         nodeIterator = queryResult.getNodes();
-        files.addAll(toFileNodes(identityManager, nodeIterator, aclIdentity, session, spaceService, offset, limit));
+        files.addAll(toFileNodes(identityManager, nodeIterator, aclIdentity, session, spaceService, showHiddenFiles, offset, limit));
         return files;
       } else {
         String workspace = session.getWorkspace().getName();
@@ -230,6 +231,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     String username = aclIdentity.getUserId();
     String parentFolderId = filter.getParentFolderId();
     String folderPath = filter.getFolderPath();
+    boolean includeHiddenFiles = filter.isIncludeHiddenFiles();
     SessionProvider sessionProvider = null;
     try {
       Node parent = null;
@@ -263,7 +265,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
           ((QueryImpl)jcrQuery).setLimit(limit);
           QueryResult queryResult = jcrQuery.execute();
           NodeIterator nodeIterator = queryResult.getNodes();
-          return toNodes(identityManager, session, nodeIterator, aclIdentity, spaceService);
+          return toNodes(identityManager, session, nodeIterator, aclIdentity, spaceService,includeHiddenFiles);
         } else {
           String workspace = session.getWorkspace().getName();
           String sortField = getSortField(filter, false);

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -188,14 +188,14 @@ public class JCRDocumentFileStorageTest {
     when(manageableRepository.getConfiguration()).thenReturn(repositoryEntry);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
     when(sessionProvider.getSession(manageableRepository.getConfiguration().getDefaultWorkspaceName(),
-            manageableRepository)).thenReturn(userSession);
-
+                                    manageableRepository)).thenReturn(userSession);
 
     when(JCRDocumentsUtil.getNodeByIdentifier(userSession, filter.getParentFolderId())).thenReturn(parentNode);
     when(parentNode.getName()).thenReturn("documents");
     when(parentNode.getNode(filter.getFolderPath())).thenReturn(parentNode);
     filter.setSortField(DocumentSortField.MODIFIED_DATE);
     filter.setAscending(true);
+    filter.setIncludeHiddenFiles(false);
     when(parentNode.getPath()).thenReturn("/documents/path");
 
     // mock the query creation and execution
@@ -227,7 +227,8 @@ public class JCRDocumentFileStorageTest {
                             userSession,
                             nodeIterator,
                             identity,
-                            spaceService);
+                            spaceService,
+                            false);
     when(JCRDocumentsUtil.toFileNode(identityManager, identity, fileNode, "", spaceService)).thenReturn(file);
     when(JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode, "", spaceService)).thenReturn(folder);
 
@@ -251,12 +252,13 @@ public class JCRDocumentFileStorageTest {
     when(nodeIterator1.hasNext()).thenReturn(true, true, false);
     when(nodeIterator1.nextNode()).thenReturn(fileNode, folderNode);
     doCallRealMethod().when(JCRDocumentsUtil.class,
-            "toNodes",
-            identityManager,
-            userSession,
-            nodeIterator1,
-            identity,
-            spaceService);
+                            "toNodes",
+                            identityManager,
+                            userSession,
+                            nodeIterator1,
+                            identity,
+                            spaceService,
+                            false);
     List<AbstractNode> nodes1 = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 0);
     assertEquals(2, nodes1.size());
 
@@ -271,5 +273,4 @@ public class JCRDocumentFileStorageTest {
            times(1)).appSearch(identity, "collaboration", "/documents/path", filter, 0, 0, "lastUpdatedDate", "ASC");
 
   }
-
 }


### PR DESCRIPTION
Prior to this change, the system folders and files displayed inside the personal drives such as Folksonomy Searches exo:thumbnails
This change these system files are hiding

(cherry picked from commit 75e805aa8ebc6277f5bb57adaabba392c5e4cf5f)