### PR TITLE
Task-59419_59420: Customize 3 dots options on One Drive and Google Drive cloud drive folders

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -256,6 +256,7 @@ public class JCRDocumentsUtil {
     if(StringUtils.isNotBlank(sourceID)){
       fileNode.setSourceID(sourceID);
     }
+
     toFileNode(identityManager, aclIdentity, node, fileNode , spaceService);
     return fileNode;
   }

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/CopyLinkMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/CopyLinkMenuAction.vue
@@ -8,7 +8,7 @@
       mdi-link-variant
     </v-icon>
     <span class="ps-1">{{ $t('documents.label.copy.link') }}</span>
-    <v-divider
+    <v-divider v-if="!file.cloudDriveFolder"
       class="mt-1 dividerStyle" />
   </div>
 </template>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
@@ -78,6 +78,9 @@ export default {
       if (!this.fileCanEdit) {
         extensions = extensions.filter(extension => extension.id !== this.editExtensions);
       }
+      if (this.file.cloudDriveFolder) {
+        extensions = extensions.filter(extension => extension.id === 'copyLink');
+      }
       extensions = extensions.filter(extension => this.checkTransferRules(extension)
                                                      && extension.enabled(this.file.acl, this.isSymlink()));
       let changed = false;


### PR DESCRIPTION
Prior to this change, all options are allowed from 3 dots for One Drive and Google Drive cloud drive folders. After this change, we keep only copy link as option for these folders in order to avoid wrong operations. 