### PR TITLE
fix: Redirection issue when sharing a folder - EXO-63010 (#801)

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/listener/ShareDocumentNotificationListener.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/listener/ShareDocumentNotificationListener.java
@@ -54,12 +54,12 @@ public class ShareDocumentNotificationListener extends Listener<Identity, Node> 
     NotificationContext ctx = NotificationContextImpl.cloneInstance();
     String documentLink = null;
     if (targetNode.hasProperty(EXO_SYMLINK_UUID)) {
-      documentLink = NotificationUtils.getSharedDocumentLink(((NodeImpl) targetNode).getIdentifier(), null, null);
+      documentLink = NotificationUtils.getSharedDocumentLink(targetNode, null, null);
     } else {
       documentLink = NotificationUtils.getDocumentLink(targetNode, spaceService, identityManager);
     }
     if (targetIdentity.getProviderId().equals(SpaceIdentityProvider.NAME)) {
-      documentLink = NotificationUtils.getSharedDocumentLink(targetNode.getProperty(EXO_SYMLINK_UUID).getString(),
+      documentLink = NotificationUtils.getSharedDocumentLink(targetNode,
                                                              spaceService,
                                                              targetIdentity.getRemoteId());
     }

--- a/documents-services/src/main/java/org/exoplatform/documents/notification/utils/NotificationUtils.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/notification/utils/NotificationUtils.java
@@ -19,6 +19,7 @@ package org.exoplatform.documents.notification.utils;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.documents.rest.util.EntityBuilder;
 import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
@@ -29,10 +30,15 @@ import org.exoplatform.social.core.space.spi.SpaceService;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 
 public class NotificationUtils {
 
-  public static final String JCR_CONTENT            = "jcr:content";
+  public static final String JCR_CONTENT      = "jcr:content";
+
+  public static final String EXO_SYMLINK_UUID = "exo:uuid";
+
+  public static final String NT_FILE          = "nt:file";
 
   public static String getDocumentLink(Node node, SpaceService spaceService, IdentityManager identityManager) throws RepositoryException {
     StringBuilder stringBuilder = new StringBuilder();
@@ -52,7 +58,7 @@ public class NotificationUtils {
     return stringBuilder.toString() ;
   }
 
-  public static String getSharedDocumentLink(String nodeUuid, SpaceService spaceService, String spacePrettyName) {
+  public static String getSharedDocumentLink(Node sharedNode, SpaceService spaceService, String spacePrettyName) throws RepositoryException {
     StringBuilder stringBuilder = new StringBuilder();
     String portalOwner = CommonsUtils.getCurrentPortalOwner();
     String domain = CommonsUtils.getCurrentDomain();
@@ -62,16 +68,17 @@ public class NotificationUtils {
     if (spaceService!= null && spacePrettyName != null) {
       Space space = spaceService.getSpaceByPrettyName(spacePrettyName);
       String groupId = space.getGroupId().replace("/", ":");
-      stringBuilder.append("g/")
-                   .append(groupId)
-                   .append("/")
-                   .append(spacePrettyName)
-                   .append("/documents/Shared?documentPreviewId=");
+      stringBuilder.append("g/").append(groupId).append("/").append(spacePrettyName).append("/documents");
     } else {
-      stringBuilder.append(portalOwner)
-                   .append("/documents/Private/Documents/Shared?documentPreviewId=");
+      stringBuilder.append(portalOwner).append("/documents/Private/Documents");
     }
-    stringBuilder.append(nodeUuid);
+    boolean isTargetNodeFile = isNodeFile(sharedNode);
+    if (isTargetNodeFile) {
+      stringBuilder.append("?documentPreviewId=");
+    } else {
+      stringBuilder.append("?folderId=");
+    }
+    stringBuilder.append(((NodeImpl) sharedNode).getIdentifier());
     return stringBuilder.toString();
   }
 
@@ -95,5 +102,12 @@ public class NotificationUtils {
   public static Profile getUserProfile(IdentityManager identityManager, String userName) {
     Identity identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, userName);
     return identity.getProfile();
+  }
+
+  public static boolean isNodeFile(Node node) throws RepositoryException {
+      Session session = node.getSession();
+      Node targetNode = session.getNodeByUUID(node.getProperty(EXO_SYMLINK_UUID).getString());
+      return targetNode.isNodeType(NT_FILE);
+
   }
 }


### PR DESCRIPTION
prior to this change, after sharing a folder when clicking on sharing notification the user is not directed inside the shared folder since the URL redirection is only for attachments (documentPreviewId: for previewing attachments" after this change, the URL is well built with documentPreviewId for attachments and folderId for folders