### PR TITLE
fix: Fix documents button show detail error at the first click -EXO-62414

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
@@ -301,7 +301,9 @@ export default {
       this.showNoDescription = !this.file.description && !this.displayEditor;
       this.showDescription = this.file.description && this.file.description.length && !this.displayEditor;
       this.fileInitialDescription = this.file.description;      
-      this.$refs.documentInfoDrawer.open();
+      this.$nextTick(()=>{
+        this.$refs.documentInfoDrawer.open();
+      });
     },
     openEditor(){
       this.firstCreateDescription = this.showNoDescription;


### PR DESCRIPTION
Prior to this change , when the document show detail button was clicked at the first time , the info drawer wouldn't be opened and a console error was displayed . The problem was that the open drawer method executed before the initial render ,as result the $refs is undefined .
This change will allow the document info drawer to be opened after the initial render by using the `nextTick() method .