### PR TITLE
fix: fullTree drawer: renamed symlink folder displayed with original  folder name - EXO-62037

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -486,6 +486,9 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       Node childNode = nodeIter.nextNode();
       if (!childNode.isNodeType(NodeTypeConstants.EXO_HIDDENABLE)
           && (childNode.isNodeType(NodeTypeConstants.NT_UNSTRUCTURED) || childNode.isNodeType(NodeTypeConstants.NT_FOLDER) || childNode.isNodeType(NodeTypeConstants.EXO_SYMLINK))) {
+        String nodeName = childNode.hasProperty(NodeTypeConstants.EXO_TITLE) ? childNode.getProperty(NodeTypeConstants.EXO_TITLE)
+                                                                                        .getString()
+                                                                             : childNode.getName();
         if(childNode.isNodeType(NodeTypeConstants.EXO_SYMLINK)){
           childNode=getNodeByIdentifier(session, childNode.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString());
           if (childNode != null && !childNode.isNodeType(NodeTypeConstants.NT_UNSTRUCTURED)
@@ -494,9 +497,6 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
           }
         }
         if(childNode != null){
-          String nodeName = childNode.hasProperty(NodeTypeConstants.EXO_TITLE) ? childNode.getProperty(NodeTypeConstants.EXO_TITLE)
-                  .getString()
-                  : childNode.getName();
           List<FullTreeItem> folderChildListNodes = getAllFolderInNode(childNode,session);
           folderListNodes.add(new FullTreeItem(((NodeImpl) childNode).getIdentifier(),
                   nodeName,


### PR DESCRIPTION
prior to this change, when displaying the full tree folder, renamed symlink folders are displayed with their original folder name
after this change, displaying the renamed symlink folders are displayed with its name