### PR TITLE
fix: Align symlink icon and folder name in the breadcrumb - EXO-60263

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -35,7 +35,7 @@
                 <v-icon 
                   v-if="documents.symlink"
                   size="10"
-                  class="pe-1 iconStyle pb-1">
+                  class="pe-1 iconStyle">
                   mdi-link-variant
                 </v-icon>
             </v-btn>
@@ -45,7 +45,7 @@
                   <v-icon 
                   v-if="documents.symlink"
                   size="10"
-                  class="pe-1 iconStyle pb-1">
+                  class="pe-1 iconStyle">
                   mdi-link-variant
                 </v-icon>
           </span>


### PR DESCRIPTION
Prior to this change,  In the breadcrumb when we are in a shortcut folder, we have a symlink icon close to the folder name is not aligned with the center of the name. After this change, The icon is aligned with the center of the name.