### PR TITLE
fix: fix No version in the history version drawer if a file is duplicated : EXO-61044 

### DIFF
--- a/documents-storage-jcr/pom.xml
+++ b/documents-storage-jcr/pom.xml
@@ -57,7 +57,11 @@
       <groupId>org.exoplatform</groupId>
       <artifactId>exo-jcr-services</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.exoplatform.ecms</groupId>
+      <artifactId>ecms-core-services</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <!-- Test -->
     <dependency>
       <groupId>junit</groupId>

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -61,7 +61,6 @@ import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.IdentityConstants;
 import org.exoplatform.services.security.IdentityRegistry;
 import org.exoplatform.services.security.MembershipEntry;
-import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
@@ -700,8 +699,8 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         newNode = duplicateItem(oldNode, parentNode, parentNode, prefixClone);
         parentNode.save();
       }
-      AutoVersionService autoVersionService = WCMCoreUtils.getService(AutoVersionService.class);
-      if(autoVersionService != null) {
+      AutoVersionService autoVersionService = CommonsUtils.getService(AutoVersionService.class);
+      if (autoVersionService != null) {
         autoVersionService.autoVersion(newNode);
       }
       return toFileNode(identityManager, aclIdentity, parentNode, "", spaceService);

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -190,7 +190,6 @@ public class JCRDocumentFileStorageTest {
     when(identity.getRemoteId()).thenReturn("username");
     when(JCRDocumentsUtil.getUserSessionProvider(repositoryService, userID)).thenReturn(sessionProvider);
     when(CommonsUtils.getService(AutoVersionService.class)).thenReturn(autoVersionService);
-    when(autoVersionService.autoVersion(any(Node.class))).thenReturn(null);
     jcrDocumentFileStorage.duplicateDocument(1L,"1","copy of",userID);
     verify(sessionProvider, times(1)).close();
     verify(autoVersionService, times(1)).autoVersion(any(Node.class));

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -7,6 +7,7 @@ import org.exoplatform.documents.storage.jcr.search.DocumentSearchServiceConnect
 import org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil;
 import org.exoplatform.documents.storage.jcr.util.NodeTypeConstants;
 import org.exoplatform.documents.storage.jcr.util.Utils;
+import org.exoplatform.services.cms.documents.AutoVersionService;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.access.AccessControlList;
 import org.exoplatform.services.jcr.config.RepositoryEntry;
@@ -79,6 +80,9 @@ public class JCRDocumentFileStorageTest {
 
   @Mock
   private ActivityManager                activityManager;
+
+  @Mock
+  private AutoVersionService             autoVersionService;
 
   private JCRDocumentFileStorage         jcrDocumentFileStorage;
 
@@ -185,8 +189,11 @@ public class JCRDocumentFileStorageTest {
     when(currentNode.addNode("copy of test","nt:file")).thenReturn(currentNode);
     when(identity.getRemoteId()).thenReturn("username");
     when(JCRDocumentsUtil.getUserSessionProvider(repositoryService, userID)).thenReturn(sessionProvider);
+    when(CommonsUtils.getService(AutoVersionService.class)).thenReturn(autoVersionService);
+    when(autoVersionService.autoVersion(any(Node.class))).thenReturn(null);
     jcrDocumentFileStorage.duplicateDocument(1L,"1","copy of",userID);
     verify(sessionProvider, times(1)).close();
+    verify(autoVersionService, times(1)).autoVersion(any(Node.class));
   }
   
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <org.exoplatform.platform-ui.version>6.4.x-maintenance-SNAPSHOT</org.exoplatform.platform-ui.version>
     <addon.exo.jcr.version>6.4.x-maintenance-SNAPSHOT</addon.exo.jcr.version>
     <addon.exo.analytics.version>1.3.x-maintenance-SNAPSHOT</addon.exo.analytics.version>
+    <org.exoplatform.ecms.version>6.4.x-maintenance-SNAPSHOT</org.exoplatform.ecms.version>
     <!-- Sonar properties -->
     <sonar.organization>exoplatform</sonar.organization>
   </properties>
@@ -67,7 +68,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
+      <dependency>
+        <groupId>org.exoplatform.ecms</groupId>
+        <artifactId>ecms-core-publication</artifactId>
+        <version>${org.exoplatform.ecms.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- Current project artifacts -->
       <dependency>
         <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
       </dependency>
       <dependency>
         <groupId>org.exoplatform.ecms</groupId>
-        <artifactId>ecms-core-publication</artifactId>
+        <artifactId>ecms</artifactId>
         <version>${org.exoplatform.ecms.version}</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
prior to this change, after duplicating a document, the history version drawer is empty since no version is added
after this change, an auto version is added after creating a document