### PR TITLE
fix: UI glitches in doc app when name is long - EXO-60814  (#618) (#621)

### DIFF
--- a/documents-webapp/src/main/webapp/skin/less/documents.less
+++ b/documents-webapp/src/main/webapp/skin/less/documents.less
@@ -265,7 +265,7 @@
                 }
               }
               .document-title {
-                max-width: 438px;
+                max-width: 420px;
                 padding-top: 2px;
               }
 


### PR DESCRIPTION
Prior to this change, in the list of documents the document title is not displayed correctly after this change, the title is displayed correctly

(cherry picked from commit 3910b21adbe35450dc858cba8a90c72d5c1e7770) (cherry picked from commit b5173ad8da2034f73faabd75378ebfda3ecd604d)