### PR TITLE
fix: Fix uploading files inside subfolders of an uppercase parent folder name - EXO-59861

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -460,7 +460,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
           throw new ObjectNotFoundException("Folder with path : " + folderPath + " isn't found");
         }
       }
-      String name = Text.escapeIllegalJcrChars(cleanString(title.toLowerCase()));
+      String name = Text.escapeIllegalJcrChars(cleanName(title.toLowerCase()));
       if (node.hasNode(name)) {
         throw new ObjectAlreadyExistsException("Folder'" + name + "' already exist");
       }
@@ -502,14 +502,14 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
           throw new ObjectNotFoundException("Folder with path : " + folderPath + " isn't found");
         }
       }
-      String name = Text.escapeIllegalJcrChars(cleanString(title.toLowerCase()));
+      String name = Text.escapeIllegalJcrChars(cleanName(title.toLowerCase()));
       int i =0;
       String newName = name;
       String newTitle = title;
       while((node.hasNode(newName))){
         i++;
         newTitle = title + " (" + i + ")";
-        newName = Text.escapeIllegalJcrChars(cleanString(newTitle.toLowerCase()));
+        newName = Text.escapeIllegalJcrChars(cleanName(newTitle.toLowerCase()));
       }
       return newTitle;
     } catch (Exception e) {
@@ -538,7 +538,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       } else {
         node = getNodeByIdentifier(session, documentID);
       }
-      String name = Text.escapeIllegalJcrChars(cleanString(title));
+      String name = Text.escapeIllegalJcrChars(cleanName(title));
       //clean node name
 
       name = URLDecoder.decode(name,"UTF-8");

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -536,39 +536,29 @@ public class JCRDocumentsUtil {
   /**
    * Clean string.
    *
-   * @param str the str
+   * @param oldName the str
    *
    * @return the string
    */
-  public static String cleanString(String str) {
-    Transliterator accentsconverter = Transliterator.getInstance("Latin; NFD; [:Nonspacing Mark:] Remove; NFC;");
-    str = accentsconverter.transliterate(str);
-    //the character ? seems to not be changed to d by the transliterate function
-    StringBuilder cleanedStr = new StringBuilder(str.trim());
-    // delete special character
-    int strLength = cleanedStr.length();
-    int i = 0;
-    while (i < strLength) {
-      char c = cleanedStr.charAt(i);
-      if (c == '/' || c == ':' || c == '[' || c == ']' || c == '*' || c == '\'' || c == '"' || c == '|' || c == 'ʿ' || c == 'ˇ' || c == '.') {
-        cleanedStr.deleteCharAt(i);
-        cleanedStr.insert(i, '_');
-      } else if (!(Character.isLetterOrDigit(c) || Character.isWhitespace(c) || c == '-' || c == '_')) {
-        cleanedStr.deleteCharAt(i);
-        strLength = cleanedStr.length();
-        continue;
+  public static String cleanName(String oldName) {
+    if (org.apache.commons.lang.StringUtils.isEmpty(oldName)) return oldName;
+    String extention ="" ;
+    if(oldName.lastIndexOf(".") > -1){
+      extention = oldName.substring(oldName.lastIndexOf("."));
+      oldName = oldName.substring(0,oldName.lastIndexOf(".")) ;
+    }
+    String specialChar = "&#*@.'\"\t\r\n$\\><:;[]/|";
+    StringBuilder ret = new StringBuilder();
+    for (int i = 0; i < oldName.length(); i++) {
+      char currentChar = oldName.charAt(i);
+      if (specialChar.indexOf(currentChar) > -1) {
+        ret.append('_');
+      } else {
+        ret.append(currentChar);
       }
-      i++;
     }
-    while (org.apache.commons.lang.StringUtils.isNotEmpty(cleanedStr.toString()) && !Character.isLetterOrDigit(cleanedStr.charAt(0))) {
-      cleanedStr.deleteCharAt(0);
-    }
-    String clean = cleanedStr.toString();
-    if (clean.endsWith("-")) {
-      clean = clean.substring(0, clean.length()-1);
-    }
-
-    return clean;
+    ret.append(extention);
+    return ret.toString();
   }
 
   public static String getMimeType(Node node) {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -506,7 +506,7 @@ export default {
         if (pathparts.length>1){
           attachmentAppConfiguration= {
             'sourceApp': 'NEW.APP',
-            'defaultFolder': this.extractDefaultFolder(pathparts[1]),
+            'defaultFolder': `Documents/${this.extractDefaultFolder()}`,
             'defaultDrive': {
               isSelected: true,
               name: 'Personal Documents',


### PR DESCRIPTION
Prior to this change, When upload a a file inside a subfolder starts from level 2 in the hierarchy and while the parent folder has an uppercase name, the upload fails and a duplicated folder is created with the attachments drawer with lowercase name.
This PR should make sure send the right selected path.

(cherry picked from commit 4170ebedd00e48d6a22fd602de4ee9c5cbb490da)