### PR TITLE
TASK-59433: Rename file : accentuated charachters aren't saved

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -546,7 +546,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       String oldName = node.getName();
       if (oldName.indexOf('.') != -1 && node.isNodeType(NodeTypeConstants.NT_FILE)) {
         String ext = oldName.substring(oldName.lastIndexOf('.'));
-        title = name.concat(ext);
+        title = title.concat(ext);
         name = name.concat(ext);
       }
 


### PR DESCRIPTION
Prior to change there is a regression caused by #416, so the modification is reverted, no need to change the title since it is a property that does not need to be cleaned nor escaped its illegal JCR characters.