### PR TITLE
fix : Fix wrong visibility information when share document with another space - EXO-62495 (#795)

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
@@ -86,7 +86,7 @@ export default {
       const collaborators = this.file.acl.collaborators;
       if (spaceIdentityId && collaborators.length > 0){
         for (const collaborator of collaborators) {
-          if (collaborator.identity.id === spaceIdentityId && collaborator.identity.name === spaceName) {
+          if (collaborator.identity.id === spaceIdentityId && collaborator.identity.remoteId === spaceName) {
             return true;
           }
         }


### PR DESCRIPTION
In the previews commit (#784) we were fixed the visibility rules when sharing a folder with another space . This new change will correct the incorrect visibility information for documents in a shared folder