### PR TITLE
fix: Create a shortcut of a folder doesn't work - EXO-60122

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -336,7 +336,8 @@ public class JCRDocumentsUtil {
       }
     }
     if (node.isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
-      Node sourceNode = node.getSession().getNodeByUUID(documentNode.getSourceID());
+      Node sourceNode = null;
+      sourceNode = getNodeByIdentifier(node.getSession(), documentNode.getSourceID());
       if (sourceNode != null && sourceNode.isNodeType(NodeTypeConstants.MIX_VERSIONABLE)
               && sourceNode.getBaseVersion() != null) {
         Version version = sourceNode.getBaseVersion();


### PR DESCRIPTION
Prior to this fix, folder symlinks are not listed in folder view because the source folder is not referencable so can't get it by uiid using a simple session, I changed the way to retrieve the node using an extended session and be sure if the source folder is not retrieved it should not affect the list of items.