### PR TITLE
fix: remove ecms dependency and rework the history version for duplicated file - EXO-61044 (#619)

### DIFF
--- a/documents-storage-jcr/pom.xml
+++ b/documents-storage-jcr/pom.xml
@@ -57,11 +57,6 @@
       <groupId>org.exoplatform</groupId>
       <artifactId>exo-jcr-services</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.exoplatform.ecms</groupId>
-      <artifactId>ecms-core-services</artifactId>
-      <scope>provided</scope>
-    </dependency>
     <!-- Test -->
     <dependency>
       <groupId>junit</groupId>

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -45,7 +45,6 @@ import org.exoplatform.documents.storage.jcr.search.DocumentSearchServiceConnect
 import org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil;
 import org.exoplatform.documents.storage.jcr.util.NodeTypeConstants;
 import org.exoplatform.documents.storage.jcr.util.Utils;
-import org.exoplatform.services.cms.documents.AutoVersionService;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.access.AccessControlEntry;
 import org.exoplatform.services.jcr.access.PermissionType;
@@ -53,6 +52,7 @@ import org.exoplatform.services.jcr.core.ExtendedNode;
 import org.exoplatform.services.jcr.core.ManageableRepository;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
+import org.exoplatform.services.jcr.ext.utils.VersionHistoryUtils;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.jcr.impl.core.query.QueryImpl;
 import org.exoplatform.services.jcr.util.Text;
@@ -108,8 +108,6 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
   private static final String                  ADD_TAG_DOCUMENT             = "add_tag_document";
 
   private static Map<Long, List<SymlinkNavigation>> symlinksNavHistory   = new HashMap<>();
-
-
 
   public JCRDocumentFileStorage(NodeHierarchyCreator nodeHierarchyCreator,
                                 RepositoryService repositoryService,
@@ -699,10 +697,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         newNode = duplicateItem(oldNode, parentNode, parentNode, prefixClone);
         parentNode.save();
       }
-      AutoVersionService autoVersionService = CommonsUtils.getService(AutoVersionService.class);
-      if (autoVersionService != null) {
-        autoVersionService.autoVersion(newNode);
-      }
+      VersionHistoryUtils.createVersion(newNode);
       return toFileNode(identityManager, aclIdentity, parentNode, "", spaceService);
     } catch (Exception e) {
       throw new IllegalStateException("Error retrieving duplicate file'" + fileId, e);

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -7,7 +7,6 @@ import org.exoplatform.documents.storage.jcr.search.DocumentSearchServiceConnect
 import org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil;
 import org.exoplatform.documents.storage.jcr.util.NodeTypeConstants;
 import org.exoplatform.documents.storage.jcr.util.Utils;
-import org.exoplatform.services.cms.documents.AutoVersionService;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.access.AccessControlList;
 import org.exoplatform.services.jcr.config.RepositoryEntry;
@@ -15,6 +14,7 @@ import org.exoplatform.services.jcr.core.ExtendedNode;
 import org.exoplatform.services.jcr.core.ManageableRepository;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
+import org.exoplatform.services.jcr.ext.utils.VersionHistoryUtils;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.jcr.impl.core.query.QueryImpl;
 import org.exoplatform.services.listener.ListenerService;
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.*;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ Utils.class, SessionProvider.class, JCRDocumentsUtil.class, CommonsUtils.class })
+@PrepareForTest({ Utils.class, SessionProvider.class, JCRDocumentsUtil.class, CommonsUtils.class , VersionHistoryUtils.class })
 public class JCRDocumentFileStorageTest {
 
   @Mock
@@ -81,8 +81,6 @@ public class JCRDocumentFileStorageTest {
   @Mock
   private ActivityManager                activityManager;
 
-  @Mock
-  private AutoVersionService             autoVersionService;
 
   private JCRDocumentFileStorage         jcrDocumentFileStorage;
 
@@ -100,6 +98,7 @@ public class JCRDocumentFileStorageTest {
     PowerMockito.mockStatic(SessionProvider.class);
     PowerMockito.mockStatic(JCRDocumentsUtil.class);
     PowerMockito.mockStatic(CommonsUtils.class);
+    PowerMockito.mockStatic(VersionHistoryUtils.class);
   }
 
   @Test
@@ -189,10 +188,10 @@ public class JCRDocumentFileStorageTest {
     when(currentNode.addNode("copy of test","nt:file")).thenReturn(currentNode);
     when(identity.getRemoteId()).thenReturn("username");
     when(JCRDocumentsUtil.getUserSessionProvider(repositoryService, userID)).thenReturn(sessionProvider);
-    when(CommonsUtils.getService(AutoVersionService.class)).thenReturn(autoVersionService);
     jcrDocumentFileStorage.duplicateDocument(1L,"1","copy of",userID);
     verify(sessionProvider, times(1)).close();
-    verify(autoVersionService, times(1)).autoVersion(any(Node.class));
+    PowerMockito.verifyStatic(VersionHistoryUtils.class, Mockito.times(1));
+    VersionHistoryUtils.createVersion(any(Node.class));
   }
   
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@
     <org.exoplatform.platform-ui.version>6.4.x-exo-SNAPSHOT</org.exoplatform.platform-ui.version>
     <addon.exo.jcr.version>6.4.x-SNAPSHOT</addon.exo.jcr.version>
     <addon.exo.analytics.version>1.3.x-exo-SNAPSHOT</addon.exo.analytics.version>
-    <addon.exo.ecms.version>6.4.x-SNAPSHOT</addon.exo.ecms.version>
     <!-- Sonar properties -->
     <sonar.organization>exoplatform</sonar.organization>
   </properties>
@@ -65,13 +64,6 @@
         <groupId>org.exoplatform.platform-ui</groupId>
         <artifactId>platform-ui</artifactId>
         <version>${org.exoplatform.platform-ui.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.exoplatform.ecms</groupId>
-        <artifactId>ecms</artifactId>
-        <version>${addon.exo.ecms.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
prior to this change, after duplicating a document, the history version drawer is empty since no version is added after this change, an auto version is added after duplicating a document