### PR TITLE
fix: fix No version in the history version drawer if a file is duplicated : EXO-61044

### DIFF
--- a/documents-storage-jcr/pom.xml
+++ b/documents-storage-jcr/pom.xml
@@ -57,7 +57,11 @@
       <groupId>org.exoplatform</groupId>
       <artifactId>exo-jcr-services</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.exoplatform.ecms</groupId>
+      <artifactId>ecms-core-services</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <!-- Test -->
     <dependency>
       <groupId>junit</groupId>

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -45,6 +45,7 @@ import org.exoplatform.documents.storage.jcr.search.DocumentSearchServiceConnect
 import org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil;
 import org.exoplatform.documents.storage.jcr.util.NodeTypeConstants;
 import org.exoplatform.documents.storage.jcr.util.Utils;
+import org.exoplatform.services.cms.documents.AutoVersionService;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.access.AccessControlEntry;
 import org.exoplatform.services.jcr.access.PermissionType;
@@ -692,12 +693,16 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         oldNode = getNodeByIdentifier(session, fileId);
       }
       Node parentNode = oldNode.getParent();
+      Node newNode = null;
 
       if (oldNode != null) {
-          duplicateItem(oldNode, parentNode, parentNode ,prefixClone);
+        newNode = duplicateItem(oldNode, parentNode, parentNode, prefixClone);
         parentNode.save();
       }
-
+      AutoVersionService autoVersionService = CommonsUtils.getService(AutoVersionService.class);
+      if (autoVersionService != null) {
+        autoVersionService.autoVersion(newNode);
+      }
       return toFileNode(identityManager, aclIdentity, parentNode, "", spaceService);
     } catch (Exception e) {
       throw new IllegalStateException("Error retrieving duplicate file'" + fileId, e);
@@ -751,9 +756,9 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
 
   }
 
-  private void duplicateItem(Node oldNode, Node destinationNode, Node parentNode, String prefixClone) throws Exception{
+  private Node duplicateItem(Node oldNode, Node destinationNode, Node parentNode, String prefixClone) throws Exception{
     if (oldNode.isNodeType(NodeTypeConstants.EXO_THUMBNAILS_FOLDER)){
-      return;
+      return null;
     }
     Node newNode = null;
     String name = oldNode.getName();
@@ -785,6 +790,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       newNode = destinationNode.addNode(name, oldNode.getPrimaryNodeType().getName());
       addProperties(oldNode,newNode,title);
     }
+    return newNode;
   }
   private void addProperties(Node oldNode, Node newNode, String title) throws RepositoryException {
     if (oldNode.isNodeType(NodeTypeConstants.MIX_VERSIONABLE) && !newNode.isNodeType(NodeTypeConstants.MIX_VERSIONABLE))

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -7,6 +7,7 @@ import org.exoplatform.documents.storage.jcr.search.DocumentSearchServiceConnect
 import org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil;
 import org.exoplatform.documents.storage.jcr.util.NodeTypeConstants;
 import org.exoplatform.documents.storage.jcr.util.Utils;
+import org.exoplatform.services.cms.documents.AutoVersionService;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.access.AccessControlList;
 import org.exoplatform.services.jcr.config.RepositoryEntry;
@@ -79,6 +80,9 @@ public class JCRDocumentFileStorageTest {
 
   @Mock
   private ActivityManager                activityManager;
+
+  @Mock
+  private AutoVersionService             autoVersionService;
 
   private JCRDocumentFileStorage         jcrDocumentFileStorage;
 
@@ -185,8 +189,10 @@ public class JCRDocumentFileStorageTest {
     when(currentNode.addNode("copy of test","nt:file")).thenReturn(currentNode);
     when(identity.getRemoteId()).thenReturn("username");
     when(JCRDocumentsUtil.getUserSessionProvider(repositoryService, userID)).thenReturn(sessionProvider);
+    when(CommonsUtils.getService(AutoVersionService.class)).thenReturn(autoVersionService);
     jcrDocumentFileStorage.duplicateDocument(1L,"1","copy of",userID);
     verify(sessionProvider, times(1)).close();
+    verify(autoVersionService, times(1)).autoVersion(any(Node.class));
   }
   
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <org.exoplatform.platform-ui.version>6.4.x-exo-SNAPSHOT</org.exoplatform.platform-ui.version>
     <addon.exo.jcr.version>6.4.x-SNAPSHOT</addon.exo.jcr.version>
     <addon.exo.analytics.version>1.3.x-exo-SNAPSHOT</addon.exo.analytics.version>
-
+    <addon.exo.ecms.version>6.4.x-SNAPSHOT</addon.exo.ecms.version>
     <!-- Sonar properties -->
     <sonar.organization>exoplatform</sonar.organization>
   </properties>
@@ -68,7 +68,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
+      <dependency>
+        <groupId>org.exoplatform.ecms</groupId>
+        <artifactId>ecms</artifactId>
+        <version>${addon.exo.ecms.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- Current project artifacts -->
       <dependency>
         <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
prior to this change, after duplicating a document, the history version drawer is empty since no version is added
after this change, an auto version is added after creating a document