### PR TITLE
fix: new folder not translated to PLF language - EXO-59410 (#682)

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -629,7 +629,8 @@ export default {
     },
     addFolder(){
       const ownerId = eXo.env.portal.spaceIdentityId || eXo.env.portal.userIdentityId;
-      this.$documentFileService.getNewName(ownerId,this.parentFolderId,this.folderPath,'new folder') 
+      const i18nName = this.$t('Folder.label.newfolder');
+      this.$documentFileService.getNewName(ownerId, this.parentFolderId, this.folderPath, i18nName)
         .then( newName => {
           const newFolder = {
             'id': -1,


### PR DESCRIPTION
prior to this change, to create a new folder the suggested one is not translated to the PLF language since it is statically added to the new name "new folder". after this change, the new name is added with i18n new folder label