### PR TITLE
fix: Miss selected mode in drawer tree folder - EXO-55417

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -89,6 +89,7 @@ export default {
   }),
   computed: {
     documentsBreadcrumbToDisplay() {
+      this.$root.$emit('documentsBreadcrumb',this.documentsBreadcrumb);
       if (!this.documentsBreadcrumb || this.documentsBreadcrumb.length <= 4) {
         return this.documentsBreadcrumb || [];
       } else {
@@ -133,6 +134,7 @@ export default {
       }
     },
     openTreeFolderDrawer(){
+      this.$root.$emit('documentsBreadcrumb',this.documentsBreadcrumb);
       this.$root.$emit('openTreeFolderDrawer');
     },
     getName(name){

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/FolderTreeViewDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/FolderTreeViewDrawer.vue
@@ -12,7 +12,7 @@
         :open.sync="openLevel"
         :items="items"
         class="treeView-item my-2"
-        item-key="name"
+        item-key="id"
         hoverable
         activatable
         open-on-click
@@ -22,7 +22,9 @@
             <v-icon size="24" class="primary--text">
               {{ 'fas fa-folder' }}
             </v-icon>
-            <v-list-item-title class="body-2 mx-2 mt-1">
+            <v-list-item-title 
+              class="body-2 mx-2 mt-1"
+              :class="idItemActive === item.id ? 'primary--text font-weight-bold' : ''">
               {{ item.name }}
             </v-list-item-title>
           </div>
@@ -37,11 +39,22 @@ export default {
   data: () => ({
     ownerId: eXo.env.portal.spaceIdentityId || eXo.env.portal.userIdentityId,
     items: [],
+    currentFolderPathTab: [],
   }),
   computed: {
     openLevel() {
-      return this.items && this.items.length && [this.items[0].name] || [];
+      return this.items && this.items.length ? this.currentFolderPathTab : [];
     },
+    idItemActive() {
+      return this.currentFolderPathTab && this.currentFolderPathTab.length ? this.currentFolderPathTab[this.currentFolderPathTab.length-1] : [];
+    }
+  },
+  created() {
+    this.$root.$on('documentsBreadcrumb',documentsBreadcrumb => {
+      const tab = [];
+      documentsBreadcrumb.forEach(element => tab.push(element.id));
+      this.currentFolderPathTab = tab;
+    });
   },
   methods: {
     open() {


### PR DESCRIPTION
Prior to this change, When open drawer tree folder , the folder tree is not displayed correctly. After this change, the activated or selected folder is open with its title in bold and colored in blue.