### PR TITLE
fix: duplicated documents in timeline view - EXO-61741

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -148,9 +148,6 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
 
       Session session = identityRootNode.getSession();
       String rootPath = identityRootNode.getPath();
-      if (ownerIdentity.isUser()) {
-        rootPath = rootPath.split("/" + USER_PRIVATE_ROOT_NODE)[0];
-      }
       if (StringUtils.isBlank(filter.getQuery()) && BooleanUtils.isNotTrue(filter.getFavorites())) {
         String sortField = getSortField(filter, true);
         String sortDirection = getSortDirection(filter);


### PR DESCRIPTION
Prior to this fix, documents added inside the public folder of user drive are displayed twice in the timeline view because a symlink of the Public folder exists in the Private folder, and that the search is using theb root folder of the user instead of just Private folder.
The fix removes an added code that changes the path from the Private folder to the root folder causing files duplication