### PR TITLE
fix: Fix exception when tring to get file description - EXO-61496 

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -220,20 +220,14 @@ public class EntityBuilder {
         ((FolderNodeEntity)nodeEntity).setPath(((FolderNode)node).getPath());
       }
 
-      if (expandProperties.contains("creator")) {
-        if(node.getCreatorId() > 0) {
-          nodeEntity.setCreatorIdentity(toIdentityEntity(identityManager, spaceService, node.getCreatorId()));
-        }
+      if (expandProperties.contains("creator") && node.getCreatorId() > 0) {
+        nodeEntity.setCreatorIdentity(toIdentityEntity(identityManager, spaceService, node.getCreatorId()));
       }
-      if (expandProperties.contains("modifier")) {
-        if(node.getModifierId() > 0) {
-          nodeEntity.setModifierIdentity(toIdentityEntity(identityManager, spaceService, node.getModifierId()));
-        }
+      if (expandProperties.contains("modifier") && node.getModifierId() > 0) {
+        nodeEntity.setModifierIdentity(toIdentityEntity(identityManager, spaceService, node.getModifierId()));
       }
-      if (expandProperties.contains("owner")) {
-        if(node.getOwnerId() > 0) {
-          nodeEntity.setOwnerIdentity(toIdentityEntity(identityManager, spaceService, node.getOwnerId()));
-        }
+      if (expandProperties.contains("owner") && node.getOwnerId() > 0) {
+        nodeEntity.setOwnerIdentity(toIdentityEntity(identityManager, spaceService, node.getOwnerId()));
       }
       if (expandProperties.contains("auditTrails")) {
         // TODO (documentFileService.getNodeAuditTrails) think of using limit of

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -221,13 +221,19 @@ public class EntityBuilder {
       }
 
       if (expandProperties.contains("creator")) {
-        nodeEntity.setCreatorIdentity(toIdentityEntity(identityManager, spaceService, node.getCreatorId()));
+        if(node.getCreatorId() > 0) {
+          nodeEntity.setCreatorIdentity(toIdentityEntity(identityManager, spaceService, node.getCreatorId()));
+        }
       }
       if (expandProperties.contains("modifier")) {
-        nodeEntity.setModifierIdentity(toIdentityEntity(identityManager, spaceService, node.getModifierId()));
+        if(node.getModifierId() > 0) {
+          nodeEntity.setModifierIdentity(toIdentityEntity(identityManager, spaceService, node.getModifierId()));
+        }
       }
       if (expandProperties.contains("owner")) {
-        nodeEntity.setOwnerIdentity(toIdentityEntity(identityManager, spaceService, node.getOwnerId()));
+        if(node.getOwnerId() > 0) {
+          nodeEntity.setOwnerIdentity(toIdentityEntity(identityManager, spaceService, node.getOwnerId()));
+        }
       }
       if (expandProperties.contains("auditTrails")) {
         // TODO (documentFileService.getNodeAuditTrails) think of using limit of

--- a/documents-storage-jcr/pom.xml
+++ b/documents-storage-jcr/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>documents-storage-jcr</artifactId>
   <name>eXo Documents - Storage JCR Implementation</name>
   <properties>
-    <exo.test.coverage.ratio>0.12</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.28</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -308,23 +308,18 @@ public class JCRDocumentsUtil {
       //Do noting, it means that the current user don't have access to the parent node
     }
 
-    if (node.isNodeType(NodeTypeConstants.MIX_VERSIONABLE)) {
-      documentNode.setVersionable(true);
-      Version version = node.getBaseVersion();
-      if (version != null && StringUtils.isNumeric(version.getName())) {
-        documentNode.setVersionNumber(version.getName());
+    Node versionNode = node;
+    if (node.isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
+      Node sourceNode = getNodeByIdentifier(node.getSession(), documentNode.getSourceID());
+      if (sourceNode != null) {
+        versionNode = sourceNode;
       }
     }
-    if (node.isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
-      Node sourceNode;
-      sourceNode = getNodeByIdentifier(node.getSession(), documentNode.getSourceID());
-      if (sourceNode != null && sourceNode.isNodeType(NodeTypeConstants.MIX_VERSIONABLE)
-              && sourceNode.getBaseVersion() != null) {
-        documentNode.setVersionable(true);
-        Version version = sourceNode.getBaseVersion();
-        if (StringUtils.isNumeric(version.getName())) {
-          documentNode.setVersionNumber(version.getName());
-        }
+    if (versionNode.isNodeType(NodeTypeConstants.MIX_VERSIONABLE) && versionNode.getBaseVersion() != null) {
+      documentNode.setVersionable(true);
+      Version version = versionNode.getBaseVersion();
+      if (StringUtils.isNumeric(version.getName())) {
+        documentNode.setVersionNumber(version.getName());
       }
     }
 

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -370,7 +370,10 @@ public class JCRDocumentsUtil {
       try {
         documentNode.setDescription(node.getProperty(NodeTypeConstants.DC_DESCRIPTION).getString());
       } catch (ValueFormatException e) {
-        documentNode.setDescription(node.getProperty(NodeTypeConstants.DC_DESCRIPTION).getValues()[0].getString());
+        Value[] descriptionValues = node.getProperty(NodeTypeConstants.DC_DESCRIPTION).getValues();
+        if(descriptionValues != null && descriptionValues.length > 0) {
+          documentNode.setDescription(descriptionValues[0].getString());
+        }
       }
     }
     if (node.isNodeType(NodeTypeConstants.DC_DESCRIPTION)) {

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2022 eXo Platform SAS.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see<http://www.gnu.org/licenses/>.
+ */
 package org.exoplatform.documents.storage.jcr.util;
 
 import org.exoplatform.documents.model.AbstractNode;

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -27,8 +27,10 @@ import org.exoplatform.social.core.space.spi.SpaceService;
 import org.junit.Test;
 
 import javax.jcr.*;
+import javax.jcr.version.Version;
 
 import java.io.IOException;
+import java.util.Calendar;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -51,6 +53,21 @@ public class JCRDocumentsUtilTest {
     when(node.getName()).thenReturn("NodeName.pdf");
     Property property = mock(Property.class);
     when(((ExtendedNode) node).getACL()).thenReturn(new AccessControlList());
+    when(node.isNodeType(NodeTypeConstants.MIX_VERSIONABLE)).thenReturn(true);
+    Version baseVersion = mock(Version.class);
+    when(baseVersion.getName()).thenReturn("1");
+    when(node.getBaseVersion()).thenReturn(baseVersion);
+    when(node.hasProperty(NodeTypeConstants.EXO_DATE_CREATED)).thenReturn(true);
+    when(node.hasProperty(NodeTypeConstants.EXO_DATE_MODIFIED)).thenReturn(true);
+    Property createdDateProperty = mock(Property.class);
+    when(createdDateProperty.getDate()).thenReturn(Calendar.getInstance());
+    Property modifiedDateProperty = mock(Property.class);
+    when(modifiedDateProperty.getDate()).thenReturn(Calendar.getInstance());
+    when(node.getProperty(NodeTypeConstants.EXO_DATE_CREATED)).thenReturn(createdDateProperty);
+    when(node.getProperty(NodeTypeConstants.EXO_DATE_MODIFIED)).thenReturn(modifiedDateProperty);
+    Property lasdtModifierProperty = mock(Property.class);
+    when(lasdtModifierProperty.getString()).thenReturn("root");
+    when(node.getProperty(NodeTypeConstants.EXO_LAST_MODIFIER)).thenReturn(lasdtModifierProperty);
 
     when(aclIdentity.getUserId()).thenReturn("root");
 

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -1,0 +1,70 @@
+package org.exoplatform.documents.storage.jcr.util;
+
+import org.exoplatform.documents.model.AbstractNode;
+import org.exoplatform.services.jcr.access.AccessControlList;
+import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.jcr.impl.core.NodeImpl;
+import org.exoplatform.services.jcr.impl.core.value.StringValue;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.space.spi.SpaceService;
+import org.junit.Test;
+
+import javax.jcr.*;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class JCRDocumentsUtilTest {
+
+  @Test
+  public void testRetrieveFileProperties() throws IOException, RepositoryException {
+    IdentityManager identityManager = mock(IdentityManager.class);
+    NodeImpl node = mock(NodeImpl.class);
+    Identity aclIdentity = mock(Identity.class);
+    AbstractNode documentNode = mock(AbstractNode.class);
+    SpaceService spaceService = mock(SpaceService.class);
+
+    // Build node properties
+    NodeImpl parentNode = mock(NodeImpl.class);
+    when(((NodeImpl) parentNode).getIdentifier()).thenReturn("identifierOfParentNode");
+    when(node.getParent()).thenReturn(parentNode);
+    when(node.getName()).thenReturn("NodeName.pdf");
+    Property property = mock(Property.class);
+    when(((ExtendedNode) node).getACL()).thenReturn(new AccessControlList());
+
+    when(aclIdentity.getUserId()).thenReturn("root");
+
+    // When
+    when(node.getProperty(NodeTypeConstants.DC_DESCRIPTION)).thenReturn(property);
+    when(node.hasProperty(NodeTypeConstants.DC_DESCRIPTION)).thenReturn(true);
+    when(node.getProperty(NodeTypeConstants.DC_DESCRIPTION).getString()).thenThrow(new ValueFormatException());
+    // Then
+    try {
+      JCRDocumentsUtil.retrieveFileProperties(identityManager, node, aclIdentity, documentNode, spaceService);
+    } catch (Exception e) {
+      // Exception should be catched
+      fail();
+    }
+
+    // When
+    when(node.getProperty(NodeTypeConstants.DC_DESCRIPTION).getValues()).thenReturn(new Value[0]);
+    // Then
+    JCRDocumentsUtil.retrieveFileProperties(identityManager, node, aclIdentity, documentNode, spaceService);
+    verify(documentNode, times(0)).setDescription(anyString());
+
+    // When
+    when(node.getProperty(NodeTypeConstants.DC_DESCRIPTION).getValues()).thenReturn(new Value[1]);
+    Value[] descriptionValues = new Value[]{new StringValue("File description !")};
+    when(node.getProperty(NodeTypeConstants.DC_DESCRIPTION).getValues()).thenReturn(descriptionValues);
+
+
+    JCRDocumentsUtil.retrieveFileProperties(identityManager, node, aclIdentity, documentNode, spaceService);
+    // Then
+    verify(documentNode, times(1)).setDescription(anyString());
+
+  }
+}


### PR DESCRIPTION
Priori to this fix, when the description is empty, an exception is thrown and the document properties are not retrieved, thus we can no more open Action menu nor display the file icon.
The fix added a check for the content of the description before trying to read its content, and added Unit test for the JCRDocumentsUtil