### PR TITLE
fix : Disable the ability to open the access manage drawer when the sharing of documents is suspended  - EXO-62870

### DIFF
--- a/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
+++ b/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
@@ -93,6 +93,7 @@ documents.label.visibility=Manage access
 documents.label.visibilityTitle=Manage Access to : {0}
 documents.label.saveVisibility.success=Access successfully updated
 documents.label.saveVisibility.error=Update of the access failed
+documents.label.share.document.suspend=Administrators have locked the ability to share a document
 documents.label.owner=Owner
 documents.label.apply=Save
 documents.label.visibility.choice=Who can access this document?

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
@@ -16,7 +16,7 @@
         </v-icon>
       </v-btn>
     </template>
-    <span class="center">{{ icon.title }}</span>
+    <span class="center">{{ sharedDocumentSuspended ? sharedDocumentSuspendedLabel : icon.title }}</span>
   </v-tooltip>
 </template>
 
@@ -34,6 +34,7 @@ export default {
   },
   data: () => ({
     unit: 'bytes',
+    sharedDocumentSuspended: true,
   }),
   computed: {
     icon() {
@@ -92,11 +93,19 @@ export default {
         }
       }
       return false;
+    },
+    sharedDocumentSuspendedLabel(){
+      return this.$t('documents.label.share.document.suspend');
     }
+  },
+  created() {
+    this.$transferRulesService.getDocumentsTransferRules().then(rules => {
+      this.sharedDocumentSuspended = rules.sharedDocumentStatus === 'true';
+    });
   },
   methods: {
     changeVisibility() {
-      if (!this.file.acl.canEdit) {
+      if (!this.file.acl.canEdit || this.sharedDocumentSuspended) {
         return;
       }
       this.$root.$emit('open-visibility-drawer', this.file);


### PR DESCRIPTION
This change is going to disable the management access icon from begin clickable when the sharing documents is suspended.