### PR TITLE
fix: Fix translation of task folder name to the selected language - EXO-46507

### DIFF
--- a/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
+++ b/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <gnu.org/licenses>.
 #
-
+documents.task.folder.name=task
 documents.button.addNew=New
 documents.button.addNewFile=Document
 documents.button.addNewFolder=Folder

--- a/documents-webapp/src/main/resources/locale/portlet/Documents_fr.properties
+++ b/documents-webapp/src/main/resources/locale/portlet/Documents_fr.properties
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <gnu.org/licenses>.
 #
-
+documents.task.folder.name=tâche
 documents.button.addNew=Nouveau
 documents.button.addNewFile=Document
 documents.button.addNewFolder=Dossier

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -127,7 +127,7 @@ export default {
   }),
   computed: {
     title() {
-      return decodeURI(this.fileName);
+     return  this.file && this.file.folder && this.fileName === 'task' ? this.$t('documents.task.folder.name') : decodeURI(this.fileName);
     },
     lastUpdated() {
       return this.file && (this.file.modifiedDate || this.file.createdDate) || '';

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -127,7 +127,7 @@ export default {
   }),
   computed: {
     title() {
-     return  this.file && this.file.folder && this.fileName === 'task' ? this.$t('documents.task.folder.name') : decodeURI(this.fileName);
+      return  this.file && this.file.folder && this.fileName === 'task' ? this.$t('documents.task.folder.name') : decodeURI(this.fileName);
     },
     lastUpdated() {
       return this.file && (this.file.modifiedDate || this.file.createdDate) || '';


### PR DESCRIPTION
Prior this change the task folder name not translated  to the selected language of platform, this pr allow the document folder task name to be translated to the same language of platform. 