### PR TITLE
fix: fix documents lost after shortcut and move actions - EXO-63061

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -183,7 +183,7 @@ public class JCRDocumentsUtil {
           sourceID = node.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString();
           sourceNode = getNodeByIdentifier(session, sourceID);
           if (sourceNode == null) {
-            break;
+            continue;
           }
         }
         if ((sourceNode.isNodeType(NodeTypeConstants.NT_FOLDER) || sourceNode.isNodeType(NodeTypeConstants.NT_UNSTRUCTURED))

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -16,6 +16,7 @@
  */
 package org.exoplatform.documents.storage.jcr.util;
 
+import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.getNodeByIdentifier;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -29,14 +30,11 @@ import java.io.IOException;
 import java.util.Calendar;
 import java.util.List;
 
-import javax.jcr.NodeIterator;
-import javax.jcr.Property;
-import javax.jcr.RepositoryException;
-import javax.jcr.Value;
-import javax.jcr.ValueFormatException;
+import javax.jcr.*;
 import javax.jcr.nodetype.NodeType;
 import javax.jcr.version.Version;
 
+import org.exoplatform.services.jcr.impl.core.SessionImpl;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -229,4 +227,44 @@ public class JCRDocumentsUtilTest {
     assertEquals("document-test.pdf", fileNodes.get(0).getName());
     assertEquals("second-document-test.pdf", fileNodes.get(1).getName());
   }
-}
+  @Test
+  public void testToNodes() throws RepositoryException {
+    IdentityManager identityManager = mock(IdentityManager.class);
+    SpaceService spaceService = mock(SpaceService.class);
+    Identity identity = mock(Identity.class);
+    NodeIterator nodeIterator = mock(NodeIterator.class);
+    SessionImpl session= mock(SessionImpl.class);
+    NodeImpl file1 = mock(NodeImpl.class);
+    NodeImpl file2 = mock(NodeImpl.class);
+    ExtendedSession extendedSession = mock(ExtendedSession.class);
+
+    //when
+    when(nodeIterator.hasNext()).thenReturn(true, false);
+    when(nodeIterator.nextNode()).thenReturn(file1);
+    when(file1.isNodeType(NodeTypeConstants.EXO_SYMLINK)).thenReturn(true);
+    Property symlinkUUID1 = mock(Property.class);
+    when(symlinkUUID1.getString()).thenReturn("file1Identifier");
+    when(file1.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID)).thenReturn(symlinkUUID1);
+    when(extendedSession.getNodeByIdentifier("file1Identifier")).thenReturn(null);
+    //then
+    List <AbstractNode> listNodes1 = JCRDocumentsUtil.toNodes(identityManager, extendedSession, nodeIterator, identity, spaceService,false);
+    assertEquals(0, listNodes1.size());
+
+    //when
+    when(file2.isNodeType(NodeTypeConstants.EXO_SYMLINK)).thenReturn(true);
+    Property symlinkUUID2 = mock(Property.class);
+    when(symlinkUUID2.getString()).thenReturn("file2Identifier");
+    when(file2.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID)).thenReturn(symlinkUUID2);
+    when(extendedSession.getNodeByIdentifier("file2Identifier")).thenReturn(file2);
+    when(file2.isNodeType(NodeTypeConstants.NT_FILE)).thenReturn(true);
+    when(file2.getSession()).thenReturn(session);
+    NodeType filePrimaryNT = mock(NodeType.class);
+    when(file2.getPrimaryNodeType()).thenReturn(filePrimaryNT);
+    when(file2.getPrimaryNodeType().getName()).thenReturn("");
+    when(nodeIterator.hasNext()).thenReturn(true, true, false);
+    when(nodeIterator.nextNode()).thenReturn(file1, file2);
+    //then
+    List <AbstractNode> listNodes2 = JCRDocumentsUtil.toNodes(identityManager, extendedSession, nodeIterator, identity, spaceService,false);
+    assertEquals(1, listNodes2.size());
+  }
+  }


### PR DESCRIPTION
Prior to this fix, when we move and create a new version of a document that has a shortcut in the same place, we lose the documents and the newly created documents are not displayed, which is due to the deletion of the source node of the shortcut.
After this change, the version is created and displayed in the dedicated folder and all newly created documents are displayed. 