### PR TITLE
fix: Details drawer title and buttons alignment - EXO-62247

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
@@ -23,7 +23,7 @@
                 @click="showVersionHistory"
                 class="item-version text-caption border-radius primary pa-0 px-1 clickable">
                 V{{ file.versionNumber }}
-            </span>
+              </span>
               <documents-favorite-action
                 v-if="!file.folder"
                 :file="file"

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
@@ -17,16 +17,18 @@
               class="fileName font-weight-bold text-color ms-2 px-2">
               {{ file.name }}
             </span>
-            <span
-              v-if="file.versionNumber"
-              @click="showVersionHistory"
-              class="item-version text-caption border-radius primary pa-0 px-1 clickable">
-              V{{ file.versionNumber }}
+            <div class="d-flex align-center pb-1">
+              <span
+                v-if="file.versionNumber"
+                @click="showVersionHistory"
+                class="item-version text-caption border-radius primary pa-0 px-1 clickable">
+                V{{ file.versionNumber }}
             </span>
-            <documents-favorite-action
-              v-if="!file.folder"
-              :file="file"
-              :is-mobile="isMobile" />
+              <documents-favorite-action
+                v-if="!file.folder"
+                :file="file"
+                :is-mobile="isMobile" />
+            </div>
             <v-spacer />
           </a>
         </v-list-item-content>


### PR DESCRIPTION
prior to this change, in the details drawer, when the document's title is in 2 lines it is not aligned 
after this change, the drawer elements are aligned