### PR TITLE
fix : Fix visiblity rules when share folder with another space -EXO-62495

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1124,7 +1124,13 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       if (destIdentity.getProviderId().equals(SPACE_PROVIDER_ID)) {
         Space space = spaceService.getSpaceByPrettyName(destIdentity.getRemoteId());
         String groupId = space.getGroupId();
-        permissions.put("*:" + groupId, PermissionType.ALL);
+        List<AccessControlEntry> acc = ((ExtendedNode) currentNode).getACL().getPermissionEntries();
+        List<String> accessControlEntryPermession = new ArrayList<>();
+        acc.stream().filter(accessControlEntry -> accessControlEntry.getIdentity().equals("*:"+groupId)).collect(Collectors.toList())
+           .forEach(accessControlEntry -> {
+                      accessControlEntryPermession.add(accessControlEntry.getPermission());
+                      permissions.put(accessControlEntry.getIdentity(),accessControlEntryPermession.toArray(new String[accessControlEntryPermession.size()]));
+                    });
       } else {
         permissions.put(destIdentity.getRemoteId(), PermissionType.ALL);
       }

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
@@ -70,6 +70,9 @@ export default {
   },
   methods: {
     changeVisibility() {
+      if (!this.file.acl.canEdit) {
+        return;
+      }
       this.$root.$emit('open-visibility-drawer', this.file);
       document.dispatchEvent(new CustomEvent('manage-access', {
         detail: {


### PR DESCRIPTION
Before this change when we shared a folder with another space with read only permission , the folder would be created but the visibility rules were wrong . The problem was that when we added a symlink to the destination space , the symlink was added with all permission and that able to open the visibility drawer .
After this change we will add the symlink to the destination space with the provided permission and disallow read-only access to open the visibility drawer.