### PR TITLE
Task-59380 : Fix document application wrong icons

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -9,11 +9,15 @@
           indeterminate
           size="16" />
         <i
-          v-else
+          v-else-if="file.cloudDriveFolder "
           class="fas fa-folder driveFolderIcon">
           <i 
-            :class="file.cloudDriveFolder ? 'fa-hdd driveFolderContentIcon' : ''"></i>
+            class="fa-hdd driveFolderContentIcon"></i>
         </i>
+        <v-icon
+          v-else
+          :size="isMobile && 32 || 22"
+          :color="icon.color">{{ icon.class }}</v-icon>
       </div>
       <div class="width-full">
         <div


### PR DESCRIPTION
prior this change all files are associated with the "Folder" type icon whether in folder view or in recent view , that because the icon removed on the[Task-59174] and replaced by folder icon or drive folder icon if the document is a folder drive icon .
this pr fix this regression .