### PR TITLE
fix: Display save description button only when the description is edited - EXO-62252 

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
@@ -167,6 +167,7 @@
       <div class="d-flex">
         <v-spacer />
         <v-btn
+          v-show="displayEditor"
           id="saveDescriptionButton"
           :loading="savingDescription"
           :disabled="disableButton"


### PR DESCRIPTION
Make the save description button display only when we are editing the description