### PR TITLE
Task-59422_59423: Don't display modify option from the 3 dots options of One Drive and Google Drive cloud drive documents

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/model/AbstractNode.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/model/AbstractNode.java
@@ -51,6 +51,8 @@ public abstract class AbstractNode {
 
   private boolean        cloudDriveFolder;
 
+  private boolean        cloudDriveFile;
+
   public  boolean isFolder(){
     return this instanceof FolderNode;
   }

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/model/AbstractNodeEntity.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/model/AbstractNodeEntity.java
@@ -66,4 +66,6 @@ public class AbstractNodeEntity {
 
   private boolean                               cloudDriveFolder;
 
+  private boolean                               cloudDriveFile;
+
 }

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -183,6 +183,7 @@ public class EntityBuilder {
       nodeEntity.setParentFolderId(node.getParentFolderId());
       nodeEntity.setSourceID(node.getSourceID());
       nodeEntity.setCloudDriveFolder(node.isCloudDriveFolder());
+      nodeEntity.setCloudDriveFile(node.isCloudDriveFile());
 
       if ((node instanceof FolderNode)) {
         ((FolderNodeEntity)nodeEntity).setPath(((FolderNode)node).getPath());

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -268,6 +268,7 @@ public class JCRDocumentsUtil {
                                 SpaceService spaceService) {
     try {
       fileNode.setDatasource(JCR_DATASOURCE_NAME);
+      fileNode.setCloudDriveFile(node.hasProperty("ecd:driveUUID"));
       retrieveFileProperties(identityManager, node, aclIdentity, fileNode, spaceService);
       if (node.hasNode(NodeTypeConstants.JCR_CONTENT)) {
         Node content = node.getNode(NodeTypeConstants.JCR_CONTENT);

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
@@ -52,9 +52,9 @@ export default {
     isMobile() {
       return this.$vuetify.breakpoint.name === 'xs' || this.$vuetify.breakpoint.name === 'sm';
     },
-    fileCanEdit(){
+    fileCanEdit() {
       const type = this.file && this.file.mimeType || '';
-      return this.supportedDocuments && this.supportedDocuments.filter(doc => doc.edit && doc.mimeType === type).length > 0;
+      return this.supportedDocuments && this.supportedDocuments.filter(doc => doc.edit && doc.mimeType === type && !this.file.cloudDriveFile).length > 0;
     }
   },
   methods: {


### PR DESCRIPTION
Prior to this change, modify option is allowed from 3 dots for One Drive and Google Drive cloud drive documents. After this change, this option should no more be displayed in order to avoid modifying cloud drive documents with only office.