### PR TITLE
fix : Fix visiblity rules when share folder with another space -EXO-62495

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
@@ -43,6 +43,19 @@ export default {
           title: this.$t('documents.label.visibility.all'),
         };
       }
+      if (this.isSharedWithCurrentSpace && !this.file.acl.canEdit) {
+        const collaborators = this.file.acl.collaborators.filter(e => e.identity.id === eXo.env.portal.spaceIdentityId );
+        return collaborators[0].permission === 'read'?
+          {
+            icon: 'fas fa-eye',
+            title: this.$t('documents.label.visibility.specific.manger'),
+          }
+          :
+          {
+            icon: 'fas fa-layer-group',
+            title: this.$t('documents.label.visibility.all'),
+          }; 
+      }
       switch (this.file.acl.visibilityChoice) {
       case 'SPECIFIC_COLLABORATOR':
         return {
@@ -67,6 +80,19 @@ export default {
         };
       }
     },
+    isSharedWithCurrentSpace(){
+      const spaceIdentityId = eXo.env.portal.spaceIdentityId;
+      const spaceName = eXo.env.portal.spaceName;
+      const collaborators = this.file.acl.collaborators;
+      if (spaceIdentityId && collaborators.length > 0){
+        for (let i = 0; i < collaborators.length; i++){
+          if (collaborators[i].identity.id === spaceIdentityId && collaborators[i].identity.name === spaceName) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
   },
   methods: {
     changeVisibility() {


### PR DESCRIPTION
Before this change, when we shared a folder containing documents with another space and gave read-only permissions, the folder would be created but the visibility rules were incorrect. The problem was that when we added a symlink to the destination space, the symlink was added with all permissions, allowing it to open the visibility drawer.

In previous commit we was added the symlink to the destination space with the provided permissions
With this fix, we will correct the wrong visibility rule icon and disallow read-only access to open the visibility drawer.

**Note**: For users who are members of both spaces, we will keep the same visibility rules provided by the source space