### PR TITLE
fix : Document uploaded in wrong location - EXO-60910

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -54,7 +54,8 @@
     </div>
     <documents-visibility-drawer />
     <documents-move-drawer />
-    <documents-info-drawer />
+    <documents-info-drawer 
+    :selected-view="selectedView" />
     <v-alert
       v-model="alert"
       :type="alertType"
@@ -428,7 +429,7 @@ export default {
           // Quit preview mode
           self.previewMode = false;
           self.fileName = null;
-          window.history.pushState('', '', eXo.env.server.portalBaseURL);
+          window.history.pushState('', '', window.location.pathname);
         } else if (documentPreviewContainer && !self.previewMode) {
           // Enter preview mode
           self.previewMode = true;

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -271,7 +271,7 @@ export default {
           })
           .catch(e => console.error(e))
           .finally(() => {
-            window.history.pushState('', '', `${eXo.env.server.portalBaseURL}?documentPreviewId=${this.file.id}`);
+            window.history.pushState('', '', `${window.location.pathname}?documentPreviewId=${this.file.id}`);
             this.loading = false;
           });
       }


### PR DESCRIPTION
Before this change, after creating a document in a specific folder and opening it in the docs preview, the window path name takes the wrong path, so when creating a new document, its location depends on the window path name resulting a wrong location after upload.
After this change, when opening a document in the preview, the window path takes the correct folder location.
(cherry-picked from [PR](https://github.com/exoplatform/documents/commit/ebbf0973946db44c42ad9a2df64bbdce1226bbf2))