### PR TITLE
Fix: Two generated file updated analytics entries after restoring a version - EXO-61297

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -313,7 +313,6 @@ export default {
           this.$root.$emit('version-restored', newVersion);
           this.refreshVersions(this.versionableFile, newVersion);
           this.refreshFiles();
-          this.addRestoreVersionStatistics(this.versionableFile);
         }
       }).catch(() => {
         this.$root.$emit('show-alert', {type: 'error', message: this.$t('documents.restore.version.error')});
@@ -367,25 +366,6 @@ export default {
         this.isLoadingVersions = false;
       });
       this.addVersionHistoryStatistics();
-    },
-    addRestoreVersionStatistics(file) {
-      document.dispatchEvent(new CustomEvent('exo-statistic-message', {
-        detail: {
-          module: 'Drive',
-          subModule: 'Documents',
-          userId: eXo.env.portal.userIdentityId,
-          userName: eXo.env.portal.userName,
-          operation: 'fileUpdated',
-          parameters: {
-            fileSize: file.size,
-            documentType: 'nt:file',
-            fileMimeType: file.mimeType,
-            documentName: file.name,
-            uuid: file.id
-          },
-          timestamp: Date.now()
-        }
-      }));
     },
     addVersionHistoryStatistics() {
       document.dispatchEvent(new CustomEvent('exo-statistic-message', {


### PR DESCRIPTION
Prior to this change, after the last change which allow to update exo last updated date of a node after restoring a version, a generic file_updated analytics entry was added + the already existing one in doc app has leaded to a two generated entries of file_upadted analytics, This PR removes the added one in doc app as a listener will be launched and add the file_updated operation on any node which its exo last updated date was modified.