### PR TITLE
fix: do not load symlinks when they are inside their source folders - EXO-59750

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
@@ -94,9 +94,6 @@ public interface DocumentFileStorage {
    * @param folderId Id of the given folder
    * @param aclIdentity {@link Identity} of the user acessing files
    * @return {@link List} of {@link AbstractNode}
-   * @throws IllegalAccessException when the user isn't allowed to access
-   *           documents of the designated parentFolderId
-   * @throws ObjectNotFoundException when folderId doesn't exisits
    */
   List<FullTreeItem> getFullTreeData(long ownerId, String folderId, Identity aclIdentity) throws IllegalAccessException, ObjectNotFoundException;
 

--- a/documents-storage-jcr/pom.xml
+++ b/documents-storage-jcr/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>documents-storage-jcr</artifactId>
   <name>eXo Documents - Storage JCR Implementation</name>
   <properties>
-    <exo.test.coverage.ratio>0.28</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.33</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -490,19 +490,21 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         String nodeName = childNode.hasProperty(NodeTypeConstants.EXO_TITLE) ? childNode.getProperty(NodeTypeConstants.EXO_TITLE)
                                                                                         .getString()
                                                                              : childNode.getName();
-        if(childNode.isNodeType(NodeTypeConstants.EXO_SYMLINK)){
-          childNode=getNodeByIdentifier(session, childNode.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString());
-          if (childNode != null && !childNode.isNodeType(NodeTypeConstants.NT_UNSTRUCTURED)
-              && !childNode.isNodeType(NodeTypeConstants.NT_FOLDER)) {
+        if (childNode.isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
+          Node parentNode = getNodeByIdentifier(session, childNode.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString());
+          if (parentNode != null && (!parentNode.isNodeType(NodeTypeConstants.NT_UNSTRUCTURED)
+              && !parentNode.isNodeType(NodeTypeConstants.NT_FOLDER) || childNode.getPath().contains(parentNode.getPath()))) {
             continue;
+          } else {
+            childNode = parentNode;
           }
         }
-        if(childNode != null){
-          List<FullTreeItem> folderChildListNodes = getAllFolderInNode(childNode,session);
+        if (childNode != null) {
+          List<FullTreeItem> folderChildListNodes = getAllFolderInNode(childNode, session);
           folderListNodes.add(new FullTreeItem(((NodeImpl) childNode).getIdentifier(),
-                  nodeName,
-                  childNode.getPath(),
-                  folderChildListNodes));
+                                               nodeName,
+                                               childNode.getPath(),
+                                               folderChildListNodes));
         }
 
       }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -447,7 +447,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
   @Override
   public List<FullTreeItem> getFullTreeData(long ownerId,
                                             String folderId,
-                                            Identity aclIdentity) throws IllegalAccessException, ObjectNotFoundException {
+                                            Identity aclIdentity) {
     String username = aclIdentity.getUserId();
     SessionProvider sessionProvider = null;
     List<FullTreeItem> parents = new ArrayList<>();
@@ -464,11 +464,10 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         node = getNodeByIdentifier(session, folderId);
       }
       if (node != null) {
-        String nodeName= node.hasProperty(NodeTypeConstants.EXO_TITLE) ? node.getProperty(NodeTypeConstants.EXO_TITLE).getString() : node.getName();
-        List<FullTreeItem> children = new ArrayList<>();
-        children = getAllFolderInNode(node,session);
+        String nodeName = node.hasProperty(NodeTypeConstants.EXO_TITLE) ? node.getProperty(NodeTypeConstants.EXO_TITLE).getString() : node.getName();
+        List<FullTreeItem> children = getAllFolderInNode(node,session);
 
-        parents.add(new FullTreeItem(((NodeImpl) node).getIdentifier(), nodeName, node.getPath(),children));
+        parents.add(new FullTreeItem(((NodeImpl) node).getIdentifier(), nodeName, node.getPath(), children));
       }
     } catch (Exception e) {
       throw new IllegalStateException("Error retrieving tree folder'" + folderId, e);
@@ -492,6 +491,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
                                                                              : childNode.getName();
         if (childNode.isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
           Node parentNode = getNodeByIdentifier(session, childNode.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString());
+          // skip if the source is not a folder or that the symlink is inside its source folder
           if (parentNode != null && (!parentNode.isNodeType(NodeTypeConstants.NT_UNSTRUCTURED)
               && !parentNode.isNodeType(NodeTypeConstants.NT_FOLDER) || childNode.getPath().contains(parentNode.getPath()))) {
             continue;


### PR DESCRIPTION
When trying to create a symlink of a folder inside the folder itself, we got a stackoverflow error and the folder tree is not built.
The fix skips loading folders of a folder symlink if the symlink is of one of its parent folders. 