### PR TITLE
Task-58708: Fix redirect to root folder when duplicate file

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -212,9 +212,8 @@ export default {
         path = window.location.pathname;
       }
       if (eXo.env.portal.spaceName){
-        const index = path.indexOf('/Documents/');
-        if (index !== -1) {
-          this.folderPath = path.substring(index + '/Documents/'.length);
+        if (path.includes('/documents/')){
+          this.folderPath = path.substring(path.indexOf('/documents/') + '/documents/'.length);
           this.selectedView = 'folder';
         }
       } else if (path.includes('Private/')) {


### PR DESCRIPTION
ISSUE : When duplicate document inside any folder in any level the document duplicated but the current location changed to the root folder of document app 
FIX :  fix the `getFolderPath` method to get correctly the  current folder path where the file duplicate