### PR TITLE
fix: remove hand cursur for not clickable area - EXO-62247

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
@@ -89,7 +89,7 @@
         <v-list-item>
           <v-list-item-content class="mt-4 mx-4">
             <v-list-item-title>
-              <a
+              <span
                 class="fileDetails text-color d-flex">
                 <span class="text-center not-clickable font-weight-bold">{{ $t('documents.drawer.details.modified') }}:</span>
                 <date-format
@@ -111,7 +111,7 @@
                 <p v-else class="text-decoration-underline primary--text not-clickable font-weight-bold mx-1">
                   {{ infoDrawerModifierLabel }}
                 </p>
-              </a>
+              </span>
             </v-list-item-title>
           </v-list-item-content>
         </v-list-item>
@@ -119,7 +119,7 @@
         <v-list-item>
           <v-list-item-content class="mx-4">
             <v-list-item-title>
-              <a
+              <span
                 class="fileDetails text-color d-flex ">
                 <span class="text-center not-clickable font-weight-bold">
                   {{ $t('documents.drawer.details.created') }}:</span>
@@ -144,7 +144,7 @@
                 <p v-else class="text-decoration-underline not-clickable primary--text font-weight-bold mx-1">
                   {{ infoDrawerCreatorLabel }}
                 </p>
-              </a>
+              </span>
             </v-list-item-title>
           </v-list-item-content>
         </v-list-item>
@@ -152,14 +152,14 @@
         <v-list-item>
           <v-list-item-content class="mx-4">
             <v-list-item-title>
-              <a
+              <span
                 class="fileDetails not-clickable text-color d-flex">
                 <span class="text-center font-weight-bold">{{ $t('documents.drawer.details.size') }}:</span>
                 <documents-file-size-cell
                   class="mx-1 text-color"
                   :file="file"
                   :is-mobile="isMobile" />
-              </a>
+              </span>
             </v-list-item-title>
           </v-list-item-content>
         </v-list-item>


### PR DESCRIPTION
prior to this change, In the details info drawer, when we place the cursor on the right after the name of the creator or the user who made the last update. We have a hand cursor as if we could click.  Click and nothing happens.
This is because we used an HTML tag for the click.
After this change, the default cursor is displayed after the change of the HTML tag.