### PR TITLE
fix: fix load more button missing - EXO-60826 (#601)

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -120,17 +120,13 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       if (StringUtils.isBlank(filter.getQuery()) && BooleanUtils.isNotTrue(filter.getFavorites())) {
         String sortField = getSortField(filter, true);
         String sortDirection = getSortDirection(filter);
-        String statement = getTimeLineQueryStatement(rootPath, NodeTypeConstants.NT_FILE, sortField, sortDirection);
+        String statement = getTimeLineQueryStatement(rootPath, sortField, sortDirection);
         Query jcrQuery = session.getWorkspace().getQueryManager().createQuery(statement, Query.SQL);
+        ((QueryImpl)jcrQuery).setOffset(offset);
+        ((QueryImpl)jcrQuery).setLimit(limit);
         QueryResult queryResult = jcrQuery.execute();
         NodeIterator nodeIterator = queryResult.getNodes();
-        files = toFileNodes(identityManager, nodeIterator, aclIdentity, session, spaceService,showHiddenFiles, offset, limit);
-
-        statement = getTimeLineQueryStatement(rootPath, NodeTypeConstants.EXO_SYMLINK, sortField, sortDirection);
-        jcrQuery = session.getWorkspace().getQueryManager().createQuery(statement, Query.SQL);
-        queryResult = jcrQuery.execute();
-        nodeIterator = queryResult.getNodes();
-        files.addAll(toFileNodes(identityManager, nodeIterator, aclIdentity, session, spaceService, showHiddenFiles, offset, limit));
+        files = toFileNodes(identityManager, nodeIterator, aclIdentity, session, spaceService,showHiddenFiles);
         return files;
       } else {
         String workspace = session.getWorkspace().getName();
@@ -260,13 +256,13 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         if (StringUtils.isBlank(filter.getQuery()) && BooleanUtils.isNotTrue(filter.getFavorites())) {
           String sortField = getSortField(filter, true);
           String sortDirection = getSortDirection(filter);
-          String statement = getFolderDocumentsQuery(parent.getPath(), sortField, sortDirection);
+          String statement = getFolderDocumentsQuery(parent.getPath(), sortField, sortDirection, includeHiddenFiles);
           Query jcrQuery = session.getWorkspace().getQueryManager().createQuery(statement, Query.SQL);
           ((QueryImpl)jcrQuery).setOffset(offset);
           ((QueryImpl)jcrQuery).setLimit(limit);
           QueryResult queryResult = jcrQuery.execute();
           NodeIterator nodeIterator = queryResult.getNodes();
-          return toNodes(identityManager, session, nodeIterator, aclIdentity, spaceService,includeHiddenFiles);
+          return toNodes(identityManager, session, nodeIterator, aclIdentity, spaceService, includeHiddenFiles);
         } else {
           String workspace = session.getWorkspace().getName();
           String sortField = getSortField(filter, false);
@@ -727,26 +723,32 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       newNode.setProperty(NodeTypeConstants.EXO_SYMLINK_UUID, oldNode.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString());
     }
   }
-  private String getTimeLineQueryStatement(String rootPath, String nodeType, String sortField, String sortDirection) {
+
+  private String getTimeLineQueryStatement(String rootPath, String sortField, String sortDirection) {
     return new StringBuilder().append("SELECT * FROM ")
-                              .append(nodeType)
+                              .append("nt:base")
                               .append(" WHERE jcr:path LIKE '")
                               .append(rootPath)
-                              .append("/%' ORDER BY ")
+                              .append("/%' ")
+                              .append(" AND ( jcr:primaryType='exo:symlink' OR jcr:primaryType='nt:file') AND NOT jcr:mixinTypes LIKE 'exo:hiddenable' ")
+                              .append(" ORDER BY ")
                               .append(sortField)
                               .append(" ")
                               .append(sortDirection)
                               .toString();
   }
 
-  private String getFolderDocumentsQuery(String folderPath, String sortField, String sortDirection) {
+  private String getFolderDocumentsQuery(String folderPath, String sortField, String sortDirection, boolean includeHiddenFiles) {
+    String hiddenableQuery = includeHiddenFiles ? " " : " AND NOT jcr:mixinTypes LIKE 'exo:hiddenable' ";
     return new StringBuilder().append("SELECT * FROM nt:base")
             .append(" WHERE jcr:path LIKE '")
             .append(folderPath)
             .append("/%'")
             .append(" AND NOT jcr:path LIKE '")
             .append(folderPath)
-            .append("/%/%' ORDER BY ")
+            .append("/%/%' ")
+            .append(hiddenableQuery)
+            .append(" ORDER BY ")
             .append(sortField)
             .append(" ")
             .append(sortDirection)

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -105,19 +105,11 @@ public class JCRDocumentsUtil {
                                            Identity aclIdentity,
                                            Session session,
                                            SpaceService spaceService,
-                                           boolean includeHiddenFiles,
-                                           int offset,
-                                           int limit) throws RepositoryException {
+                                           boolean includeHiddenFiles) throws RepositoryException {
     List<FileNode> fileNodes = new ArrayList<>();
     JCRDeleteFileStorage jCRDeleteFileStorage =  CommonsUtils.getService(JCRDeleteFileStorage.class);
     Map<String, String> documetsToDelete = jCRDeleteFileStorage.getDocumentsToDelete();
-    int index = 0;
-    int size = 0;
     while (nodeIterator.hasNext()) {
-      if (index < offset) {
-        index++;
-        continue;
-      }
       String sourceID = "";
       String sourceMimeType = "";
       Node node = nodeIterator.nextNode();
@@ -145,10 +137,6 @@ public class JCRDocumentsUtil {
         fileNode.setMimeType(sourceMimeType);
       }
       fileNodes.add(fileNode);
-      size++;
-      if (size >= limit) {
-        return fileNodes;
-      }
     }
     return fileNodes;
   }
@@ -163,7 +151,7 @@ public class JCRDocumentsUtil {
     while (nodeIterator.hasNext()) {
       Node node = nodeIterator.nextNode();
       String sourceID = "";
-      Node sourceNode = null;
+      Node sourceNode = node;
       try {
         if (node.isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
           sourceID = node.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString();
@@ -171,28 +159,17 @@ public class JCRDocumentsUtil {
           if (sourceNode == null) {
             break;
           }
-          if ((sourceNode.isNodeType(NodeTypeConstants.NT_FOLDER) || sourceNode.isNodeType(NodeTypeConstants.NT_UNSTRUCTURED))
-              && (!(node.isNodeType(NodeTypeConstants.EXO_HIDDENABLE) || includeHiddenFiles))) {
-            FolderNode folderNode = toFolderNode(identityManager, aclIdentity, node, sourceID, spaceService);
-            fileNodes.add(folderNode);
-          }
-          if ((sourceNode.isNodeType(NodeTypeConstants.NT_FILE)) && (!(node.isNodeType(NodeTypeConstants.EXO_HIDDENABLE)
-              || includeHiddenFiles))) {
-            FileNode fileNode = toFileNode(identityManager, aclIdentity, node, sourceID, spaceService);
-            fileNode.setMimeType(getMimeType(sourceNode));
-            fileNodes.add(fileNode);
-          }
-        } else {
-          if ((node.isNodeType(NodeTypeConstants.NT_FOLDER) || node.isNodeType(NodeTypeConstants.NT_UNSTRUCTURED)) && (!(
-              node.isNodeType(NodeTypeConstants.EXO_HIDDENABLE) || includeHiddenFiles))) {
-            FolderNode folderNode = toFolderNode(identityManager, aclIdentity, node, sourceID, spaceService);
-            fileNodes.add(folderNode);
-          }
-          if ((node.isNodeType(NodeTypeConstants.NT_FILE)) && (!(node.isNodeType(NodeTypeConstants.EXO_HIDDENABLE)
-              || includeHiddenFiles))) {
-            FileNode fileNode = toFileNode(identityManager, aclIdentity, node, sourceID, spaceService);
-            fileNodes.add(fileNode);
-          }
+        }
+        if ((sourceNode.isNodeType(NodeTypeConstants.NT_FOLDER) || sourceNode.isNodeType(NodeTypeConstants.NT_UNSTRUCTURED))
+            && (!(node.isNodeType(NodeTypeConstants.EXO_HIDDENABLE) || includeHiddenFiles))) {
+          FolderNode folderNode = toFolderNode(identityManager, aclIdentity, node, sourceID, spaceService);
+          fileNodes.add(folderNode);
+        }
+        if ((sourceNode.isNodeType(NodeTypeConstants.NT_FILE))
+            && (!(node.isNodeType(NodeTypeConstants.EXO_HIDDENABLE) || includeHiddenFiles))) {
+          FileNode fileNode = toFileNode(identityManager, aclIdentity, node, sourceID, spaceService);
+          fileNode.setMimeType(getMimeType(sourceNode));
+          fileNodes.add(fileNode);
         }
       } catch (RepositoryException e) {
         LOG.warn("Error getting Folder Node for search result with path {}", node, e);

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -213,14 +213,18 @@ public class JCRDocumentFileStorageTest {
     // mock toNodes method
     FileNode file = new FileNode();
     file.setName("file1");
-    FolderNode folder = new FolderNode();
-    folder.setName("folder1");
+    FolderNode folder1 = new FolderNode();
+    folder1.setName("folder1");
+    FolderNode folder2 = new FolderNode();
+    folder2.setName("folder2");
     when(nodeIterator.hasNext()).thenReturn(true, true, false);
     Node fileNode = mock(Node.class);
-    Node folderNode = mock(Node.class);
+    Node folderNode1 = mock(Node.class);
+    Node folderNode2 = mock(Node.class);
     when(fileNode.isNodeType(NodeTypeConstants.NT_FILE)).thenReturn(true);
-    when(folderNode.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
-    when(nodeIterator.nextNode()).thenReturn(fileNode, folderNode);
+    when(folderNode1.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
+    when(folderNode2.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
+    when(nodeIterator.nextNode()).thenReturn(fileNode, folderNode1);
     doCallRealMethod().when(JCRDocumentsUtil.class,
                             "toNodes",
                             identityManager,
@@ -230,10 +234,15 @@ public class JCRDocumentFileStorageTest {
                             spaceService,
                             false);
     when(JCRDocumentsUtil.toFileNode(identityManager, identity, fileNode, "", spaceService)).thenReturn(file);
-    when(JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode, "", spaceService)).thenReturn(folder);
+    when(JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode1, "", spaceService)).thenReturn(folder1);
+    when(JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode2, "", spaceService)).thenReturn(folder2);
 
-    List<AbstractNode> nodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 0);
+    List<AbstractNode> nodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 2);
     assertEquals(2, nodes.size());
+    when(nodeIterator.hasNext()).thenReturn(true, false);
+    when(nodeIterator.nextNode()).thenReturn(folderNode2);
+    nodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 2, 4);
+    assertEquals(1, nodes.size());
 
     // case of folderNodeId empty
     filter.setParentFolderId(null);
@@ -250,7 +259,7 @@ public class JCRDocumentFileStorageTest {
     NodeIterator nodeIterator1 = mock(NodeIterator.class);
     when(queryResult.getNodes()).thenReturn(nodeIterator1);
     when(nodeIterator1.hasNext()).thenReturn(true, true, false);
-    when(nodeIterator1.nextNode()).thenReturn(fileNode, folderNode);
+    when(nodeIterator1.nextNode()).thenReturn(fileNode, folderNode1);
     doCallRealMethod().when(JCRDocumentsUtil.class,
                             "toNodes",
                             identityManager,
@@ -259,8 +268,12 @@ public class JCRDocumentFileStorageTest {
                             identity,
                             spaceService,
                             false);
-    List<AbstractNode> nodes1 = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 0);
+    List<AbstractNode> nodes1 = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 2);
     assertEquals(2, nodes1.size());
+    when(nodeIterator1.hasNext()).thenReturn(true, false);
+    when(nodeIterator1.nextNode()).thenReturn(folderNode2);
+    nodes1 = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 2, 4);
+    assertEquals(1, nodes1.size());
 
     // case filter with query
     filter.setQuery("docum");

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -295,8 +295,7 @@ export default {
       }
     },
     loadMore() {
-      this.limit += this.pageSize;
-      this.refreshFiles(this.primaryFilter);
+      this.refreshFiles(this.primaryFilter,null, null, null , true);
     },
     changeView(view) {
       const realPageUrlIndex = window.location.href.toLowerCase().indexOf(eXo.env.portal.selectedNodeUri.toLowerCase()) + eXo.env.portal.selectedNodeUri.length;
@@ -329,7 +328,7 @@ export default {
         window.history.pushState('Documents', 'Personal Documents', `${window.location.pathname}?view=${this.selectedView}`);
       }
     },
-    refreshFiles(filterPrimary, deleted, documentId) {
+    refreshFiles(filterPrimary, deleted, documentId, symlinkId, append) {
       if (!this.selectedViewExtension) {
         return Promise.resolve(null);
       }
@@ -365,11 +364,12 @@ export default {
       }
       filter.favorites = this.isFavorites;
       const expand = this.selectedViewExtension.filePropertiesExpand || 'modifier,creator,owner,metadatas';
-      this.limit = this.limit || this.pageSize;
+      this.offset = append ? this.offset + this.pageSize : 0 ;
+      this.limit = append ? this.limit + this.pageSize : this.pageSize ;
       this.loading = true;
       return this.$documentFileService.getDocumentItems(filter, this.offset, this.limit + 1, expand)
         .then(files => {
-          this.files = this.sortField === 'favorite' ? files && files.slice(this.offset, this.limit).sort((file1, file2) => {
+          files = this.sortField === 'favorite' ? files && files.sort((file1, file2) => {
             if (file1.favorite === false && file2.favorite === true) {
               return this.ascending ? 1 : -1;
             }
@@ -377,9 +377,10 @@ export default {
               return this.ascending ? -1 : 1;
             }
             return 0;
-          }) || [] : files && files.slice(this.offset, this.limit) || [];
+          }) || files : files;
+          this.files = append ? this.files.concat(files) : files ;
           this.files = deleted ? this.files.filter(doc => doc.id !== documentId) : this.files;
-          this.hasMore = files && files.length > this.limit;
+          this.hasMore = files && files.length >= this.limit;
           if (this.fileName) {
             const result = files.filter(file => file?.path.endsWith(`/${this.fileName}`));
             if (result.length > 0) {


### PR DESCRIPTION
before this change, load more is not displayed because the size of the folders returned is less than or equal to the limit because when filtering the folders, some of them were deleted ; after this change, retrieved documents from the database are filtred and with offset and limit

(cherry picked from commit a503f7bf8cbd2ef162bf9206b663be0bc22f19c1)