### PR TITLE
fix: Fix refresh after delete - EXO-57172

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/storage/JCRDeleteFileStorage.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/storage/JCRDeleteFileStorage.java
@@ -18,7 +18,11 @@ package org.exoplatform.documents.storage;
 
 import org.exoplatform.services.security.Identity;
 
+import java.util.Map;
+
 public interface JCRDeleteFileStorage {
+
+  Map<String, String> getDocumentsToDelete();
 
   /**
    * Delete document (Move to trash)

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDeleteFileStorageImpl.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDeleteFileStorageImpl.java
@@ -107,7 +107,10 @@ public class JCRDeleteFileStorageImpl implements JCRDeleteFileStorage, Startable
       documentsToDeleteQueue.remove(documentId);
     }
   }
-
+  @Override
+  public Map<String, String> getDocumentsToDelete(){
+    return documentsToDeleteQueue;
+  }
   @Override
   public void deleteDocument(String folderPath, String documentId, boolean favorite, boolean checkToMoveToTrash, long delay, Identity identity, long userIdentityId) {
     SessionProvider sessionProvider = null;

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -27,6 +27,7 @@ import org.exoplatform.commons.api.search.data.SearchResult;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.documents.constant.DocumentSortField;
 import org.exoplatform.documents.model.*;
+import org.exoplatform.documents.storage.JCRDeleteFileStorage;
 import org.exoplatform.documents.storage.jcr.search.DocumentFileSearchResult;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.access.AccessControlEntry;
@@ -107,8 +108,10 @@ public class JCRDocumentsUtil {
                                            SpaceService spaceService,
                                            boolean includeHiddenFiles,
                                            int offset,
-                                           int limit) {
+                                           int limit) throws RepositoryException {
     List<FileNode> fileNodes = new ArrayList<>();
+    JCRDeleteFileStorage jCRDeleteFileStorage =  CommonsUtils.getService(JCRDeleteFileStorage.class);
+    Map<String, String> documetsToDelete = jCRDeleteFileStorage.getDocumentsToDelete();
     int index = 0;
     int size = 0;
     while (nodeIterator.hasNext()) {
@@ -119,7 +122,8 @@ public class JCRDocumentsUtil {
       String sourceID = "";
       String sourceMimeType = "";
       Node node = nodeIterator.nextNode();
-
+      // Check if the node is in the queue of documents to be deleted
+      if(documetsToDelete.containsKey(((NodeImpl) node).getIdentifier())) continue;
       try {
         Node sourceNode = null;
         if (node.isNodeType(NodeTypeConstants.EXO_SYMLINK)) {


### PR DESCRIPTION
Prior to this fix, when a user deletes a file in the documents app, the delete operation is delayed by 5 seconds to allow the user to cancel the edit if needed, so if the user refreshes the UI before the delay is over, the list of documents is retrieved before de delete is done, and the deleted file will be displayed in the list, another refresh after the delay will return the list without the file.
The fix will simply check the list of files to be deleted and don't add them to the list.