### PR TITLE
fix: UI glitches in doc app when name is long - EXO-60814

### DIFF
--- a/documents-webapp/src/main/webapp/skin/less/documents.less
+++ b/documents-webapp/src/main/webapp/skin/less/documents.less
@@ -305,7 +305,7 @@
               }
               
               .document-title {
-                max-width: 438px;
+                max-width: 420px;
                 padding-top: 2px;
               }
 


### PR DESCRIPTION
Prior to this change, in the list of documents the document title is not displayed correctly after this change, the title is displayed correctly