### PR TITLE
fix: creating uppercase folder through webdav leads to duplicate folder - EXO-59745

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -490,7 +490,7 @@ export default {
         if (pathparts.length>1){
           attachmentAppConfiguration= {
             'sourceApp': 'NEW.APP',
-            'defaultFolder': this.extractDefaultFolder(pathparts[1]),
+            'defaultFolder': this.extractDefaultFolder(),
             'defaultDrive': {
               isSelected: true,
               name: `.spaces.${eXo.env.portal.spaceGroup}`,
@@ -506,7 +506,7 @@ export default {
         if (pathparts.length>1){
           attachmentAppConfiguration= {
             'sourceApp': 'NEW.APP',
-            'defaultFolder': this.extractDefaultFolder(pathparts[1]),
+            'defaultFolder': this.extractDefaultFolder(),
             'defaultDrive': {
               isSelected: true,
               name: 'Personal Documents',
@@ -517,10 +517,9 @@ export default {
       }
       document.dispatchEvent(new CustomEvent('open-attachments-app-drawer', {detail: attachmentAppConfiguration}));
     },
-    extractDefaultFolder(targetPath) {
-      const path = decodeURI(targetPath);
-      const folderName = path && path.substring(path.lastIndexOf('/'));
-      return folderName && path.replace(folderName, `/${this.currentFolder.path.split('/').pop()}`);
+    extractDefaultFolder() {
+      const path = this.currentFolder.path;
+      return path.substring(path.indexOf('Documents')+ '/Documents'.length);
     },
     setCurrentFolder(folder) {
       this.currentFolder = folder;


### PR DESCRIPTION
Prior to this change,When opening the attachment drawer, the default folder wasn't well extracted, when it has upercase letters and same for it's subfolders. This PR should make sure to correctly extract the default folder name, what ever was the hieararchy level of the folder

(cherry picked from commit bf0faefe812ffed6a2977fa3ef5062b702ce8852)