### PR TITLE
fix: Shortcut not created without alert if document with same name an…

### DIFF
--- a/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
+++ b/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
@@ -145,3 +145,6 @@ documents.restore.version.success=Version successfully restored
 document.summary.add.empty.error=Add a summary version before validating it
 documents.message.extendedSearch=Extend your search to the contents of the documents and their description
 document.valid.name.error.message=These chars are not allowed <>:"/|?*
+
+document.shortcut.creationError=Error while creating shortcut
+document.shortcut.creationSuccess=Shortcut successfully created

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -670,6 +670,7 @@ export default {
     createShortcut(file,destPath, destFolder,space) {
       this.$documentFileService.createShortcut(file.id,destPath)
         .then(() => {
+          this.$root.$emit('show-alert', {type: 'success', message: this.$t('document.shortcut.creationSuccess')});
           this.createShortcutStatistics(file,space);
           if (space && space.groupId) {
             const folderPath = destFolder.path.includes('/Documents/') ? destFolder.path.split('/Documents/')[1] : '';
@@ -678,7 +679,9 @@ export default {
             this.openFolder(destFolder);
           }
         })
-        .catch(e => console.error(e))
+        .catch(() => {
+          this.$root.$emit('show-alert', {type: 'error', message: this.$t('document.shortcut.creationError')});
+        })
         .finally(() => this.loading = false);
     },
     createShortcutStatistics(file,space) {

--- a/documents-webapp/src/main/webapp/vue-app/documents/js/DocumentFileService.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/js/DocumentFileService.js
@@ -324,9 +324,9 @@ export function createShortcut(documentID,destPath) {
   }).then((resp) => {
     if (resp && resp.ok) {
       return resp.ok;
+    } else  {
+      throw new Error('Error creating document shortcut');
     }
-  }).catch(e => {
-    throw new Error(`Error renaming document ${e}`);
   });
 }
 


### PR DESCRIPTION
…d analytics is incremented - EXO-61437 (#681)

prior to this change, when creating a shortcut for a document with the same name, no alert is displayed and analytics for the shortcut creation is incremented. after this change, an alert is displayed for both cases error and fail, and the analytics is only incremented in the success case