### PR TITLE
fix: remove ecms dependency and rework the history version for duplicated file - EXO-61044

### DIFF
--- a/documents-storage-jcr/pom.xml
+++ b/documents-storage-jcr/pom.xml
@@ -57,11 +57,6 @@
       <groupId>org.exoplatform</groupId>
       <artifactId>exo-jcr-services</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.exoplatform.ecms</groupId>
-      <artifactId>ecms-core-services</artifactId>
-      <scope>provided</scope>
-    </dependency>
     <!-- Test -->
     <dependency>
       <groupId>junit</groupId>

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1368,17 +1368,17 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     // check if mixin mix:versionDisplayName is added then,
     // update max version after add new version (increment by 1)
     if (version != null && nodeVersioning.isNodeType(MIX_DISPLAY_VERSION_NAME)) {
-      int maxVersion = 0;
+      long maxVersion = 0;
       if (nodeVersioning.hasProperty(MAX_VERSION_PROPERTY)) {
         // Get old max version ID
-        maxVersion = (int) nodeVersioning.getProperty(MAX_VERSION_PROPERTY).getLong();
+        maxVersion = nodeVersioning.getProperty(MAX_VERSION_PROPERTY).getLong();
         // Update max version IX (maxVersion+1)
         nodeVersioning.setProperty(MAX_VERSION_PROPERTY, maxVersion + 1);
       }
       // add a new entry to store the display version for the new added version
       // (jcrID, maxVersion)
       String newRef = version.getName() + VERSION_SEPARATOR + maxVersion;
-      List<Value> newValues = new ArrayList<Value>();
+      List<Value> newValues = new ArrayList<>();
       Value[] values;
       if (nodeVersioning.hasProperty(LIST_VERSION_PROPERTY)) {
         values = nodeVersioning.getProperty(LIST_VERSION_PROPERTY).getValues();
@@ -1398,7 +1398,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
 
     VersionHistory versionHistory = nodeVersioning.getVersionHistory();
     String[] oldVersionLabels = versionHistory.getVersionLabels(versionHistory.getRootVersion());
-    if (oldVersionLabels != null) {
+    if (oldVersionLabels != null && version != null) {
       for (String oldVersionLabel : oldVersionLabels) {
         versionHistory.addVersionLabel(version.getName(), oldVersionLabel, true);
         nodeVersioning.save();
@@ -1414,14 +1414,14 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
    * @param nodeVersioning
    * @throws Exception
    */
-  private static void removeRedundant(Node nodeVersioning) throws Exception {
+  private static void removeRedundant(Node nodeVersioning) throws RepositoryException {
     VersionHistory versionHistory = nodeVersioning.getVersionHistory();
     String baseVersion = nodeVersioning.getBaseVersion().getName();
     String rootVersion = nodeVersioning.getVersionHistory().getRootVersion().getName();
     VersionIterator versions = versionHistory.getAllVersions();
     Date currentDate = new Date();
-    Map<String, String> lstVersions = new HashMap<String, String>();
-    List<String> lstVersionTime = new ArrayList<String>();
+    Map<String, String> lstVersions = new HashMap<>();
+    List<String> lstVersionTime = new ArrayList<>();
     while (versions.hasNext()) {
       Version version = versions.nextVersion();
       if (rootVersion.equals(version.getName()) || baseVersion.equals(version.getName()))

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -17,7 +17,6 @@
 package org.exoplatform.documents.storage.jcr;
 
 import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.*;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.*;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -30,7 +29,6 @@ import javax.jcr.*;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryResult;
 import javax.jcr.version.Version;
-import javax.jcr.version.VersionHistory;
 import javax.jcr.version.VersionIterator;
 
 import org.apache.commons.lang.math.NumberUtils;
@@ -110,37 +108,6 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
   private static final String                  ADD_TAG_DOCUMENT             = "add_tag_document";
 
   private static Map<Long, List<SymlinkNavigation>> symlinksNavHistory   = new HashMap<>();
-
-
-  public static final String WEB_CONTENT      = "exo:webContent";
-
-  public static  final String MIX_DISPLAY_VERSION_NAME = "mix:versionDisplayName";
-
-  public static  final String MAX_VERSION_PROPERTY = "exo:maxVersion";
-
-  public static  final String VERSION_SEPARATOR = ":";
-
-  public static  final String LIST_VERSION_PROPERTY = "exo:versionList";
-  private static int maxAllowVersion;
-  private static long maxLiveTime;
-  private static String maxAllowVersionProp   = "jcr.documents.versions.max";
-  private static String expirationTimeProp    = "jcr.documents.versions.expiration";
-  private static final int DOCUMENT_AUTO_DEFAULT_VERSION_MAX = 0;
-  private static final int DOCUMENT_AUTO_DEFAULT_VERSION_EXPIRED = 0;
-  static {
-    try {
-      maxAllowVersion = Integer.parseInt(System.getProperty(maxAllowVersionProp));
-      maxLiveTime = Integer.parseInt(System.getProperty(expirationTimeProp));
-      //ignore invalid input config
-      if(maxAllowVersion < 0) maxAllowVersion = DOCUMENT_AUTO_DEFAULT_VERSION_MAX;
-      if(maxLiveTime < 0) maxLiveTime = DOCUMENT_AUTO_DEFAULT_VERSION_EXPIRED;
-    }catch(NumberFormatException nex){
-      maxAllowVersion = DOCUMENT_AUTO_DEFAULT_VERSION_MAX;
-      maxLiveTime = DOCUMENT_AUTO_DEFAULT_VERSION_EXPIRED;
-    }
-    maxLiveTime = maxLiveTime * 24 * 60 * 60 * 1000;
-  }
-
 
   public JCRDocumentFileStorage(NodeHierarchyCreator nodeHierarchyCreator,
                                 RepositoryService repositoryService,

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -14,6 +14,7 @@ import org.exoplatform.services.jcr.core.ExtendedNode;
 import org.exoplatform.services.jcr.core.ManageableRepository;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
+import org.exoplatform.services.jcr.ext.utils.VersionHistoryUtils;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.jcr.impl.core.query.QueryImpl;
 import org.exoplatform.services.listener.ListenerService;
@@ -53,7 +54,7 @@ import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.*;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ Utils.class, SessionProvider.class, JCRDocumentsUtil.class, CommonsUtils.class })
+@PrepareForTest({ Utils.class, SessionProvider.class, JCRDocumentsUtil.class, CommonsUtils.class , VersionHistoryUtils.class })
 public class JCRDocumentFileStorageTest {
 
   @Mock
@@ -97,6 +98,7 @@ public class JCRDocumentFileStorageTest {
     PowerMockito.mockStatic(SessionProvider.class);
     PowerMockito.mockStatic(JCRDocumentsUtil.class);
     PowerMockito.mockStatic(CommonsUtils.class);
+    PowerMockito.mockStatic(VersionHistoryUtils.class);
   }
 
   @Test
@@ -188,6 +190,8 @@ public class JCRDocumentFileStorageTest {
     when(JCRDocumentsUtil.getUserSessionProvider(repositoryService, userID)).thenReturn(sessionProvider);
     jcrDocumentFileStorage.duplicateDocument(1L,"1","copy of",userID);
     verify(sessionProvider, times(1)).close();
+    PowerMockito.verifyStatic(VersionHistoryUtils.class, Mockito.times(1));
+    VersionHistoryUtils.createVersion(any(Node.class));
   }
   
   @Test

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -7,7 +7,6 @@ import org.exoplatform.documents.storage.jcr.search.DocumentSearchServiceConnect
 import org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil;
 import org.exoplatform.documents.storage.jcr.util.NodeTypeConstants;
 import org.exoplatform.documents.storage.jcr.util.Utils;
-import org.exoplatform.services.cms.documents.AutoVersionService;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.access.AccessControlList;
 import org.exoplatform.services.jcr.config.RepositoryEntry;
@@ -81,8 +80,6 @@ public class JCRDocumentFileStorageTest {
   @Mock
   private ActivityManager                activityManager;
 
-  @Mock
-  private AutoVersionService             autoVersionService;
 
   private JCRDocumentFileStorage         jcrDocumentFileStorage;
 
@@ -189,10 +186,8 @@ public class JCRDocumentFileStorageTest {
     when(currentNode.addNode("copy of test","nt:file")).thenReturn(currentNode);
     when(identity.getRemoteId()).thenReturn("username");
     when(JCRDocumentsUtil.getUserSessionProvider(repositoryService, userID)).thenReturn(sessionProvider);
-    when(CommonsUtils.getService(AutoVersionService.class)).thenReturn(autoVersionService);
     jcrDocumentFileStorage.duplicateDocument(1L,"1","copy of",userID);
     verify(sessionProvider, times(1)).close();
-    verify(autoVersionService, times(1)).autoVersion(any(Node.class));
   }
   
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@
     <org.exoplatform.platform-ui.version>6.4.x-maintenance-SNAPSHOT</org.exoplatform.platform-ui.version>
     <addon.exo.jcr.version>6.4.x-maintenance-SNAPSHOT</addon.exo.jcr.version>
     <addon.exo.analytics.version>1.3.x-maintenance-SNAPSHOT</addon.exo.analytics.version>
-    <addon.exo.ecms.version>6.4.x-maintenance-SNAPSHOT</addon.exo.ecms.version>
     <!-- Sonar properties -->
     <sonar.organization>exoplatform</sonar.organization>
   </properties>
@@ -65,13 +64,6 @@
         <groupId>org.exoplatform.platform-ui</groupId>
         <artifactId>platform-ui</artifactId>
         <version>${org.exoplatform.platform-ui.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.exoplatform.ecms</groupId>
-        <artifactId>ecms</artifactId>
-        <version>${addon.exo.ecms.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
prior to this change, after duplicating a document, the history version drawer is empty since no version is added
after this change, an auto version is added after duplicating a document