### PR TITLE
fix: display correctly files/folders containing % in their names - EXO-59750

### DIFF
--- a/documents-services/pom.xml
+++ b/documents-services/pom.xml
@@ -159,6 +159,12 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <systemProperties>
+            <property>
+              <name>exo.files.storage.dir</name>
+              <value>target/exo-files</value>
+            </property>
+          </systemProperties>
           <argLine>@{argLine} --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</argLine>
         </configuration>
       </plugin>

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -204,7 +204,7 @@ public class EntityBuilder {
     try {
       nodeEntity.setId(node.getId());
       nodeEntity.setPath(node.getPath());
-      nodeEntity.setName(node.getName() != null ? URLDecoder.decode(node.getName(), StandardCharsets.UTF_8) : null);
+      nodeEntity.setName(encodeName(node));
       nodeEntity.setDatasource(node.getDatasource());
       nodeEntity.setDescription(node.getDescription());
       nodeEntity.setAcl(toNodePermissionEntity(node,identityManager, spaceService));
@@ -255,6 +255,23 @@ public class EntityBuilder {
     } catch (Exception e) {
       LOG.error("==== exception occured when converting node with ID = {} and name = {}", node.getId(), node.getName(), e);
     }
+  }
+
+  /**
+   * Decode node name if it is already encoded
+   * @param node its name
+   * @return decoded node name
+   */
+  private static String encodeName(AbstractNode node) {
+    String nodeName = node.getName();
+    if(StringUtils.isNotBlank(nodeName)) {
+      try {
+        nodeName = URLDecoder.decode(node.getName(), StandardCharsets.UTF_8);
+      } catch (IllegalArgumentException iae) {
+        // nothing to do
+      }
+    }
+    return nodeName;
   }
 
   private static NodePermissionEntity toNodePermissionEntity(AbstractNode node, IdentityManager identityManager, SpaceService spaceService){

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -159,11 +159,17 @@ export default {
   }),
   computed: {
     title() {
-      let title = decodeURI(this.fileName);
-      if (this.query){
-        title = this.highlightSearchResult(title,this.query);      
+      let docTitle = this.fileName;
+      try {
+        docTitle = decodeURI(this.fileName);
+      } catch (error) {
+        // Nothing to do, title contains % character but it represent not an encoded character
+        // No need to decode the title
       }
-      return title;
+      if (this.query){
+        docTitle = this.highlightSearchResult(docTitle,this.query);
+      }
+      return docTitle;
     },
     lastUpdated() {
       return this.file && (this.file.modifiedDate || this.file.createdDate) || '';


### PR DESCRIPTION
Prior to this fix, when a folder has a % character, the folder is not displayed in the documents application. The fix will check if the file name is encoded otherwise, it takes the filename as is without decoding.