### PR TITLE
fix: fix warning when create a new folder - EXO-61872

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ build
 npm-debug.log
 node_modules
 /bin/
+
+# Vs code
+.vscode/

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -421,8 +421,8 @@ export default {
       }
     },
     openFolder(parentFolder) {
-      this.folderPath='';
-      this.fileName=null;
+      this.folderPath = '';
+      this.fileName = null;
       this.parentFolderId = parentFolder.id;
       let symlinkId = null;
       if (parentFolder.sourceID){
@@ -450,7 +450,7 @@ export default {
         const userPublicPathPrefix = `${userName}/Public`;
         if (parentFolder.path.includes(userPrivatePathPrefix)){
           const pathParts = parentFolder.path.split(userPrivatePathPrefix);
-          if (pathParts.length>1){
+          if (pathParts.length > 1){
             folderPath = pathParts[1];
           }
           

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
@@ -28,6 +28,12 @@ export default {
   }),
   computed: {
     icon() {
+      if (this.file.folder && this.file.id < 0) {
+        return {
+          icon: 'fas fa-layer-group',
+          title: this.$t('documents.label.visibility.all'),
+        };
+      }
       switch (this.file.acl.visibilityChoice) {
       case 'SPECIFIC_COLLABORATOR':
         return {


### PR DESCRIPTION
In the process of creating a new folder, its visibilityChoice is not yet defined, thus an error is thrown when trying to check its value to decide which icon to display.
The fix checks for nullity of the property visibilityChoice and returns the default visibility choice value