### PR TITLE
feat: Cleanup Test Classes and Dependencies - Meeds-io/MIPs#42 - EXO-62860

### DIFF
--- a/documents-services/pom.xml
+++ b/documents-services/pom.xml
@@ -12,7 +12,7 @@
     <rest.api.doc.version>1.0</rest.api.doc.version>
     <rest.api.doc.description>Documents addon rest endpoints</rest.api.doc.description>
 
-    <exo.test.coverage.ratio>0.60</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.59</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>
@@ -25,44 +25,10 @@
       <artifactId>documents-api</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.exoplatform.core</groupId>
-      <artifactId>exo.core.component.security.core</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.commons</groupId>
-      <artifactId>commons-component-common</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.commons</groupId>
-      <artifactId>commons-search</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.gatein.portal</groupId>
-      <artifactId>exo.portal.component.portal</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.social</groupId>
-      <artifactId>social-component-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.social</groupId>
-      <artifactId>social-component-core</artifactId>
-      <scope>provided</scope>
-    </dependency>
+
     <dependency>
       <groupId>org.exoplatform.social</groupId>
       <artifactId>social-component-service</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -70,104 +36,24 @@
       <artifactId>social-component-notification</artifactId>
       <scope>provided</scope>
     </dependency>
-    <!-- swagger -->
-    <dependency>
-      <groupId>io.swagger.core.v3</groupId>
-      <artifactId>swagger-annotations</artifactId>
-      <scope>provided</scope>
-    </dependency>
+
     <!-- Test -->
     <dependency>
-      <groupId>org.exoplatform.gatein.portal</groupId>
-      <artifactId>exo.portal.component.identity</artifactId>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.gatein.portal</groupId>
-      <artifactId>exo.portal.component.portal</artifactId>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.gatein.portal</groupId>
-      <artifactId>exo.portal.component.application-registry</artifactId>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.gatein.portal</groupId>
-      <artifactId>exo.portal.component.test.core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.commons</groupId>
-      <artifactId>commons-component-common</artifactId>
+      <groupId>org.exoplatform.social</groupId>
+      <artifactId>social-component-service</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.social</groupId>
-      <artifactId>social-component-core</artifactId>
-      <scope>test</scope>
+      <artifactId>social-component-notification</artifactId>
       <type>test-jar</type>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.commons</groupId>
-      <artifactId>commons-testing</artifactId>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.exoplatform.tool</groupId>
-          <artifactId>exo.tool.framework.junit</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hsqldb</groupId>
-      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
   <build>
     <finalName>documents-services</finalName>
     <plugins>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <systemProperties>
-            <property>
-              <name>exo.files.storage.dir</name>
-              <value>target/exo-files</value>
-            </property>
-          </systemProperties>
-          <argLine>@{argLine} --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</argLine>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>io.openapitools.swagger</groupId>
         <artifactId>swagger-maven-plugin</artifactId>

--- a/documents-services/src/test/java/org/exoplatform/documents/notification/plugin/AddDocumentCollaboratorPluginTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/notification/plugin/AddDocumentCollaboratorPluginTest.java
@@ -11,41 +11,49 @@ import org.exoplatform.documents.notification.utils.NotificationConstants;
 import org.exoplatform.services.idgenerator.IDGeneratorService;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
+
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.*;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.*;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({ "javax.management.*" })
-@PrepareForTest({ CommonsUtils.class, PluginKey.class, CommonsUtils.class, ExoContainerContext.class })
+@RunWith(MockitoJUnitRunner.class)
 public class AddDocumentCollaboratorPluginTest {
 
-  @Mock
-  private InitParams                    initParams;
+  private static final MockedStatic<ExoContainerContext> EXOCONTAINER_CONTEXT = mockStatic(ExoContainerContext.class);
+
+  private static final MockedStatic<CommonsUtils>        COMMONS_UTILS        = mockStatic(CommonsUtils.class);
+
+  private static final MockedStatic<PluginKey>           PLUGIN_KEY           = mockStatic(PluginKey.class);
 
   @Mock
-  private SpaceService                  spaceService;
+  private InitParams                                     initParams;
 
-  private AddDocumentCollaboratorPlugin addDocumentCollaboratorPlugin;
+  @Mock
+  private SpaceService                                   spaceService;
+
+  private AddDocumentCollaboratorPlugin                  addDocumentCollaboratorPlugin;
+
+  @AfterClass
+  public static void afterRunBare() throws Exception { // NOSONAR
+    EXOCONTAINER_CONTEXT.close();
+    COMMONS_UTILS.close();
+    PLUGIN_KEY.close();
+  }
 
   @Before
   public void setUp() throws Exception {
     this.addDocumentCollaboratorPlugin = new AddDocumentCollaboratorPlugin(initParams, spaceService);
-    PowerMockito.mockStatic(CommonsUtils.class);
-    PowerMockito.mockStatic(ExoContainerContext.class);
-    when(ExoContainerContext.getService(IDGeneratorService.class)).thenReturn(null);
+    EXOCONTAINER_CONTEXT.when(() -> ExoContainerContext.getService(IDGeneratorService.class)).thenReturn(null);
   }
 
   @Test
@@ -56,27 +64,29 @@ public class AddDocumentCollaboratorPluginTest {
 
   @Test
   public void makeNotification() {
-      NotificationContext ctx = NotificationContextImpl.cloneInstance();
-      ctx.append(NotificationConstants.FROM_USER, "root");
-      ctx.append(NotificationConstants.DOCUMENT_NAME, "document");
-      ctx.append(NotificationConstants.DOCUMENT_URL, "document url");
-      ctx.append(NotificationConstants.RECEIVERS, "receiver");
+    NotificationContext ctx = NotificationContextImpl.cloneInstance();
+    ctx.append(NotificationConstants.FROM_USER, "root");
+    ctx.append(NotificationConstants.DOCUMENT_NAME, "document");
+    ctx.append(NotificationConstants.DOCUMENT_URL, "document url");
+    ctx.append(NotificationConstants.RECEIVERS, "receiver");
 
-      String[] members = {"user1", "user2"};
+    String[] members = {
+        "user1", "user2"
+    };
 
-      Space space = mock(Space.class);
+    Space space = mock(Space.class);
 
-      when(spaceService.getSpaceByPrettyName("receiver")).thenReturn(space);
-      when(space.getMembers()).thenReturn(members);
-      NotificationInfo notificationInfo = addDocumentCollaboratorPlugin.makeNotification(ctx);
-      assertEquals("root", notificationInfo.getValueOwnerParameter(NotificationConstants.FROM_USER.getKey()));
-      assertEquals("document", notificationInfo.getValueOwnerParameter(NotificationConstants.DOCUMENT_NAME.getKey()));
-      assertEquals("document url", notificationInfo.getValueOwnerParameter(NotificationConstants.DOCUMENT_URL.getKey()));
-      assertEquals("root", notificationInfo.getFrom());
-      assertEquals(Arrays.asList(members), notificationInfo.getSendToUserIds());
-      when(spaceService.getSpaceByPrettyName("receiver")).thenReturn(null);
-      NotificationInfo notificationInfo1 = addDocumentCollaboratorPlugin.makeNotification(ctx);
-      assertEquals(List.of("receiver"), notificationInfo1.getSendToUserIds());
+    when(spaceService.getSpaceByPrettyName("receiver")).thenReturn(space);
+    when(space.getMembers()).thenReturn(members);
+    NotificationInfo notificationInfo = addDocumentCollaboratorPlugin.makeNotification(ctx);
+    assertEquals("root", notificationInfo.getValueOwnerParameter(NotificationConstants.FROM_USER.getKey()));
+    assertEquals("document", notificationInfo.getValueOwnerParameter(NotificationConstants.DOCUMENT_NAME.getKey()));
+    assertEquals("document url", notificationInfo.getValueOwnerParameter(NotificationConstants.DOCUMENT_URL.getKey()));
+    assertEquals("root", notificationInfo.getFrom());
+    assertEquals(Arrays.asList(members), notificationInfo.getSendToUserIds());
+    when(spaceService.getSpaceByPrettyName("receiver")).thenReturn(null);
+    NotificationInfo notificationInfo1 = addDocumentCollaboratorPlugin.makeNotification(ctx);
+    assertEquals(List.of("receiver"), notificationInfo1.getSendToUserIds());
 
   }
 }

--- a/documents-services/src/test/java/org/exoplatform/documents/notification/utils/NotificationUtilsTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/notification/utils/NotificationUtilsTest.java
@@ -1,5 +1,24 @@
 package org.exoplatform.documents.notification.utils;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.documents.rest.util.EntityBuilder;
@@ -11,44 +30,34 @@ import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.service.LinkProvider;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-import javax.jcr.Node;
-import javax.jcr.Property;
-import javax.jcr.RepositoryException;
-import javax.jcr.Value;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({ "javax.management.*" })
-@PrepareForTest({ CommonsUtils.class, LinkProvider.class, EntityBuilder.class })
+@RunWith(MockitoJUnitRunner.class)
 public class NotificationUtilsTest {
 
-  @Mock
-  private IdentityManager identityManager;
+  private static final MockedStatic<CommonsUtils>  COMMONS_UTILS  = mockStatic(CommonsUtils.class);
+
+  private static final MockedStatic<LinkProvider>  LINK_PROVIDER  = mockStatic(LinkProvider.class);
+
+  private static final MockedStatic<EntityBuilder> ENTITY_BUILDER = mockStatic(EntityBuilder.class);
 
   @Mock
-  private SpaceService    spaceService;
+  private IdentityManager                          identityManager;
+
+  @Mock
+  private SpaceService                             spaceService;
+
+  @AfterClass
+  public static void afterRunBare() throws Exception { // NOSONAR
+    COMMONS_UTILS.close();
+    ENTITY_BUILDER.close();
+    LINK_PROVIDER.close();
+  }
 
   @Before
   public void setUp() throws Exception {
-    PowerMockito.mockStatic(CommonsUtils.class);
-    PowerMockito.mockStatic(LinkProvider.class);
-
-    when(CommonsUtils.getCurrentPortalOwner()).thenReturn("dw");
-    when(CommonsUtils.getCurrentDomain()).thenReturn("http://domain");
-    when(LinkProvider.getPortalName(null)).thenReturn("portal");
+    COMMONS_UTILS.when(() -> CommonsUtils.getCurrentPortalOwner()).thenReturn("dw");
+    COMMONS_UTILS.when(() -> CommonsUtils.getCurrentDomain()).thenReturn("http://domain");
+    LINK_PROVIDER.when(() -> LinkProvider.getPortalName(null)).thenReturn("portal");
   }
 
   @Test
@@ -59,24 +68,24 @@ public class NotificationUtilsTest {
     space.setPrettyName("spacex");
     when(identity.getRemoteId()).thenReturn("spacex");
     Node node = Mockito.mock(ExtendedNode.class);
-    when(((ExtendedNode)node).getIdentifier()).thenReturn("123");
+    when(((ExtendedNode) node).getIdentifier()).thenReturn("123");
     when(node.hasNode("jcr:content")).thenReturn(true);
     when(node.getPath()).thenReturn("/Groups/spaces/spacex/Documents/new folder 32");
-    when(spaceService.getSpaceByGroupId("/spaces/spacex")).thenReturn(space);
     when(spaceService.getSpaceByPrettyName("spacex")).thenReturn(space);
-    when( identityManager.getOrCreateSpaceIdentity("spacex")).thenReturn(identity);
+    ENTITY_BUILDER.when(() -> EntityBuilder.getOwnerIdentityFromNodePath(any(), any(), any())).thenReturn(identity);
 
-    String link = NotificationUtils.getDocumentLink(node, spaceService,identityManager);
+    String link = NotificationUtils.getDocumentLink(node, spaceService, identityManager);
     assertEquals("http://domain/portal/g/:spaces:spacex/spacex/documents?documentPreviewId=123", link);
   }
+
   @Test
   public void getSharedDocumentLink() {
     Space space = new Space();
     space.setGroupId("/spaces/spacename");
     when(spaceService.getSpaceByPrettyName("space_name")).thenReturn(space);
-    String link = NotificationUtils.getSharedDocumentLink("123", null,null);
+    String link = NotificationUtils.getSharedDocumentLink("123", null, null);
     assertEquals("http://domain/portal/dw/documents/Private/Documents/Shared?documentPreviewId=123", link);
-    String link1 = NotificationUtils.getSharedDocumentLink("123", spaceService,"space_name");
+    String link1 = NotificationUtils.getSharedDocumentLink("123", spaceService, "space_name");
     assertEquals("http://domain/portal/g/:spaces:spacename/space_name/documents/Shared?documentPreviewId=123", link1);
   }
 

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
@@ -17,40 +17,68 @@
 
 package org.exoplatform.documents.rest;
 
-import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.doThrow;
-
-
-import org.exoplatform.commons.ObjectAlreadyExistsException;
-import org.exoplatform.commons.exception.ObjectNotFoundException;
-import org.exoplatform.documents.rest.util.RestUtils;
-import org.exoplatform.documents.service.DocumentFileService;
-import org.exoplatform.services.listener.ListenerService;
-import org.junit.runner.RunWith;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
-import java.util.*;
+import java.util.Map;
 
 import javax.jcr.RepositoryException;
 import javax.ws.rs.core.Response;
 
-import org.exoplatform.documents.rest.util.EntityBuilder;
-import org.exoplatform.documents.storage.JCRDeleteFileStorage;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
 
+import org.exoplatform.commons.ObjectAlreadyExistsException;
+import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.documents.constant.DocumentSortField;
 import org.exoplatform.documents.constant.FileListingType;
-import org.exoplatform.documents.model.*;
-import org.exoplatform.documents.rest.model.*;
+import org.exoplatform.documents.model.AbstractNode;
+import org.exoplatform.documents.model.BreadCrumbItem;
+import org.exoplatform.documents.model.DocumentFolderFilter;
+import org.exoplatform.documents.model.DocumentGroupsSize;
+import org.exoplatform.documents.model.DocumentTimelineFilter;
+import org.exoplatform.documents.model.FileNode;
+import org.exoplatform.documents.model.FileVersion;
+import org.exoplatform.documents.model.FolderNode;
+import org.exoplatform.documents.model.FullTreeItem;
+import org.exoplatform.documents.model.NodePermission;
+import org.exoplatform.documents.model.PermissionEntry;
+import org.exoplatform.documents.model.PermissionRole;
+import org.exoplatform.documents.rest.model.AbstractNodeEntity;
+import org.exoplatform.documents.rest.model.BreadCrumbItemEntity;
+import org.exoplatform.documents.rest.model.FileNodeEntity;
+import org.exoplatform.documents.rest.model.FileVersionsEntity;
+import org.exoplatform.documents.rest.model.FolderNodeEntity;
+import org.exoplatform.documents.rest.model.IdentityEntity;
+import org.exoplatform.documents.rest.model.NodeAuditTrailItemEntity;
+import org.exoplatform.documents.rest.model.NodeAuditTrailsEntity;
+import org.exoplatform.documents.rest.model.NodePermissionEntity;
+import org.exoplatform.documents.rest.model.PermissionEntryEntity;
+import org.exoplatform.documents.rest.model.Visibility;
+import org.exoplatform.documents.rest.util.EntityBuilder;
+import org.exoplatform.documents.rest.util.RestUtils;
+import org.exoplatform.documents.service.DocumentFileService;
 import org.exoplatform.documents.service.DocumentFileServiceImpl;
 import org.exoplatform.documents.storage.DocumentFileStorage;
+import org.exoplatform.documents.storage.JCRDeleteFileStorage;
+import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.security.Authenticator;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.IdentityRegistry;
@@ -65,32 +93,33 @@ import org.exoplatform.social.metadata.model.Metadata;
 import org.exoplatform.social.metadata.model.MetadataItem;
 import org.exoplatform.social.metadata.model.MetadataObject;
 import org.exoplatform.social.metadata.model.MetadataType;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class DocumentFileRestTest {
 
-  private DocumentFileStorage     documentFileStorage;
+  private static MockedStatic<RestUtils>     REST_UTILS     = mockStatic(RestUtils.class);
 
-  private IdentityManager         identityManager;
+  private static MockedStatic<EntityBuilder> ENTITY_BUILDER = mockStatic(EntityBuilder.class);
 
-  private SpaceService            spaceService;
+  private DocumentFileStorage                      documentFileStorage;
 
-  private IdentityRegistry        identityRegistry;
+  private IdentityManager                          identityManager;
 
-  private MetadataService         metadataService;
+  private SpaceService                             spaceService;
 
-  private Authenticator           authenticator;
+  private IdentityRegistry                         identityRegistry;
 
-  private DocumentFileServiceImpl documentFileService;
+  private MetadataService                          metadataService;
 
-  private DocumentFileRest        documentFileRest;
+  private Authenticator                            authenticator;
 
-  private JCRDeleteFileStorage jcrDeleteFileStorage;
+  private DocumentFileServiceImpl                  documentFileService;
 
-  private ListenerService listenerService;
+  private DocumentFileRest                         documentFileRest;
+
+  private JCRDeleteFileStorage                     jcrDeleteFileStorage;
+
+  private ListenerService                          listenerService;
 
   @Before
   public void setUp() {
@@ -110,6 +139,18 @@ public class DocumentFileRestTest {
                                                       identityRegistry,
                                                       listenerService);
     documentFileRest = new DocumentFileRest(documentFileService, spaceService, identityManager, metadataService);
+  }
+
+  @After
+  public void teardown() throws Exception { // NOSONAR
+    if (REST_UTILS != null) {
+      REST_UTILS.close();
+      REST_UTILS = null;
+    }
+    if (ENTITY_BUILDER != null) {
+      ENTITY_BUILDER.close();
+      ENTITY_BUILDER = null;
+    }
   }
 
   @Test
@@ -336,7 +377,7 @@ public class DocumentFileRestTest {
     assertEquals(((DocumentGroupsSize) response4.getEntity()).getThisDay(), 4);
 
     when(documentFileRest.getDocumentGroupsCount(currentOwnerId, "", null, false)).thenThrow(ObjectNotFoundException.class);
-    Response response =  documentFileRest.getDocumentGroupsCount(currentOwnerId, "", null, false);
+    Response response = documentFileRest.getDocumentGroupsCount(currentOwnerId, "", null, false);
     assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
     when(documentFileRest.getDocumentGroupsCount(currentOwnerId, "", null, false)).thenThrow(RuntimeException.class);
     response =  documentFileRest.getDocumentGroupsCount(currentOwnerId, "", null, false);
@@ -355,6 +396,7 @@ public class DocumentFileRestTest {
     currentProfile.setProperty(Profile.FULL_NAME, username);
     currentIdentity.setProfile(currentProfile);
     when(identityManager.getOrCreateUserIdentity(username)).thenReturn(currentIdentity);
+    mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(currentOwnerId);
 
     String userbname = "userb";
     long userId = 3;
@@ -395,7 +437,6 @@ public class DocumentFileRestTest {
     identity1.setAvatar(null);
     identity1.setProviderId("organization");
     identity1.setRemoteId("spacetest");
-
 
     NodeAuditTrailItemEntity nodeAuditTrailItemEntity = new NodeAuditTrailItemEntity();
     nodeAuditTrailItemEntity.setId(11);
@@ -456,10 +497,8 @@ public class DocumentFileRestTest {
     permissionEntries.add(permissionEntry4);
     permissionEntries.add(permissionEntry5);
     permissionEntries.add(permissionEntry6);
-    NodePermission nodePermission = new NodePermission(true,true,true,permissionEntries,null, null);
+    NodePermission nodePermission = new NodePermission(true, true, true, permissionEntries, null, null);
     folder1.setAcl(nodePermission);
-
-
 
     FolderNodeEntity folderEntity = new FolderNodeEntity();
     folderEntity.setId("2");
@@ -597,33 +636,31 @@ public class DocumentFileRestTest {
     breadCrumbItems.add(breadCrumbItem3);
     breadCrumbItems.add(breadCrumbItem4);
 
-
     List<BreadCrumbItemEntity> breadCrumbItemEntities = new ArrayList<>();
 
-
-    when(documentFileStorage.getBreadcrumb(2,"Folder1","",userID)).thenReturn(breadCrumbItems);
+    when(documentFileStorage.getBreadcrumb(2, "Folder1", "", userID)).thenReturn(breadCrumbItems);
 
     Response response1 = documentFileRest.getBreadcrumb(null,
             null,"");
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response1.getStatus());
 
-    Response response2 = documentFileRest.getBreadcrumb(Long.valueOf(2),"Folder1","");
+    Response response2 = documentFileRest.getBreadcrumb(Long.valueOf(2), "Folder1", "");
 
     assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response2.getStatus());
 
     when(identityManager.getOrCreateUserIdentity(username)).thenReturn(currentIdentity);
-    Response response3 = documentFileRest.getBreadcrumb(Long.valueOf(2),"Folder1","");
+    Response response3 = documentFileRest.getBreadcrumb(Long.valueOf(2), "Folder1", "");
     assertEquals(Response.Status.OK.getStatusCode(), response3.getStatus());
     breadCrumbItemEntities = (List<BreadCrumbItemEntity>) response3.getEntity();
     assertEquals(breadCrumbItemEntities.size(), 4);
-    assertEquals(breadCrumbItemEntities.get(0).getId(),"4");
-    assertEquals(breadCrumbItemEntities.get(0).getName(),"Folder4");
+    assertEquals(breadCrumbItemEntities.get(0).getId(), "4");
+    assertEquals(breadCrumbItemEntities.get(0).getName(), "Folder4");
 
     when(documentFileRest.getBreadcrumb(1L, "123", "")).thenThrow(ObjectNotFoundException.class);
-    Response response =  documentFileRest.getBreadcrumb(1L, "123", "");
+    Response response = documentFileRest.getBreadcrumb(1L, "123", "");
     assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
     when(documentFileRest.getBreadcrumb(1L, "123", "")).thenThrow(RuntimeException.class);
-    response =  documentFileRest.getBreadcrumb(1L, "123", "");
+    response = documentFileRest.getBreadcrumb(1L, "123", "");
     assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
   }
 
@@ -658,33 +695,33 @@ public class DocumentFileRestTest {
     file2.setMimeType(":file");
     file2.setSize(50);
 
-    when(documentFileStorage.duplicateDocument(2,"oldFile", "copy of",userID)).thenReturn(file2);
-
+    when(documentFileStorage.duplicateDocument(2, "oldFile", "copy of", userID)).thenReturn(file2);
 
     Response response1 = documentFileRest.duplicateDocument(null,
-            null,"copy of","");
+                                                            null,
+                                                            "copy of",
+                                                            "");
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response1.getStatus());
 
-    Response response2 = documentFileRest.duplicateDocument(Long.valueOf(2),"oldFile", "copy of","");
+    Response response2 = documentFileRest.duplicateDocument(Long.valueOf(2), "oldFile", "copy of", "");
 
     assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response2.getStatus());
 
     when(identityManager.getOrCreateUserIdentity(username)).thenReturn(currentIdentity);
-    Response response3 = documentFileRest.duplicateDocument(Long.valueOf(2),"oldFile", "copy of","");
+    Response response3 = documentFileRest.duplicateDocument(Long.valueOf(2), "oldFile", "copy of", "");
     assertEquals(Response.Status.OK.getStatusCode(), response3.getStatus());
     AbstractNodeEntity fileNode = (AbstractNodeEntity) response3.getEntity();
     assertEquals(fileNode.getName(), "Copy of oldFile");
-    assertEquals(fileNode.getId(),"2");
+    assertEquals(fileNode.getId(), "2");
 
     when(documentFileRest.duplicateDocument(1L, "oldFile", "copy of", "")).thenThrow(ObjectNotFoundException.class);
-    Response response =  documentFileRest.duplicateDocument(1L, "oldFile", "copy of", "");
+    Response response = documentFileRest.duplicateDocument(1L, "oldFile", "copy of", "");
     assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
     when(documentFileRest.duplicateDocument(1L, "oldFile", "copy of", "")).thenThrow(RuntimeException.class);
-    response =  documentFileRest.duplicateDocument(1L, "oldFile", "copy of", "");
+    response = documentFileRest.duplicateDocument(1L, "oldFile", "copy of", "");
     assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
 
   }
-
 
   @Test
   public void testCreateFolder() throws Exception {
@@ -697,9 +734,10 @@ public class DocumentFileRestTest {
     Profile currentProfile = new Profile();
     currentProfile.setProperty(Profile.FULL_NAME, username);
     currentIdentity.setProfile(currentProfile);
+    mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(currentOwnerId);
 
     List<FullTreeItem> children = new ArrayList<>();
-    FullTreeItem fullTreeItem = new FullTreeItem("11111222","test","path",null);
+    FullTreeItem fullTreeItem = new FullTreeItem("11111222", "test", "path", null);
     children.add(fullTreeItem);
 
     org.exoplatform.services.security.Identity userID = new org.exoplatform.services.security.Identity(username);
@@ -709,55 +747,55 @@ public class DocumentFileRestTest {
 
     when(identityManager.getOrCreateUserIdentity(username)).thenReturn(currentIdentity);
 
-    Response response = documentFileRest.createFolder(null,null,null,"");
+    Response response = documentFileRest.createFolder(null, null, null, "");
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     assertEquals("either_ownerId_or_parentid_is_mandatory", response.getEntity());
 
-    response = documentFileRest.createFolder("11111111",null,null,"");
+    response = documentFileRest.createFolder("11111111", null, null, "");
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     assertEquals("Folder Name should not be empty", response.getEntity());
 
     AbstractNode folder = new FolderNode();
     when(documentFileStorage.createFolder(2L, "11111111", null, "222", userID)).thenReturn(folder);
-    response = documentFileRest.createFolder("11111111",null,2L,"222");
+    response = documentFileRest.createFolder("11111111", null, 2L, "222");
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
     when(documentFileStorage.createFolder(2L, "11111111", null, "test", userID)).thenReturn(folder);
-    response = documentFileRest.createFolder("11111111",null,2L,"test");
+    response = documentFileRest.createFolder("11111111", null, 2L, "test");
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
-    when(documentFileRest.createFolder("11111111",null,2L,"test")).thenThrow(RuntimeException.class);
-    response =  documentFileRest.createFolder("11111111",null,2L,"test");
+    when(documentFileRest.createFolder("11111111", null, 2L, "test")).thenThrow(RuntimeException.class);
+    response = documentFileRest.createFolder("11111111", null, 2L, "test");
     assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
 
-    response = documentFileRest.renameDocument(null,null,"");
+    response = documentFileRest.renameDocument(null, null, "");
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     assertEquals("either_ownerId_or_documentID_is_mandatory", response.getEntity());
 
-    response = documentFileRest.renameDocument("11111111",2L,"");
+    response = documentFileRest.renameDocument("11111111", 2L, "");
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     assertEquals("Document Name should not be empty", response.getEntity());
 
     doNothing().when(documentFileStorage).renameDocument(2L, "11111111", "renameTest", userID);
-    Response response1 = documentFileRest.renameDocument("11111111",2L,"renameTest");
+    Response response1 = documentFileRest.renameDocument("11111111", 2L, "renameTest");
     assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
 
     when(documentFileStorage.getFullTreeData(2L, "11111111", userID)).thenReturn(children);
-    Response response2 = documentFileRest.getFullTreeData(2L,"11111111");
+    Response response2 = documentFileRest.getFullTreeData(2L, "11111111");
     assertEquals(Response.Status.OK.getStatusCode(), response2.getStatus());
 
-    Response response3 = documentFileRest.moveDocument(null,null,"/Groups/spaces/test/Documents/test", null);
+    Response response3 = documentFileRest.moveDocument(null, null, "/Groups/spaces/test/Documents/test", null);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response3.getStatus());
     assertEquals("either_ownerId_or_documentID_is_mandatory", response3.getEntity());
 
-    Response response4 = documentFileRest.moveDocument("11111111",2L,null, null);
+    Response response4 = documentFileRest.moveDocument("11111111", 2L, null, null);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response4.getStatus());
 
     doNothing().when(documentFileStorage).moveDocument(2L, "11111111", "/Groups/spaces/test/Documents/test", userID, "keepBoth");
-    Response response5 = documentFileRest.moveDocument("11111111",2L,"/Groups/spaces/test/Documents/test", "keepBoth");
+    Response response5 = documentFileRest.moveDocument("11111111", 2L, "/Groups/spaces/test/Documents/test", "keepBoth");
     assertEquals(Response.Status.OK.getStatusCode(), response5.getStatus());
 
     when(documentFileRest.moveDocument("11111111",2L,"/Groups/spaces/test/Documents/test", null)).thenThrow(RuntimeException.class);
-    response =  documentFileRest.moveDocument("11111111",2L,"/Groups/spaces/test/Documents/test", null);
+    response = documentFileRest.moveDocument("11111111", 2L, "/Groups/spaces/test/Documents/test", null);
     assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
 
   }
@@ -788,12 +826,12 @@ public class DocumentFileRestTest {
     file1.setMimeType(":file");
     file1.setSize(50);
 
-    Response response = documentFileRest.deleteDocument(null,"/document/oldFile",false, 6);
+    Response response = documentFileRest.deleteDocument(null, "/document/oldFile", false, 6);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     assertEquals("document_id_is_mandatory", response.getEntity());
 
-    doNothing().when(jcrDeleteFileStorage).deleteDocument("1","/document/oldFile",false, true, 6, root, currentOwnerId);
-    response = documentFileRest.deleteDocument("1","/document/oldFile",false, 6);
+    doNothing().when(jcrDeleteFileStorage).deleteDocument("1", "/document/oldFile", false, true, 6, root, currentOwnerId);
+    response = documentFileRest.deleteDocument("1", "/document/oldFile", false, 6);
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
   }
 
@@ -833,12 +871,10 @@ public class DocumentFileRestTest {
   }
 
   @Test
-  @PrepareForTest({ RestUtils.class, EntityBuilder.class })
   public void testUpdatePermissions() throws Exception {
     DocumentFileService documentFileService = mock(DocumentFileService.class);
-    PowerMockito.mockStatic(RestUtils.class);
-    PowerMockito.mockStatic(EntityBuilder.class);
-    DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService, spaceService, identityManager, metadataService);
+    DocumentFileRest documentFileRest1 =
+                                       new DocumentFileRest(documentFileService, spaceService, identityManager, metadataService);
 
     FileNodeEntity nodeEntity = new FileNodeEntity();
     NodePermission nodePermission = mock(NodePermission.class);
@@ -848,9 +884,10 @@ public class DocumentFileRestTest {
     Response response1 = documentFileRest1.updatePermissions(nodeEntity);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response1.getStatus());
     nodeEntity.setAcl(nodePermissionEntity);
-    when(RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(1L);
+    mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(1L);
     nodeEntity.setId("123");
-    when(EntityBuilder.toNodePermission(nodeEntity, documentFileService, spaceService, identityManager)).thenReturn(nodePermission);
+    mockEntityBuilder().when(() -> EntityBuilder.toNodePermission(nodeEntity, documentFileService, spaceService, identityManager))
+                  .thenReturn(nodePermission);
     doNothing().when(documentFileService).updatePermissions("123", nodePermission, 1L);
     Response response2 = documentFileRest1.updatePermissions(nodeEntity);
     assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response2.getStatus());
@@ -860,17 +897,15 @@ public class DocumentFileRestTest {
   }
 
   @Test
-  @PrepareForTest({ RestUtils.class })
   public void testCreateShortcut() throws Exception {
-    PowerMockito.mockStatic(RestUtils.class);
-    when(RestUtils.getCurrentUser()).thenReturn("user");
+    mockRestUtils().when(() -> RestUtils.getCurrentUser()).thenReturn("user");
     DocumentFileService documentFileService = mock(DocumentFileService.class);
     DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService, spaceService, identityManager, metadataService);
 
-    Response response = documentFileRest1.createShortcut(null,null, null);
+    Response response = documentFileRest1.createShortcut(null, null, null);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     assertEquals("Document's id should not be empty", response.getEntity());
-    response = documentFileRest1.createShortcut("11111111",null, null);
+    response = documentFileRest1.createShortcut("11111111", null, null);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     assertEquals("Document destination path should not be empty", response.getEntity());
 
@@ -885,9 +920,7 @@ public class DocumentFileRestTest {
   }
 
   @Test
-  @PrepareForTest(RestUtils.class)
   public void getFileVersions() {
-    PowerMockito.mockStatic(RestUtils.class);
     FileVersion fileVersion = new FileVersion();
     fileVersion.setCurrent(true);
     fileVersion.setTitle("test.docx");
@@ -900,11 +933,11 @@ public class DocumentFileRestTest {
     versions.add(fileVersion);
     Response response = documentFileRest.getFileVersions(null);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-    when(RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(0L);
-    when(RestUtils.getCurrentUser()).thenReturn("user");
+    mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(0L);
+    mockRestUtils().when(() -> RestUtils.getCurrentUser()).thenReturn("user");
     response = documentFileRest.getFileVersions("3654654651");
     assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
-    when(RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(1L);
+    mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(1L);
     when(documentFileService.getFileVersions("655645ezfefzef6z54", "user")).thenReturn(versions);
     response = documentFileRest.getFileVersions("qsdqs54dq65sd");
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
@@ -924,21 +957,19 @@ public class DocumentFileRestTest {
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     response = documentFileRest.getNewName("123", "patg", 1L, "125");
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-    when(documentFileService.getNewName(1L,"123","path", "test")).thenReturn("new");
+    when(documentFileService.getNewName(1L, "123", "path", "test")).thenReturn("new");
     response = documentFileRest.getNewName("123", "path", 1L, "test");
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    when(documentFileService.getNewName(1L,"123","path", "test")).thenThrow(RuntimeException.class);
+    when(documentFileService.getNewName(1L, "123", "path", "test")).thenThrow(RuntimeException.class);
     response = documentFileRest.getNewName("123", "path", 1L, "test");
     assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
   }
 
   @Test
-  @PrepareForTest({ RestUtils.class })
   public void updateDocumentDescription() throws IllegalAccessException, RepositoryException {
-    PowerMockito.mockStatic(RestUtils.class);
     DocumentFileService documentFileService1 = mock(DocumentFileService.class);
     DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService);
-    when(RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(1L);
+    mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(1L);
     doNothing().when(documentFileService1).updateDocumentDescription(1L, "123", "hello", 1L);
     Response response = documentFileRest1.updateDocumentDescription(1L, "123", "hello");
     assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
@@ -948,29 +979,25 @@ public class DocumentFileRestTest {
   }
 
   @Test
-  @PrepareForTest({ RestUtils.class })
   public void getFullTreeData() {
-    PowerMockito.mockStatic(RestUtils.class);
     DocumentFileService documentFileService1 = mock(DocumentFileService.class);
     DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService);
-    Response response =  documentFileRest1.getFullTreeData(null, null);
+    Response response = documentFileRest1.getFullTreeData(null, null);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     when(documentFileRest1.getFullTreeData(1L, "123")).thenThrow(IllegalAccessException.class);
-    response =  documentFileRest1.getFullTreeData(1L, "123");
+    response = documentFileRest1.getFullTreeData(1L, "123");
     assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
     when(documentFileRest1.getFullTreeData(1L, "123")).thenThrow(ObjectNotFoundException.class);
-    response =  documentFileRest1.getFullTreeData(1L, "123");
+    response = documentFileRest1.getFullTreeData(1L, "123");
     assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
     when(documentFileRest1.getFullTreeData(1L, "123")).thenThrow(RuntimeException.class);
-    response =  documentFileRest1.getFullTreeData(1L, "123");
+    response = documentFileRest1.getFullTreeData(1L, "123");
     assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
   }
 
   @Test
-  @PrepareForTest({ RestUtils.class })
   public void updateVersionSummary() {
-    PowerMockito.mockStatic(RestUtils.class);
-    when(RestUtils.getCurrentUser()).thenReturn("user");
+    mockRestUtils().when(() -> RestUtils.getCurrentUser()).thenReturn("user");
     Map<String, String> summary = new HashMap<>();
     summary.put("value", "test");
     FileVersion fileVersion = new FileVersion();
@@ -987,10 +1014,10 @@ public class DocumentFileRestTest {
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     response = documentFileRest1.updateVersionSummary(summary, "1225", null);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-    when(RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(0L);
+    mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(0L);
     response = documentFileRest1.updateVersionSummary(summary, "123", "123336");
     assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
-    when(RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(1L);
+    mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(1L);
     when(documentFileService1.updateVersionSummary(anyString(), anyString(), anyString(), anyString())).thenReturn(fileVersion);
     response = documentFileRest1.updateVersionSummary(summary, "123", "123336");
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
@@ -1003,28 +1030,24 @@ public class DocumentFileRestTest {
   }
 
   @Test
-  @PrepareForTest({ RestUtils.class })
   public void shouldThrowServerErrorWhenUpdateSummary() {
-    PowerMockito.mockStatic(RestUtils.class);
-    when(RestUtils.getCurrentUser()).thenReturn("user");
+    mockRestUtils().when(() -> RestUtils.getCurrentUser()).thenReturn("user");
     Map<String, String> summary = new HashMap<>();
     summary.put("value", "test");
     DocumentFileService documentFileService1 = mock(DocumentFileService.class);
     DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService);
-    when(RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(1L);
+    mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(1L);
     when(documentFileService1.updateVersionSummary(anyString(),
-            anyString(),
-            anyString(),
-            anyString())).thenThrow(RuntimeException.class);
+                                                   anyString(),
+                                                   anyString(),
+                                                   anyString())).thenThrow(RuntimeException.class);
     Response response = documentFileRest1.updateVersionSummary(summary, "123", "123336");
     assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
   }
 
   @Test
-  @PrepareForTest({ RestUtils.class })
   public void restoreVersion() {
-    PowerMockito.mockStatic(RestUtils.class);
-    when(RestUtils.getCurrentUser()).thenReturn("user");
+    mockRestUtils().when(() -> RestUtils.getCurrentUser()).thenReturn("user");
     FileVersion fileVersion = new FileVersion();
     fileVersion.setCurrent(true);
     fileVersion.setTitle("test.docx");
@@ -1037,23 +1060,21 @@ public class DocumentFileRestTest {
     DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService);
     Response response = documentFileRest1.restoreVersion(null);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-    when(RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(0L);
+    mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(0L);
     response = documentFileRest1.restoreVersion("123");
     assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
-    when(RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(1L);
+    mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(1L);
     when(documentFileService1.restoreVersion(anyString(), anyString())).thenReturn(fileVersion);
     response = documentFileRest1.restoreVersion("123");
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    doThrow(new RuntimeException()).when(documentFileService1).restoreVersion(anyString(),anyString());
+    doThrow(new RuntimeException()).when(documentFileService1).restoreVersion(anyString(), anyString());
     response = documentFileRest1.restoreVersion("123");
     assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
   }
 
   @Test
-  @PrepareForTest({ RestUtils.class })
-  public void  testRenameDocumentWithExistTitle() throws Exception {
-    PowerMockito.mockStatic(RestUtils.class);
-    when(RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(2L);
+  public void testRenameDocumentWithExistTitle() throws Exception {
+    mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(2L);
     DocumentFileService documentFileService1 = mock(DocumentFileService.class);
     DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService);
     doThrow(new ObjectAlreadyExistsException("exist")).when(documentFileService1).renameDocument(1L, "123", "test", 2L);
@@ -1062,14 +1083,27 @@ public class DocumentFileRestTest {
   }
 
   @Test
-  @PrepareForTest({ RestUtils.class })
-  public void  testMoveWithExistTitle() throws Exception {
-    PowerMockito.mockStatic(RestUtils.class);
-    when(RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(2L);
+  public void testMoveWithExistTitle() throws Exception {
+    mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(2L);
     DocumentFileService documentFileService1 = mock(DocumentFileService.class);
     DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService);
     doThrow(new ObjectAlreadyExistsException("exist")).when(documentFileService1).moveDocument(1L, "123", "test", 2L, "");
-    Response response = documentFileRest1.moveDocument("123",1L, "test", "");
+    Response response = documentFileRest1.moveDocument("123", 1L, "test", "");
     assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
   }
+
+  private MockedStatic<RestUtils> mockRestUtils() {
+    if (REST_UTILS == null) {
+      REST_UTILS = mockStatic(RestUtils.class);
+    }
+    return REST_UTILS;
+  }
+
+  private MockedStatic<EntityBuilder> mockEntityBuilder() {
+    if (ENTITY_BUILDER == null) {
+      ENTITY_BUILDER = mockStatic(EntityBuilder.class);
+    }
+    return ENTITY_BUILDER;
+  }
+
 }

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/util/EntityBuilderTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/util/EntityBuilderTest.java
@@ -1,25 +1,31 @@
 package org.exoplatform.documents.rest.util;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
 import org.exoplatform.documents.model.NodePermission;
-import org.exoplatform.documents.rest.model.*;
+import org.exoplatform.documents.rest.model.AbstractNodeEntity;
+import org.exoplatform.documents.rest.model.IdentityEntity;
+import org.exoplatform.documents.rest.model.NodePermissionEntity;
+import org.exoplatform.documents.rest.model.PermissionEntryEntity;
+import org.exoplatform.documents.rest.model.Visibility;
 import org.exoplatform.documents.service.DocumentFileService;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.List;
-
-import static org.junit.Assert.*;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
-
-@RunWith(PowerMockRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EntityBuilderTest {
 
     @Mock

--- a/documents-services/src/test/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
+++ b/documents-services/src/test/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
@@ -1,0 +1,1 @@
+org.exoplatform.services.rest.impl.RuntimeDelegateImpl

--- a/documents-storage-jcr/pom.xml
+++ b/documents-storage-jcr/pom.xml
@@ -16,26 +16,7 @@
       <artifactId>documents-api</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.exoplatform.social</groupId>
-      <artifactId>social-component-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.commons</groupId>
-      <artifactId>commons-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.commons</groupId>
-      <artifactId>commons-search</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.commons</groupId>
-      <artifactId>commons-component-common</artifactId>
-      <scope>provided</scope>
-    </dependency>
+
     <dependency>
       <groupId>org.exoplatform.social</groupId>
       <artifactId>social-component-core</artifactId>
@@ -57,30 +38,12 @@
       <groupId>org.exoplatform</groupId>
       <artifactId>exo-jcr-services</artifactId>
     </dependency>
+
     <!-- Test -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>xml-apis</groupId>
-      <artifactId>xml-apis</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
+      <groupId>org.exoplatform.social</groupId>
+      <artifactId>social-component-core</artifactId>
+      <type>test-jar</type>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/legacy/search/data/SearchContext.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/legacy/search/data/SearchContext.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright (C) 2023 eXo Platform SAS.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see<http://www.gnu.org/licenses/>.
+*/
+package org.exoplatform.documents.legacy.search.data;
+
+import org.apache.commons.collections.map.HashedMap;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.web.controller.QualifiedName;
+import org.exoplatform.web.controller.router.Router;
+
+import java.util.Map;
+
+/**
+ * Search Context contains a set of data needed for SearchService and all connectors.
+ *  
+ * @LevelAPI Experimental  
+ * @deprecated Copied from commons-search to this module.
+ *  Should be reworked to be more simple.
+ */
+@Deprecated(forRemoval = true, since = "6.0.0")
+public class SearchContext {
+  
+  private static Log LOG = ExoLogger.getExoLogger(SearchContext.class);
+  
+  public static enum RouterParams {
+   SITE_TYPE("sitetype"),
+   SITE_NAME("sitename"),
+   HANDLER("handler"),
+   PATH("path"),
+   LANG("lang");
+   
+   private final static String PREFIX = "gtn";
+   private String paramName = null;
+   
+   /**
+    * Constructor with paramName
+    * @param paramName
+    * @LevelAPI Experimental
+    */
+   private RouterParams(String paramName) {
+     this.paramName = paramName;
+   }
+   
+   /**
+    * Create qualified name
+    * @LevelAPI Experimental
+    * @return QualifiedName
+    * @LevelAPI Experimental 
+    */
+   public QualifiedName create() {
+     return QualifiedName.create(PREFIX, paramName);
+   }
+   
+  };
+  /** */
+  private Router router; // Gatein router, provides routing information for building resource URLs
+  
+  /** */
+  private String siteName;
+  
+  /** */
+  private Map<QualifiedName, String> params = null;
+  
+  /**
+   * Get router
+   * @return Router
+   * @LevelAPI Experimental 
+   */
+  public Router getRouter() {
+    return router;
+  }
+
+  /**
+   * Set router
+   * @param router
+   * @LevelAPI Experimental 
+   */
+  public void setRouter(Router router) {
+    this.router = router;
+  }
+
+  public String getParamValue(QualifiedName name) {
+    return params.get(name);
+  }
+
+  /**
+   * Get site name, e.g. intranet, acme, ..
+   * @return String
+   * @LevelAPI Experimental
+   */
+  public String getSiteName() {
+    return siteName;
+  }
+
+  /**
+   * Get site type
+   * @return String
+   * @LevelAPI Experimental
+   */
+  public String getSiteType() {
+    return params.get(RouterParams.SITE_TYPE.create());
+  }
+
+  /**
+   * Contructor to create a context for search service
+   * @param router
+   * @param siteName
+   * @LevelAPI Experimental 
+   */
+  public SearchContext(Router router, String siteName) {
+    this.router = router;
+    this.siteName = siteName;
+    params = new HashedMap();
+  }
+  
+  /**
+   * Puts Handler value into QualifiedName map
+   * @param value
+   * @return SearchContext
+   * @LevelAPI Experimental  
+   */
+  public SearchContext handler(String value) {
+    params.put(RouterParams.HANDLER.create(), value);
+    return this;
+  }
+  
+  /**
+   * Puts Lang value into QualifiedName map
+   * @param value
+   * @return SearchContext
+   * @LevelAPI Experimental 
+   */
+  public SearchContext lang(String value) {
+    params.put(RouterParams.LANG.create(), value);
+    return this;
+  }
+  
+  /**
+   * Puts Path value into QualifiedName map
+   * @param value
+   * @return SearchContext
+   * @LevelAPI Experimental
+   */
+  public SearchContext path(String value) {
+    params.put(RouterParams.PATH.create(), value);
+    return this;
+  }
+  
+  /**
+   * Puts SiteType value into QualifiedName map
+   * @param value
+   * @return SearchContext
+   * @LevelAPI Experimental
+   */
+  public SearchContext siteType(String value) {
+    params.put(RouterParams.SITE_TYPE.create(), value);
+    return this;
+  }
+  
+  /**
+   * Puts SiteType value into QualifiedName map
+   * @param value
+   * @return SearchContext
+   * @LevelAPI Experimental
+   */
+  public SearchContext siteName(String value) {
+    params.put(RouterParams.SITE_NAME.create(), value);
+    return this;
+  }
+  
+  /**
+   * Render link base on router and {@literal Map<QualifiedName, String>}
+   * @return String
+   * @throws Exception
+   * @LevelAPI Experimental
+   */
+  public String renderLink() throws Exception {
+    //
+    if (params.containsKey(RouterParams.LANG.create()) == false) {
+      lang("");
+    }
+    
+    //
+    if (params.containsKey(RouterParams.HANDLER.create()) == false) {
+      LOG.warn("Handler of QualifiedName not found!");
+    }
+    
+    //
+    if (params.containsKey(RouterParams.SITE_NAME.create()) == false) {
+      LOG.warn("SiteName of QualifiedName not found!");
+    }
+    
+    //
+    if (params.containsKey(RouterParams.SITE_TYPE.create()) == false) {
+      LOG.warn("SiteType of QualifiedName not found!");
+    }
+    
+    //
+    return router.render(params);
+  }
+  
+}

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/legacy/search/data/SearchResult.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/legacy/search/data/SearchResult.java
@@ -1,0 +1,238 @@
+/**
+ * Copyright (C) 2023 eXo Platform SAS.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see<http://www.gnu.org/licenses/>.
+*/
+package org.exoplatform.documents.legacy.search.data;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Search result returned by SearchService and all of its connectors, for rendering their search results on UI in a unified format.
+ *   
+ * @LevelAPI Experimental  
+ * @deprecated Copied from commons-search to this module.
+ *  Should be reworked to be more simple.
+ */
+@Deprecated(forRemoval = true, since = "6.0.0")
+public class SearchResult {
+  private String url;  //url of this result
+  private String previewUrl;  //preview url of this result
+  private String title; //title to be displayed on UI
+  private String excerpt; //the excerpt to be displayed on UI
+  private Map<String, List<String>> excerpts; //the excerpts by field and the corresponding list of excerpts
+  private String detail; //details information
+  private String imageUrl; //an image to be displayed on UI
+  private long date; //created or modified date, for sorting on UI
+  private long relevancy; //the result's relevancy, for sorting on UI
+
+  public Map<String, List<String>> getExcerpts() {
+    return excerpts;
+  }
+
+  public void setExcerpts(Map<String, List<String>> excerpts) {
+    this.excerpts = excerpts;
+  }
+
+  /**
+   * Get url of result 
+   * @return String
+   * @LevelAPI Experimental
+   */
+  public String getUrl() {
+    return url;
+  }
+  /**
+   * Set url for result
+   * @param url
+   * @LevelAPI Experimental
+   */
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  /**
+   * Get preview url of result
+   * @return String
+   * @LevelAPI Experimental
+   */
+  public String getPreviewUrl() {
+    return previewUrl;
+  }
+  /**
+   * Set preview url for result
+   * @param previewUrl
+   * @LevelAPI Experimental
+   */
+  public void setPreviewUrl(String previewUrl) {
+    this.previewUrl = previewUrl;
+  }
+
+  /**
+   * Get title of result
+   * @return String
+   * @LevelAPI Experimental
+   */
+  public String getTitle() {
+    return title;
+  }
+  /**
+   * Set title for result
+   * @param title
+   * @LevelAPI Experimental
+   */
+  public void setTitle(String title) {
+    this.title = title;
+  }
+  
+  /**
+   * Get excerpt of result
+   * @return String
+   * @LevelAPI Experimental
+   */
+  public String getExcerpt() {
+    return excerpt;
+  }
+  /**
+   * Set excerpt for result
+   * @param excerpt
+   * @LevelAPI Experimental
+   */
+  public void setExcerpt(String excerpt) {
+    this.excerpt = excerpt;
+  }
+  
+  /**
+   * Get detail of result
+   * @return String
+   * @LevelAPI Experimental
+   */
+  public String getDetail() {
+    return detail;
+  }
+  /**
+   * Set detail for result
+   * @param detail
+   * @LevelAPI Experimental
+   */
+  public void setDetail(String detail) {
+    this.detail = detail;
+  }
+  
+  /**
+   * Get image url of avatar
+   * @return String
+   * @LevelAPI Experimental
+   */
+  public String getImageUrl() {
+    return imageUrl;
+  }
+  /**
+   * Set image url for avatar
+   * @param imageUrl
+   * @LevelAPI Experimental
+   */
+  public void setImageUrl(String imageUrl) {
+    this.imageUrl = imageUrl;
+  }
+  /**
+   * Get date of result
+   * @return Long
+   * @LevelAPI Experimental
+   */
+  public long getDate() {
+    return date;
+  }
+  /**
+   * Set data for result
+   * @param date
+   * @LevelAPI Experimental
+   */
+  public void setDate(long date) {
+    this.date = date;
+  }
+  /**
+   * Get relevancy of result
+   * @return Long
+   * @LevelAPI Experimental
+   */
+  public long getRelevancy() {
+    return relevancy;
+  }
+  /**
+   * Set relevancy
+   * @param relevancy
+   * @LevelAPI Experimental
+   */
+  public void setRelevancy(long relevancy) {
+    this.relevancy = relevancy;
+  }
+  
+  /**
+   * Constructor that helps to create search result by the unique way
+   * @param url Url of this result
+   * @param title Title to be displayed on UI
+   * @param excerpt The excerpt to be displayed on UI
+   * @param detail Details information
+   * @param imageUrl An image to be displayed on UI
+   * @param date Created or modified date, for sorting on UI
+   * @param relevancy The result's relevancy, for sorting on UI
+   * @LevelAPI Experimental
+   */
+  public SearchResult(String url, String title, String excerpt, String detail, String imageUrl, long date, long relevancy) {
+    this.url = url;
+    this.title = title;
+    this.excerpt = excerpt;
+    this.detail = detail;
+    this.imageUrl = imageUrl;
+    this.date = date;
+    this.relevancy = relevancy;
+  }
+
+  /**
+   * Constructor that helps to create search result by the unique way
+   * (keeping the other constructor without previewUrl for backward compatibility reasons)
+   * @param url Url of this result
+   * @param previewUrl Preview url of this result
+   * @param title Title to be displayed on UI
+   * @param excerpt The excerpt to be displayed on UI
+   * @param detail Details information
+   * @param imageUrl An image to be displayed on UI
+   * @param date Created or modified date, for sorting on UI
+   * @param relevancy The result's relevancy, for sorting on UI
+   * @LevelAPI Experimental
+   */
+  public SearchResult(String url, String previewUrl, String title, String excerpt, String detail, String imageUrl, long date, long relevancy) {
+    this(url, title, excerpt, detail, imageUrl, date, relevancy);
+    this.previewUrl = previewUrl;
+  }
+
+  public SearchResult(String url,
+                      String title,
+                      Map<String, List<String>> excerpts,
+                      String excerpt,
+                      String detail,
+                      String imageUrl,
+                      Long date,
+                      long relevancy) {
+    this(url, title, excerpt, detail, imageUrl, date, relevancy);
+    this.excerpts = excerpts;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("SearchResult {url=%s, relevancy=%s}", url, relevancy);
+  }
+}

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -37,9 +37,9 @@ import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.ObjectAlreadyExistsException;
-import org.exoplatform.commons.api.search.data.SearchResult;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.documents.legacy.search.data.SearchResult;
 import org.exoplatform.documents.model.*;
 import org.exoplatform.documents.storage.DocumentFileStorage;
 import org.exoplatform.documents.storage.jcr.search.DocumentSearchServiceConnector;

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentFileSearchResult.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentFileSearchResult.java
@@ -1,6 +1,6 @@
 package org.exoplatform.documents.storage.jcr.search;
 
-import org.exoplatform.commons.api.search.data.SearchResult;
+import org.exoplatform.documents.legacy.search.data.SearchResult;
 
 public class DocumentFileSearchResult extends SearchResult {
 

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
@@ -29,7 +29,6 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
-import org.exoplatform.commons.api.search.data.SearchResult;
 import org.exoplatform.commons.search.es.ElasticSearchException;
 import org.exoplatform.commons.search.es.client.ElasticSearchingClient;
 import org.exoplatform.commons.utils.IOUtil;
@@ -37,6 +36,7 @@ import org.exoplatform.commons.utils.PropertyManager;
 import org.exoplatform.container.configuration.ConfigurationManager;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.PropertiesParam;
+import org.exoplatform.documents.legacy.search.data.SearchResult;
 import org.exoplatform.documents.model.DocumentNodeFilter;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -25,9 +25,9 @@ import javax.jcr.version.Version;
 
 import org.apache.commons.lang3.StringUtils;
 
-import org.exoplatform.commons.api.search.data.SearchResult;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.documents.constant.DocumentSortField;
+import org.exoplatform.documents.legacy.search.data.SearchResult;
 import org.exoplatform.documents.model.*;
 import org.exoplatform.documents.storage.JCRDeleteFileStorage;
 import org.exoplatform.documents.storage.jcr.search.DocumentFileSearchResult;

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/TrashStorageImplTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/TrashStorageImplTest.java
@@ -16,7 +16,29 @@
 */
 package org.exoplatform.documents.storage.jcr;
 
-import org.exoplatform.container.PortalContainer;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Property;
+import javax.jcr.Session;
+import javax.jcr.Workspace;
+import javax.jcr.nodetype.NodeType;
+
+import org.gatein.pc.api.PortletInvokerException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.PropertiesParam;
 import org.exoplatform.container.xml.ValueParam;
@@ -35,19 +57,6 @@ import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;
-import org.gatein.pc.api.PortletInvokerException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import javax.jcr.*;
-import javax.jcr.nodetype.NodeType;
-
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TrashStorageImplTest {
@@ -69,8 +78,6 @@ public class TrashStorageImplTest {
 
   private ListenerService listenerService;
 
-  private InitParams initParams;
-
   private TrashStorageImpl trashStorage;
 
 
@@ -84,7 +91,6 @@ public class TrashStorageImplTest {
     repositoryEntry = mock(RepositoryEntry.class);
     sessionProvider = mock(SessionProvider.class);
     session = mock(Session.class);
-    initParams = mock(InitParams.class);
     trashStorage = new TrashStorageImpl(repositoryService, sessionProviderService, listenerService, getParams());
   }
   @Test

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -16,50 +16,63 @@
  */
 package org.exoplatform.documents.storage.jcr.util;
 
-import org.apache.commons.lang3.StringUtils;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.List;
+
+import javax.jcr.NodeIterator;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import javax.jcr.ValueFormatException;
+import javax.jcr.nodetype.NodeType;
+import javax.jcr.version.Version;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.documents.model.AbstractNode;
 import org.exoplatform.documents.model.FileNode;
-
 import org.exoplatform.documents.storage.JCRDeleteFileStorage;
 import org.exoplatform.services.jcr.access.AccessControlList;
 import org.exoplatform.services.jcr.core.ExtendedNode;
 import org.exoplatform.services.jcr.core.ExtendedSession;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
-import org.exoplatform.services.jcr.impl.core.SessionImpl;
 import org.exoplatform.services.jcr.impl.core.value.StringValue;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.spi.SpaceService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-import javax.jcr.*;
-import javax.jcr.nodetype.NodeType;
-import javax.jcr.version.Version;
-
-import java.io.IOException;
-import java.util.*;
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
-
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({ "javax.management.*" })
-@PrepareForTest({ CommonsUtils.class})
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class JCRDocumentsUtilTest {
-  
+
+  private static final MockedStatic<CommonsUtils>        COMMONS_UTILS_UTIL    = mockStatic(CommonsUtils.class);
+
+  @AfterClass
+  public static void afterRunBare() throws Exception { // NOSONAR
+    COMMONS_UTILS_UTIL.close();
+  }
+
   @Before
   public void setUp() throws Exception {
-    PowerMockito.mockStatic(CommonsUtils.class);
     JCRDeleteFileStorage jcrDeleteFileStorage = mock(JCRDeleteFileStorage.class);
-    when(CommonsUtils.getService(JCRDeleteFileStorage.class)).thenReturn(jcrDeleteFileStorage);
+    COMMONS_UTILS_UTIL.when(() -> CommonsUtils.getService(JCRDeleteFileStorage.class)).thenReturn(jcrDeleteFileStorage);
   }
+
   @Test
   public void testRetrieveFileProperties() throws IOException, RepositoryException {
     IdentityManager identityManager = mock(IdentityManager.class);


### PR DESCRIPTION
Prior to this change, the service testing was using powermock which is useless and restrictive in term of third party libraries dependency tree (complex to maintain with Java versions higher than JDK11). In addition, the dependency tree has been cleaned up as well to transitively import dependencies for compilation and test scope.