### PR TITLE
Task-58900: In move drawer when changing the destination folder the current location shouldn't be changed (#432)

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsMoveDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsMoveDrawer.vue
@@ -27,6 +27,7 @@
             <documents-breadcrumb
               :show-icon="false"
               :documents-breadcrumb="documentsBreadcrumbSource"
+              :disabled-icon-tree="true"
               move />
           </div>
         </v-list-item>
@@ -36,6 +37,7 @@
             <documents-breadcrumb
               :show-icon="false"
               :documents-breadcrumb="documentsBreadcrumbDestination"
+              :disabled-icon-tree="true"
               move />
           </div>
         </v-list-item>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -5,6 +5,7 @@
         icon
         small
         class="me-2"
+        :disabled="disabledIconTree"
         @click="openTreeFolderDrawer()">
         <v-icon class="text-sub-title" size="16">
           fas fa-sitemap
@@ -25,6 +26,7 @@
               text
               v-bind="attrs"
               v-on="on"
+              :disabled="disabledIconTree"
               @click="openFolder(documents)">
               <a
                 class="caption text-truncate"
@@ -56,6 +58,10 @@ export default {
       default: true,
     },
     move: {
+      type: Boolean,
+      default: false,
+    },
+    disabledIconTree: {
       type: Boolean,
       default: false,
     },


### PR DESCRIPTION
Problem: when click on the the move button of a folder in documents application of a spaceX, the hierarchy icon of the Current Location and destination in the opened move drawer are clickable
Fix: we add a property to assure that these two tree views are hidden and not clickable