### PR TITLE
fix: bad display for filter badge icon in mobile vue - EXO-62361

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsFilter.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsFilter.vue
@@ -17,7 +17,7 @@
     <button
       v-if="canShowMobileFilter"
       :class="btnClass"
-      class="px-3 py-3"
+      class="px-3 width-max-content"
       @click="openDrawer()">
       <v-icon size="16" class="filterIcon"> fa-sliders-h </v-icon>
       <span v-if="filterNumber>0">({{ filterNumber }})</span>    
@@ -69,7 +69,7 @@ export default {
       if (this.filterNumber>0 || this.query){
         return 'mobile-filter-button';
       }
-      return 'btn';
+      return 'btn py-3';
     }
   },
   methods: {


### PR DESCRIPTION
prior to this change, The filter option button is too big and the number is displayed under the icon
after this change,  The number is displayed in the same line with the icon