### PR TITLE
fix: fix load more button missing - EXO-60826 (#601)

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -156,17 +156,13 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       if (StringUtils.isBlank(filter.getQuery()) && BooleanUtils.isNotTrue(filter.getFavorites())) {
         String sortField = getSortField(filter, true);
         String sortDirection = getSortDirection(filter);
-        String statement = getTimeLineQueryStatement(rootPath, NodeTypeConstants.NT_FILE, sortField, sortDirection);
+        String statement = getTimeLineQueryStatement(rootPath, sortField, sortDirection);
         Query jcrQuery = session.getWorkspace().getQueryManager().createQuery(statement, Query.SQL);
+        ((QueryImpl)jcrQuery).setOffset(offset);
+        ((QueryImpl)jcrQuery).setLimit(limit);
         QueryResult queryResult = jcrQuery.execute();
         NodeIterator nodeIterator = queryResult.getNodes();
-        files = toFileNodes(identityManager, nodeIterator, aclIdentity, session, spaceService,showHiddenFiles, offset, limit);
-
-        statement = getTimeLineQueryStatement(rootPath, NodeTypeConstants.EXO_SYMLINK, sortField, sortDirection);
-        jcrQuery = session.getWorkspace().getQueryManager().createQuery(statement, Query.SQL);
-        queryResult = jcrQuery.execute();
-        nodeIterator = queryResult.getNodes();
-        files.addAll(toFileNodes(identityManager, nodeIterator, aclIdentity, session, spaceService, showHiddenFiles, offset, limit));
+        files = toFileNodes(identityManager, nodeIterator, aclIdentity, session, spaceService,showHiddenFiles);
         return files;
       } else {
         String workspace = session.getWorkspace().getName();
@@ -317,13 +313,13 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         if (StringUtils.isBlank(filter.getQuery()) && BooleanUtils.isNotTrue(filter.getFavorites())) {
           String sortField = getSortField(filter, true);
           String sortDirection = getSortDirection(filter);
-          String statement = getFolderDocumentsQuery(parent.getPath(), sortField, sortDirection);
+          String statement = getFolderDocumentsQuery(parent.getPath(), sortField, sortDirection, includeHiddenFiles);
           Query jcrQuery = session.getWorkspace().getQueryManager().createQuery(statement, Query.SQL);
           ((QueryImpl)jcrQuery).setOffset(offset);
           ((QueryImpl)jcrQuery).setLimit(limit);
           QueryResult queryResult = jcrQuery.execute();
           NodeIterator nodeIterator = queryResult.getNodes();
-          return toNodes(identityManager, session, nodeIterator, aclIdentity, spaceService,includeHiddenFiles);
+          return toNodes(identityManager, session, nodeIterator, aclIdentity, spaceService, includeHiddenFiles);
         } else {
           String workspace = session.getWorkspace().getName();
           String sortField = getSortField(filter, false);
@@ -829,26 +825,32 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       newNode.setProperty(NodeTypeConstants.EXO_SYMLINK_UUID, oldNode.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString());
     }
   }
-  private String getTimeLineQueryStatement(String rootPath, String nodeType, String sortField, String sortDirection) {
+
+  private String getTimeLineQueryStatement(String rootPath, String sortField, String sortDirection) {
     return new StringBuilder().append("SELECT * FROM ")
-                              .append(nodeType)
+                              .append("nt:base")
                               .append(" WHERE jcr:path LIKE '")
                               .append(rootPath)
-                              .append("/%' ORDER BY ")
+                              .append("/%' ")
+                              .append(" AND ( jcr:primaryType='exo:symlink' OR jcr:primaryType='nt:file') AND NOT jcr:mixinTypes LIKE 'exo:hiddenable' ")
+                              .append(" ORDER BY ")
                               .append(sortField)
                               .append(" ")
                               .append(sortDirection)
                               .toString();
   }
 
-  private String getFolderDocumentsQuery(String folderPath, String sortField, String sortDirection) {
+  private String getFolderDocumentsQuery(String folderPath, String sortField, String sortDirection, boolean includeHiddenFiles) {
+    String hiddenableQuery = includeHiddenFiles ? " " : " AND NOT jcr:mixinTypes LIKE 'exo:hiddenable' ";
     return new StringBuilder().append("SELECT * FROM nt:base")
             .append(" WHERE jcr:path LIKE '")
             .append(folderPath)
             .append("/%'")
             .append(" AND NOT jcr:path LIKE '")
             .append(folderPath)
-            .append("/%/%' ORDER BY ")
+            .append("/%/%' ")
+            .append(hiddenableQuery)
+            .append(" ORDER BY ")
             .append(sortField)
             .append(" ")
             .append(sortDirection)

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -232,14 +232,18 @@ public class JCRDocumentFileStorageTest {
     // mock toNodes method
     FileNode file = new FileNode();
     file.setName("file1");
-    FolderNode folder = new FolderNode();
-    folder.setName("folder1");
+    FolderNode folder1 = new FolderNode();
+    folder1.setName("folder1");
+    FolderNode folder2 = new FolderNode();
+    folder2.setName("folder2");
     when(nodeIterator.hasNext()).thenReturn(true, true, false);
     Node fileNode = mock(Node.class);
-    Node folderNode = mock(Node.class);
+    Node folderNode1 = mock(Node.class);
+    Node folderNode2 = mock(Node.class);
     when(fileNode.isNodeType(NodeTypeConstants.NT_FILE)).thenReturn(true);
-    when(folderNode.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
-    when(nodeIterator.nextNode()).thenReturn(fileNode, folderNode);
+    when(folderNode1.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
+    when(folderNode2.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
+    when(nodeIterator.nextNode()).thenReturn(fileNode, folderNode1);
     doCallRealMethod().when(JCRDocumentsUtil.class,
                             "toNodes",
                             identityManager,
@@ -249,10 +253,15 @@ public class JCRDocumentFileStorageTest {
                             spaceService,
                             false);
     when(JCRDocumentsUtil.toFileNode(identityManager, identity, fileNode, "", spaceService)).thenReturn(file);
-    when(JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode, "", spaceService)).thenReturn(folder);
+    when(JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode1, "", spaceService)).thenReturn(folder1);
+    when(JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode2, "", spaceService)).thenReturn(folder2);
 
-    List<AbstractNode> nodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 0);
+    List<AbstractNode> nodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 2);
     assertEquals(2, nodes.size());
+    when(nodeIterator.hasNext()).thenReturn(true, false);
+    when(nodeIterator.nextNode()).thenReturn(folderNode2);
+    nodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 2, 4);
+    assertEquals(1, nodes.size());
 
     // case of folderNodeId empty
     filter.setParentFolderId(null);
@@ -269,7 +278,7 @@ public class JCRDocumentFileStorageTest {
     NodeIterator nodeIterator1 = mock(NodeIterator.class);
     when(queryResult.getNodes()).thenReturn(nodeIterator1);
     when(nodeIterator1.hasNext()).thenReturn(true, true, false);
-    when(nodeIterator1.nextNode()).thenReturn(fileNode, folderNode);
+    when(nodeIterator1.nextNode()).thenReturn(fileNode, folderNode1);
     doCallRealMethod().when(JCRDocumentsUtil.class,
                             "toNodes",
                             identityManager,
@@ -278,8 +287,12 @@ public class JCRDocumentFileStorageTest {
                             identity,
                             spaceService,
                             false);
-    List<AbstractNode> nodes1 = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 0);
+    List<AbstractNode> nodes1 = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 2);
     assertEquals(2, nodes1.size());
+    when(nodeIterator1.hasNext()).thenReturn(true, false);
+    when(nodeIterator1.nextNode()).thenReturn(folderNode2);
+    nodes1 = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 2, 4);
+    assertEquals(1, nodes1.size());
 
     // case filter with query
     filter.setQuery("docum");


### PR DESCRIPTION
before this change, load more is not displayed because the size of the folders returned is less than or equal to the limit because when filtering the folders, some of them were deleted ; after this change, retrieved documents from the database are filtred and with offset and limit