### PR TITLE
fix : Fix visibility rules when share folder with another space - EXO-62495

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1124,7 +1124,13 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       if (destIdentity.getProviderId().equals(SPACE_PROVIDER_ID)) {
         Space space = spaceService.getSpaceByPrettyName(destIdentity.getRemoteId());
         String groupId = space.getGroupId();
-        permissions.put("*:" + groupId, PermissionType.ALL);
+        List<AccessControlEntry> acc = ((ExtendedNode) currentNode).getACL().getPermissionEntries();
+        List<String> accessControlEntryPermession = new ArrayList<>();
+        acc.stream().filter(accessControlEntry -> accessControlEntry.getIdentity().equals("*:"+groupId)).collect(Collectors.toList())
+           .forEach(accessControlEntry -> {
+                      accessControlEntryPermession.add(accessControlEntry.getPermission());
+                      permissions.put(accessControlEntry.getIdentity(),accessControlEntryPermession.toArray(new String[accessControlEntryPermession.size()]));
+                    });
       } else {
         permissions.put(destIdentity.getRemoteId(), PermissionType.ALL);
       }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1126,7 +1126,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         String groupId = space.getGroupId();
         List<AccessControlEntry> acc = ((ExtendedNode) currentNode).getACL().getPermissionEntries();
         List<String> accessControlEntryPermession = new ArrayList<>();
-        acc.stream().filter(accessControlEntry -> accessControlEntry.getIdentity().equals("*:"+groupId)).collect(Collectors.toList())
+        acc.stream().filter(accessControlEntry -> accessControlEntry.getIdentity().equals("*:" + groupId)).toList()
            .forEach(accessControlEntry -> {
                       accessControlEntryPermession.add(accessControlEntry.getPermission());
                       permissions.put(accessControlEntry.getIdentity(),accessControlEntryPermession.toArray(new String[accessControlEntryPermession.size()]));

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
@@ -43,6 +43,19 @@ export default {
           title: this.$t('documents.label.visibility.all'),
         };
       }
+      if (this.isSharedWithCurrentSpace && !this.file.acl.canEdit) {
+        const collaborators = this.file.acl.collaborators.filter(e => e.identity.id === eXo.env.portal.spaceIdentityId );
+        return collaborators[0].permission === 'read'?
+          {
+            icon: 'fas fa-eye',
+            title: this.$t('documents.label.visibility.specific.manger'),
+          }
+          :
+          {
+            icon: 'fas fa-layer-group',
+            title: this.$t('documents.label.visibility.all'),
+          }; 
+      }
       switch (this.file.acl.visibilityChoice) {
       case 'SPECIFIC_COLLABORATOR':
         return {
@@ -67,6 +80,19 @@ export default {
         };
       }
     },
+    isSharedWithCurrentSpace(){
+      const spaceIdentityId = eXo.env.portal.spaceIdentityId;
+      const spaceName = eXo.env.portal.spaceName;
+      const collaborators = this.file.acl.collaborators;
+      if (spaceIdentityId && collaborators.length > 0){
+        for (let i = 0; i < collaborators.length; i++){
+          if (collaborators[i].identity.id === spaceIdentityId && collaborators[i].identity.name === spaceName) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
   },
   methods: {
     changeVisibility() {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
@@ -70,6 +70,9 @@ export default {
   },
   methods: {
     changeVisibility() {
+      if (!this.file.acl.canEdit) {
+        return;
+      }
       this.$root.$emit('open-visibility-drawer', this.file);
       document.dispatchEvent(new CustomEvent('manage-access', {
         detail: {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
@@ -85,8 +85,8 @@ export default {
       const spaceName = eXo.env.portal.spaceName;
       const collaborators = this.file.acl.collaborators;
       if (spaceIdentityId && collaborators.length > 0){
-        for (let i = 0; i < collaborators.length; i++){
-          if (collaborators[i].identity.id === spaceIdentityId && collaborators[i].identity.name === spaceName) {
+        for (const collaborator of collaborators) {
+          if (collaborator.identity.id === spaceIdentityId && collaborator.identity.name === spaceName) {
             return true;
           }
         }


### PR DESCRIPTION
Before this change, when we shared a folder containing documents with another space and gave read-only permissions, the folder would be created but the visibility rules were incorrect. The problem was that when we added a symlink to the destination space, the symlink was added with all permissions, allowing it to open the visibility drawer.

With this fix, we will add the symlink to the destination space with the provided permissions and correct the wrong visibility rule icon and disallow read-only access to open the visibility drawer.