### PR TITLE
fix: wrong space document after creating a document shortcut - EXO-61289 (#632)

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -624,7 +624,12 @@ export default {
       this.$documentFileService.createShortcut(file.id,destPath)
         .then(() => {
           this.createShortcutStatistics(file,space);
-          this.openFolder(destFolder);
+          if (space && space.groupId) {
+            const folderPath = destFolder.path.includes('/Documents/') ? destFolder.path.split('/Documents/')[1] : '';
+            window.location.href = `${window.location.pathname.split(':spaces')[0] + space.groupId.replaceAll('/', ':')}/${space.prettyName}/documents/${folderPath}`;
+          } else {
+            this.openFolder(destFolder);
+          }
         })
         .catch(e => console.error(e))
         .finally(() => this.loading = false);


### PR DESCRIPTION
prior to this change, after creating a shortcut for another space the shortcut is successfully created under the folder, but the current space is displayed instead of the space where I have created the shortcut. After this change, redirection for the chosen space after creating a shortcut and the specific shortcut is opened.