### PR TITLE
fix: fix displaying alert when reloading the page after saving the description - EXO-62449 (#765)

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
@@ -317,7 +317,6 @@ export default {
       this.displayEditor = false;
       this.showNoDescription = false;
       this.showDescription = true;
-      this.displayEditor=true;
       this.$refs.documentInfoDrawer.close();
 
     },


### PR DESCRIPTION
prior to this change, after saving the document description when trying to change the navigation an alert is displayed and telling that we need to save the changes (while it has been successfully saved) because the editor has been reopened after this change, no alert is displayed after successfully saving the description