### PR TITLE
Task-58997: Add the ability to create folder with the name contains only numbers

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
@@ -367,10 +367,6 @@ public class DocumentFileRest implements ResourceContainer {
     if (StringUtils.isEmpty(name)) {
       return Response.status(Response.Status.BAD_REQUEST).entity("Folder Name should not be empty").build();
     }
-    if (NumberUtils.isNumber(name)) {
-      LOG.warn("Folder Name should not be number");
-      return Response.status(Response.Status.BAD_REQUEST).entity("Folder Name should not be number").build();
-    }
     try {
       long userIdentityId = RestUtils.getCurrentUserIdentityId(identityManager);
         documentFileService.createFolder(ownerId, parentid, folderPath, name, userIdentityId);

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
@@ -653,10 +653,9 @@ public class DocumentFileRestTest {
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     assertEquals("Folder Name should not be empty", response.getEntity());
 
-    response = documentFileRest.createFolder("11111111",null,null,"222");
-    assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-    assertEquals("Folder Name should not be number", response.getEntity());
-
+    doNothing().when(documentFileStorage).createFolder(2L, "11111111", null, "222", userID);
+    response = documentFileRest.createFolder("11111111",null,2L,"222");
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
     doNothing().when(documentFileStorage).createFolder(2L, "11111111", null, "test", userID);
     response = documentFileRest.createFolder("11111111",null,2L,"test");
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());


### PR DESCRIPTION
ISSUE : On new document application users can't create a folder  with the name contains only numbers
FIX : Remove the condition who verify if the name of folder is contain only numbers and can't able user to create this folder 