### PR TITLE
fix : Enable to move a folder in a certain cases - EXO-62663 (#780)

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -33,7 +33,7 @@ import javax.jcr.version.Version;
 import javax.jcr.version.VersionIterator;
 
 import org.apache.commons.lang.BooleanUtils;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.ObjectAlreadyExistsException;
@@ -512,7 +512,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     return folderListNodes.stream().sorted( new Comparator<FullTreeItem>() {
       public int compare(FullTreeItem o1, FullTreeItem o2) {
         //sorted the tree item when the name contains numbers
-        if(NumberUtils.isNumber(o1.getName())&&NumberUtils.isNumber(o2.getName())){
+        if(NumberUtils.isParsable(o1.getName()) && NumberUtils.isParsable(o2.getName())){
           return Integer.parseInt(o1.getName()) - Integer.parseInt(o2.getName());
         }
         // sorted the tree item when the name contains only characters

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -339,10 +339,10 @@ public class JCRDocumentFileStorageTest {
     List<AbstractNode> nodes2 = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 3);
 
     //assert that the method return the correct result and dosen't throw any exception
-    assertEquals(nodes2.size(),3);
-    assertEquals(nodes2.get(0).getName(), "15");
-    assertEquals(nodes2.get(1).getName(), "15f");
-    assertEquals(nodes2.get(2).getName(), "16L");
+    assertEquals(3, nodes2.size());
+    assertEquals("15", nodes2.get(0).getName());
+    assertEquals("15f", nodes2.get(1).getName());
+    assertEquals("16L", nodes2.get(2).getName());
 
     // case filter with query
     filter.setQuery("docum");

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -1,5 +1,6 @@
 package org.exoplatform.documents.storage.jcr;
 
+import org.apache.commons.lang3.math.NumberUtils;
 import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.documents.constant.DocumentSortField;
@@ -244,13 +245,25 @@ public class JCRDocumentFileStorageTest {
     folder1.setName("folder1");
     FolderNode folder2 = new FolderNode();
     folder2.setName("folder2");
+    FolderNode folderWithNumericName = new FolderNode();
+    folderWithNumericName.setName("15");
+    FolderNode folderWithSpecificName = new FolderNode();
+    folderWithSpecificName.setName("15f");
+    FolderNode folderWithSpecificName1 = new FolderNode();
+    folderWithSpecificName1.setName("16L");
     when(nodeIterator.hasNext()).thenReturn(true, true, false);
     Node fileNode = mock(Node.class);
     Node folderNode1 = mock(Node.class);
     Node folderNode2 = mock(Node.class);
+    Node folderNode3 = mock(Node.class);
+    Node folderNode4 = mock(Node.class);
+    Node folderNode5 = mock(Node.class);
     when(fileNode.isNodeType(NodeTypeConstants.NT_FILE)).thenReturn(true);
     when(folderNode1.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
     when(folderNode2.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
+    when(folderNode3.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
+    when(folderNode4.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
+    when(folderNode5.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
     when(nodeIterator.nextNode()).thenReturn(fileNode, folderNode1);
     doCallRealMethod().when(JCRDocumentsUtil.class,
                             "toNodes",
@@ -263,6 +276,10 @@ public class JCRDocumentFileStorageTest {
     when(JCRDocumentsUtil.toFileNode(identityManager, identity, fileNode, "", spaceService)).thenReturn(file);
     when(JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode1, "", spaceService)).thenReturn(folder1);
     when(JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode2, "", spaceService)).thenReturn(folder2);
+    when(JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode3, "", spaceService)).thenReturn(folderWithNumericName);
+    when(JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode4, "", spaceService)).thenReturn(folderWithSpecificName);
+    when(JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode5, "", spaceService)).thenReturn(folderWithSpecificName1);
+
 
     List<AbstractNode> nodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 2);
     assertEquals(2, nodes.size());
@@ -301,6 +318,31 @@ public class JCRDocumentFileStorageTest {
     when(nodeIterator1.nextNode()).thenReturn(folderNode2);
     nodes1 = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 2, 4);
     assertEquals(1, nodes1.size());
+
+    // case folder with specific name
+    NodeIterator nodeIterator2 = mock(NodeIterator.class);
+    when(queryResult.getNodes()).thenReturn(nodeIterator2);
+    when(nodeIterator2.hasNext()).thenReturn(true, true, true,false);
+    when(nodeIterator2.nextNode()).thenReturn(folderNode3, folderNode4, folderNode5);
+    doCallRealMethod().when(JCRDocumentsUtil.class,
+                            "toNodes",
+                            identityManager,
+                            userSession,
+                            nodeIterator2,
+                            identity,
+                            spaceService,
+                            false);
+
+    //assert NumberFormatException when try to parse specific folder name
+    assertThrows(NumberFormatException.class,() -> Integer.parseInt(folderWithSpecificName.getName()));
+
+    List<AbstractNode> nodes2 = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 3);
+
+    //assert that the method return the correct result and dosen't throw any exception
+    assertEquals(nodes2.size(),3);
+    assertEquals(nodes2.get(0).getName(), "15");
+    assertEquals(nodes2.get(1).getName(), "15f");
+    assertEquals(nodes2.get(2).getName(), "16L");
 
     // case filter with query
     filter.setQuery("docum");

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -28,6 +28,7 @@ import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvide
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.spi.SpaceService;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -334,7 +335,8 @@ public class JCRDocumentFileStorageTest {
                             false);
 
     //assert NumberFormatException when try to parse specific folder name
-    assertThrows(NumberFormatException.class,() -> Integer.parseInt(folderWithSpecificName.getName()));
+    String folderName = folderWithSpecificName.getName();
+    Assert.assertThrows(NumberFormatException.class, () -> Integer.parseInt(folderName));
 
     List<AbstractNode> nodes2 = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 3);
 


### PR DESCRIPTION
To sort folders, we use `NumberUtils.isNumber()` library to check if the folder or file name is a number. However in some cases we may have a specific document name like `12f` or `12L` which is considered a valid number in java , as result the `isNumber` method return true but if we try to parse this number we received a `numberFormatException` because this number format cannot be parsed , therefor the tree-view of the move to drawer not displayed if we want to move folder with this specific name. To handle this exception we need to replace the `isNumber` method with `isParsable` method.