### PR TITLE
fix: Keep documents search term filter when switching between documents views - EXO-60059

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -527,6 +527,9 @@ export default {
           this.files.forEach(file => {
             file.canAdd = this.canAdd;
           });
+          if (filter.query){
+            this.$root.$emit('filer-query',filter.query);
+          }
         })
         .finally(() => this.loading = false);
     },

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsFilterInput.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsFilterInput.vue
@@ -52,8 +52,16 @@ export default {
   },
   created() {
     this.$root.$on('resetSearch', this.resetSearch);
+    this.$root.$on('filer-query', this.filterQuery);
   },
   methods: {
+    filterQuery(query){
+      if (this.query === query){
+        return;
+      }
+      this.query = query;
+      this.$root.$emit('document-search', this.query);
+    },
     mobileFilter(){
       this.showMobileFilter = !this.showMobileFilter;
       this.$root.$emit('show-mobile-filter', this.showMobileFilter);


### PR DESCRIPTION

Prior to this change, when we are on a specific document view, make a document search based on a search term filter then switch to another document view, the search results are still displayed but the corresponding search term filter is removed. After this change, we keep the search term filter displayed like the search results when switching between views.