### PR TITLE
fix: fix the 3 dots menu actions are not immediatly displayed after the creation of a folder - EXO-62146

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -702,6 +702,7 @@ export default {
       const ownerId = eXo.env.portal.spaceIdentityId || eXo.env.portal.userIdentityId;
       this.$documentFileService.createFolder(ownerId,this.parentFolderId,this.folderPath,name)
         .then(createdFolder => {
+          createdFolder.canAdd = this.canAdd;
           this.files.shift();
           this.files.unshift(createdFolder);
         }).catch(e => {


### PR DESCRIPTION
Prior this change, not all actions in the 3 dots menu are available after creating a folder. After this change, all actions are available, this has been fixed by adding the value of the canAdd attribute to the newly created folder.