### PR TITLE
fix: display correctly files/folders containing % in their names - EXO-59750

### DIFF
--- a/documents-services/pom.xml
+++ b/documents-services/pom.xml
@@ -159,6 +159,12 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <systemProperties>
+            <property>
+              <name>exo.files.storage.dir</name>
+              <value>target/exo-files</value>
+            </property>
+          </systemProperties>
           <argLine>@{argLine} --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</argLine>
         </configuration>
       </plugin>

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -204,15 +204,7 @@ public class EntityBuilder {
     try {
       nodeEntity.setId(node.getId());
       nodeEntity.setPath(node.getPath());
-      String nodeName = node.getName();
-      if(StringUtils.isNotBlank(nodeName)) {
-        try {
-          nodeName = URLDecoder.decode(node.getName(), StandardCharsets.UTF_8);
-        } catch (IllegalArgumentException iae) {
-          // nothing to do
-        }
-        nodeEntity.setName(nodeName);
-      }
+      nodeEntity.setName(encodeName(node));
       nodeEntity.setDatasource(node.getDatasource());
       nodeEntity.setDescription(node.getDescription());
       nodeEntity.setAcl(toNodePermissionEntity(node,identityManager, spaceService));
@@ -263,6 +255,23 @@ public class EntityBuilder {
     } catch (Exception e) {
       LOG.error("==== exception occured when converting node with ID = {} and name = {}", node.getId(), node.getName(), e);
     }
+  }
+
+  /**
+   * Decode node name if it is already encoded
+   * @param node its name
+   * @return decoded node name
+   */
+  private static String encodeName(AbstractNode node) {
+    String nodeName = node.getName();
+    if(StringUtils.isNotBlank(nodeName)) {
+      try {
+        nodeName = URLDecoder.decode(node.getName(), StandardCharsets.UTF_8);
+      } catch (IllegalArgumentException iae) {
+        // nothing to do
+      }
+    }
+    return nodeName;
   }
 
   private static NodePermissionEntity toNodePermissionEntity(AbstractNode node, IdentityManager identityManager, SpaceService spaceService){

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -204,7 +204,15 @@ public class EntityBuilder {
     try {
       nodeEntity.setId(node.getId());
       nodeEntity.setPath(node.getPath());
-      nodeEntity.setName(node.getName() != null ? URLDecoder.decode(node.getName(), StandardCharsets.UTF_8) : null);
+      String nodeName = node.getName();
+      if(StringUtils.isNotBlank(nodeName)) {
+        try {
+          nodeName = URLDecoder.decode(node.getName(), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException iae) {
+          // nothing to do
+        }
+        nodeEntity.setName(nodeName);
+      }
       nodeEntity.setDatasource(node.getDatasource());
       nodeEntity.setDescription(node.getDescription());
       nodeEntity.setAcl(toNodePermissionEntity(node,identityManager, spaceService));

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -17,6 +17,7 @@
 package org.exoplatform.documents.storage.jcr;
 
 import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.*;
+import static org.gatein.common.net.URLTools.SLASH;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -542,7 +543,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       }
       if (StringUtils.isNotBlank(folderPath)) {
         try {
-          node = node.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8.name()));
+          node = node.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8).replace("%", "%25"));
         } catch (RepositoryException repositoryException) {
           throw new ObjectNotFoundException("Folder with path : " + folderPath + " isn't found");
         }
@@ -590,7 +591,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       }
       if(StringUtils.isNotBlank(folderPath)){
         try {
-          node = node.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8.name()));
+          node = node.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8).replace("%", "%25"));
         } catch (RepositoryException repositoryException) {
           throw new ObjectNotFoundException("Folder with path : " + folderPath + " isn't found");
         }
@@ -976,15 +977,15 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     try {
       if ((node.getName().equals(USER_PRIVATE_ROOT_NODE))) {
         if (folderPath.startsWith(USER_PRIVATE_ROOT_NODE)) {
-          folderPath = folderPath.split(USER_PRIVATE_ROOT_NODE + "/")[1];
-          return (node.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8.name())));
+          folderPath = folderPath.split(USER_PRIVATE_ROOT_NODE + SLASH)[1];
+          return (node.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8).replace("%", "%25")));
         }
         if (folderPath.startsWith(USER_PUBLIC_ROOT_NODE)) {
           SessionProvider systemSessionProvides = SessionProvider.createSystemProvider();
           Session systemSession = systemSessionProvides.getSession(sessionProvider.getCurrentWorkspace(),
                                                                    sessionProvider.getCurrentRepository());
           Node parent = getNodeByIdentifier(systemSession, ((NodeImpl) node).getIdentifier()).getParent();
-          node = parent.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8.name()));
+          node = parent.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8).replace("%", "%25"));
           Session session = sessionProvider.getSession(sessionProvider.getCurrentWorkspace(),
                                                        sessionProvider.getCurrentRepository());
           if (session.itemExists(node.getPath())) {
@@ -995,19 +996,17 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       }
       if ((node.getName().equals(USER_PUBLIC_ROOT_NODE))) {
         if (folderPath.startsWith(USER_PRIVATE_ROOT_NODE + "/" + USER_PUBLIC_ROOT_NODE)) {
-          folderPath = folderPath.split(USER_PRIVATE_ROOT_NODE + "/" + USER_PUBLIC_ROOT_NODE + "/")[1];
-          return (node.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8.name())));
+          folderPath = folderPath.split(USER_PRIVATE_ROOT_NODE + "/" + USER_PUBLIC_ROOT_NODE + SLASH)[1];
+          return (node.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8).replace("%", "%25")));
         }
         if (folderPath.startsWith(USER_PUBLIC_ROOT_NODE)) {
-          folderPath = folderPath.split(USER_PUBLIC_ROOT_NODE + "/")[1];
-          return (node.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8.name())));
+          folderPath = folderPath.split(USER_PUBLIC_ROOT_NODE + SLASH)[1];
+          return (node.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8).replace("%", "%25")));
         }
       }
-      return (node.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8.name())));
+      return (node.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8).replace("%", "%25")));
     } catch (RepositoryException repositoryException) {
       throw new ObjectNotFoundException("Folder with path : " + folderPath + " isn't found");
-    } catch (UnsupportedEncodingException e) {
-      throw new IllegalStateException("Error retrieving folder'" + folderPath, e);
     }
   }
 

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -667,7 +667,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
 
       Node parent = node.getParent();
       String srcPath = node.getPath();
-      String destPath = (parent.getPath().equals("/") ? org.apache.commons.lang.StringUtils.EMPTY : parent.getPath()).concat("/").concat(name);
+      String destPath = (parent.getPath().equals(SLASH) ? org.apache.commons.lang.StringUtils.EMPTY : parent.getPath()).concat(SLASH).concat(name);
       node.getSession().getWorkspace().move(srcPath, destPath);
       node.setProperty(NodeTypeConstants.EXO_TITLE, title);
       node.setProperty(NodeTypeConstants.EXO_NAME, name);
@@ -774,10 +774,10 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       node.save();
 
       String srcPath = node.getPath();
-      if (session.itemExists(destPath + "/" + node.getName())) {
+      if (session.itemExists(destPath + SLASH + node.getName())) {
         handleMoveDocConflict(session, node, srcPath, destPath, conflictAction);
       } else {
-        node.getSession().getWorkspace().move(srcPath, destPath + "/" + node.getName());
+        node.getSession().getWorkspace().move(srcPath, destPath + SLASH + node.getName());
         node.save();
       }
     } catch (ObjectAlreadyExistsException e) {
@@ -801,10 +801,10 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     String originName = node.getName();
     String name = originName;
     if (Objects.equals(conflictAction, KEEP_BOTH)) {
-      while (session.itemExists(destPath + "/" + name)) {
+      while (session.itemExists(destPath + SLASH + name)) {
         name = increaseNameIndex(originName, ++count);
       }
-      destPath = destPath + "/" + name;
+      destPath = destPath + SLASH + name;
       node.getSession().getWorkspace().move(srcPath, destPath);
       Node destNode = (Node) session.getItem(destPath);
       if (destNode.hasProperty(NodeTypeConstants.EXO_TITLE)) {
@@ -813,7 +813,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       }
       destNode.getSession().save();
     } else if (Objects.equals(conflictAction, CREATE_NEW_VERSION)) {
-      Node destNode = (Node) session.getItem(destPath + "/" + name);
+      Node destNode = (Node) session.getItem(destPath + SLASH + name);
       Node scrNode = (Node) session.getItem(srcPath);
       if (destNode.isNodeType(NodeTypeConstants.MIX_VERSIONABLE)) {
         Node destContentNode = destNode.getNode(NodeTypeConstants.JCR_CONTENT);
@@ -835,7 +835,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         destNode.getSession().save();
       }
     } else {
-      Node destNode = (Node) session.getItem(destPath + "/" + name);
+      Node destNode = (Node) session.getItem(destPath + SLASH + name);
       Map<String, Boolean> map = new HashMap<>();
       map.put("versionable", destNode.isNodeType(NodeTypeConstants.MIX_VERSIONABLE));
       throw new ObjectAlreadyExistsException(map);
@@ -995,8 +995,8 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         }
       }
       if ((node.getName().equals(USER_PUBLIC_ROOT_NODE))) {
-        if (folderPath.startsWith(USER_PRIVATE_ROOT_NODE + "/" + USER_PUBLIC_ROOT_NODE)) {
-          folderPath = folderPath.split(USER_PRIVATE_ROOT_NODE + "/" + USER_PUBLIC_ROOT_NODE + SLASH)[1];
+        if (folderPath.startsWith(USER_PRIVATE_ROOT_NODE + SLASH + USER_PUBLIC_ROOT_NODE)) {
+          folderPath = folderPath.split(USER_PRIVATE_ROOT_NODE + SLASH + USER_PUBLIC_ROOT_NODE + SLASH)[1];
           return (node.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8).replace("%", "%25")));
         }
         if (folderPath.startsWith(USER_PUBLIC_ROOT_NODE)) {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -158,11 +158,17 @@ export default {
   }),
   computed: {
     title() {
-      let title = decodeURI(this.fileName);
-      if (this.query){
-        title = this.highlightSearchResult(title,this.query);      
+      let docTitle = this.fileName;
+      try {
+        docTitle = decodeURI(this.fileName);
+      } catch (error) {
+        // Nothing to do, title contains % character but it represent not an encoded character
+        // No need to decode the title
       }
-      return title;
+      if (this.query){
+        docTitle = this.highlightSearchResult(docTitle,this.query);
+      }
+      return docTitle;
     },
     lastUpdated() {
       return this.file && (this.file.modifiedDate || this.file.createdDate) || '';


### PR DESCRIPTION
Prior to this fix, when a folder has a % character, the folder is not displayed in the documents application.
The fix will check if the file name is encoded otherwise, it takes the filename as is without decoding.