### PR TITLE
fix: Folder view : prioritize the sort of folders over files - EXO-60880

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
@@ -189,7 +189,7 @@ public interface DocumentFileService {
 
   void notifyMember(String documentId, long destId) throws IllegalAccessException;
 
-  void createFolder(long ownerId,String folderId, String folderPath, String name, long authenticatedUserId) throws IllegalAccessException, ObjectAlreadyExistsException, ObjectNotFoundException;
+  AbstractNode createFolder(long ownerId,String folderId, String folderPath, String name, long authenticatedUserId) throws IllegalAccessException, ObjectAlreadyExistsException, ObjectNotFoundException;
 
   String getNewName(long ownerId, String folderId, String folderPath, String name) throws IllegalAccessException, ObjectAlreadyExistsException, ObjectNotFoundException;
 

--- a/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
@@ -123,7 +123,7 @@ public interface DocumentFileStorage {
    */
   void moveDocument(long ownerId, String fileId, String destPath, Identity aclIdentity) throws IllegalAccessException, ObjectNotFoundException;
 
-  void createFolder(long ownerId, String folderId, String folderPath, String title, Identity aclIdentity) throws IllegalAccessException,  ObjectAlreadyExistsException,
+  AbstractNode createFolder(long ownerId, String folderId, String folderPath, String title, Identity aclIdentity) throws IllegalAccessException,  ObjectAlreadyExistsException,
                                                                                ObjectNotFoundException;
 
   String getNewName(long ownerId,

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
@@ -378,6 +378,7 @@ public class DocumentFileRest implements ResourceContainer {
 
   @POST
   @Path("/folder")
+  @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed("users")
   @Operation(summary = "Add a new Folder", method = "POST", description = "This adds a new Folder under givin Folder.")
   @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Request fulfilled"),
@@ -397,8 +398,15 @@ public class DocumentFileRest implements ResourceContainer {
     }
     try {
       long userIdentityId = RestUtils.getCurrentUserIdentityId(identityManager);
-        documentFileService.createFolder(ownerId, parentid, folderPath, name, userIdentityId);
-        return Response.ok().build();
+      AbstractNode createdFolder = documentFileService.createFolder(ownerId, parentid, folderPath, name, userIdentityId);
+      AbstractNodeEntity abstractNodeEntity = EntityBuilder.toDocumentItemEntity(documentFileService,
+              identityManager,
+              spaceService,
+              metadataService,
+              createdFolder,
+              null,
+              userIdentityId);
+      return Response.ok(abstractNodeEntity).build();
       } catch (Exception ex) {
         LOG.warn("Failed to create Folder", ex);
         return Response.status(HTTPStatus.INTERNAL_ERROR).build();

--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -229,8 +229,8 @@ public class DocumentFileServiceImpl implements DocumentFileService {
   }
 
   @Override
-  public void createFolder(long ownerId, String folderId, String folderPath, String name, long authenticatedUserId) throws IllegalAccessException, ObjectAlreadyExistsException, ObjectNotFoundException {
-    documentFileStorage.createFolder(ownerId, folderId, folderPath, name, getAclUserIdentity(authenticatedUserId));
+  public AbstractNode createFolder(long ownerId, String folderId, String folderPath, String name, long authenticatedUserId) throws IllegalAccessException, ObjectAlreadyExistsException, ObjectNotFoundException {
+   return documentFileStorage.createFolder(ownerId, folderId, folderPath, name, getAclUserIdentity(authenticatedUserId));
   }
 
   @Override

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
@@ -710,10 +710,11 @@ public class DocumentFileRestTest {
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     assertEquals("Folder Name should not be empty", response.getEntity());
 
-    doNothing().when(documentFileStorage).createFolder(2L, "11111111", null, "222", userID);
+    AbstractNode folder = new FolderNode();
+    when(documentFileStorage.createFolder(2L, "11111111", null, "222", userID)).thenReturn(folder);
     response = documentFileRest.createFolder("11111111",null,2L,"222");
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    doNothing().when(documentFileStorage).createFolder(2L, "11111111", null, "test", userID);
+    when(documentFileStorage.createFolder(2L, "11111111", null, "test", userID)).thenReturn(folder);
     response = documentFileRest.createFolder("11111111",null,2L,"test");
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -515,7 +515,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     }).collect(Collectors.toList());
   }
   @Override
-  public void createFolder(long ownerId,
+  public AbstractNode createFolder(long ownerId,
                            String folderId,
                            String folderPath,
                            String title,
@@ -553,6 +553,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         addedNode.addMixin("mix:referenceable");
       }
       node.save();
+      return toFolderNode(identityManager, aclIdentity, addedNode, "", spaceService);
     } catch (Exception e) {
       throw new IllegalStateException("Error retrieving folder'" + folderId + "' breadcrumb", e);
     } finally {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -601,7 +601,10 @@ export default {
     createFolder(name){
       const ownerId = eXo.env.portal.spaceIdentityId || eXo.env.portal.userIdentityId;
       this.$documentFileService.createFolder(ownerId,this.parentFolderId,this.folderPath,name)
-        .then(() => this.refreshFiles())
+        .then(createdFolder => {
+          this.files.shift();
+          this.files.unshift(createdFolder);
+        })
         .catch(e => console.error(e))
         .finally(() => this.loading = false);
     },

--- a/documents-webapp/src/main/webapp/vue-app/documents/js/DocumentFileService.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/js/DocumentFileService.js
@@ -210,7 +210,7 @@ export function createFolder(ownerId,parentid,folderPath,name) {
     method: 'POST',
   }).then((resp) => {
     if (resp && resp.ok) {
-      return resp.ok;
+      return resp.json();
     }
   }).catch(e => {
     throw new Error(`Error creating folder ${e}`);


### PR DESCRIPTION
prior to this change, Folders and files are alphabetically sorted when creating a new folder whose name starts with any character following the last character where the folders/files are sorted, the newly added folder is not displayed at the first interface because when adding a new folder the files list is refreshed and it does not belong  to the first 50 sorted displayed files
after this change, the added folder is added automatically to the displayed list without refreshing the list