### PR TITLE
fix : favorite quick filter doesn't work on document application - EXO-62473

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -167,6 +167,9 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         String workspace = session.getWorkspace().getName();
         String sortField = getSortField(filter, false);
         String sortDirection = getSortDirection(filter);
+        if (rootPath.endsWith(username + "/Private")) {
+          rootPath = rootPath.substring(0, rootPath.lastIndexOf("/"));
+        }
 
         Collection<SearchResult> filesSearchList =
                                                  documentSearchServiceConnector.search(aclIdentity,


### PR DESCRIPTION
On the timeline view of the personal drive, when we create a new file and add it to our favorites, and then select the "favorites" quick filter, the newly added file is not displayed. The problem is that the "favorites" quick filter only returns files inside the Private route path, while we need it to return files inside both the Public and Private paths.
This change addresses the issue.