### PR TITLE
fix: Fix personal drive shared document preview issues (breadcrumb, wrong folder displayed) - EXO-60838

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/listener/ShareDocumentNotificationListener.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/listener/ShareDocumentNotificationListener.java
@@ -22,6 +22,7 @@ import org.exoplatform.commons.notification.impl.NotificationContextImpl;
 import org.exoplatform.documents.notification.plugin.AddDocumentCollaboratorPlugin;
 import org.exoplatform.documents.notification.utils.NotificationConstants;
 import org.exoplatform.documents.notification.utils.NotificationUtils;
+import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.security.ConversationState;
@@ -53,7 +54,7 @@ public class ShareDocumentNotificationListener extends Listener<Identity, Node> 
     NotificationContext ctx = NotificationContextImpl.cloneInstance();
     String documentLink = null;
     if (targetNode.hasProperty(EXO_SYMLINK_UUID)) {
-      documentLink = NotificationUtils.getSharedDocumentLink(targetNode.getProperty(EXO_SYMLINK_UUID).getString(), null, null);
+      documentLink = NotificationUtils.getSharedDocumentLink(((NodeImpl) targetNode).getIdentifier(), null, null);
     } else {
       documentLink = NotificationUtils.getDocumentLink(targetNode, spaceService, identityManager);
     }

--- a/documents-services/src/test/java/org/exoplatform/documents/listener/ShareDocumentNotificationListenerTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/listener/ShareDocumentNotificationListenerTest.java
@@ -9,6 +9,7 @@ import org.exoplatform.commons.notification.impl.NotificationContextImpl;
 import org.exoplatform.commons.notification.impl.setting.NotificationPluginContainer;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.documents.notification.plugin.AddDocumentCollaboratorPlugin;
+import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.social.core.identity.model.Identity;
@@ -62,6 +63,9 @@ public class ShareDocumentNotificationListenerTest {
   @Mock
   private IdentityManager                   identityManager;
 
+  @Mock
+  private NodeImpl                   nodeImpl;
+
   private ShareDocumentNotificationListener shareDocumentNotificationListener;
 
   @Before
@@ -81,6 +85,7 @@ public class ShareDocumentNotificationListenerTest {
     when(CommonsUtils.getService(NotificationPluginContainer.class)).thenReturn(notificationPluginContainer);
     when(CommonsUtils.getService(PluginSettingService.class)).thenReturn(pluginSettingService);
     when(CommonsUtils.getService(ChannelManager.class)).thenReturn(channelManager);
+    when(CommonsUtils.getService(NodeImpl.class)).thenReturn(nodeImpl);
     when(CommonsUtils.getCurrentPortalOwner()).thenReturn("dw");
     when(CommonsUtils.getCurrentDomain()).thenReturn("http://domain/");
     when(LinkProvider.getPortalName(null)).thenReturn("portal");
@@ -93,13 +98,13 @@ public class ShareDocumentNotificationListenerTest {
     Space space = new Space();
     space.setGroupId("/spaces/spacename");
     when(spaceService.getSpaceByPrettyName("space_name")).thenReturn(space);
-    Node targetNode = mock(Node.class);
+    Node targetNode = mock(NodeImpl.class);
     Identity targetIdentity = mock(Identity.class);
     Event<Identity, Node> event = new Event<>("share_document_event", targetIdentity, targetNode);
     when(targetIdentity.getProviderId()).thenReturn("USER");
     Property property = mock(Property.class);
     when(targetNode.getProperty("exo:uuid")).thenReturn(property);
-    when(property.getString()).thenReturn("313445hegefezd");
+    when(((NodeImpl) targetNode).getIdentifier()).thenReturn("313445hegefezd");
     Property propertyTitle = mock(Property.class);
     Value value = mock(Value.class);
     when(propertyTitle.getValue()).thenReturn(value);

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -254,10 +254,7 @@ export default {
       if (this.file && this.file.folder){
         this.$root.$emit('document-open-folder', this.file);
       } else {
-        let id = this.file.id;
-        if (this.file.sourceID){
-          id = this.file.sourceID;
-        }
+        const id = this.file.id;
         this.$attachmentService.getAttachmentById(id)
           .then(attachment => {
             documentPreview.init({


### PR DESCRIPTION
prior to this change, when sending a notification for the shared document or selecting a document to display it send the UUID of the original document which resulted in an incorrect display of the breadcrumb trail and folders
prior to this change, when sharing or selecting a document it's retrieved by its UUID 