### PR TITLE
fix: Redirection issue when sharing a folder - EXO-63010 (#801)

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/listener/ShareDocumentNotificationListener.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/listener/ShareDocumentNotificationListener.java
@@ -54,12 +54,12 @@ public class ShareDocumentNotificationListener extends Listener<Identity, Node> 
     NotificationContext ctx = NotificationContextImpl.cloneInstance();
     String documentLink = null;
     if (targetNode.hasProperty(EXO_SYMLINK_UUID)) {
-      documentLink = NotificationUtils.getSharedDocumentLink(((NodeImpl) targetNode).getIdentifier(), null, null);
+      documentLink = NotificationUtils.getSharedDocumentLink(targetNode, null, null);
     } else {
       documentLink = NotificationUtils.getDocumentLink(targetNode, spaceService, identityManager);
     }
     if (targetIdentity.getProviderId().equals(SpaceIdentityProvider.NAME)) {
-      documentLink = NotificationUtils.getSharedDocumentLink(targetNode.getProperty(EXO_SYMLINK_UUID).getString(),
+      documentLink = NotificationUtils.getSharedDocumentLink(targetNode,
                                                              spaceService,
                                                              targetIdentity.getRemoteId());
     }

--- a/documents-services/src/main/java/org/exoplatform/documents/notification/utils/NotificationUtils.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/notification/utils/NotificationUtils.java
@@ -19,6 +19,7 @@ package org.exoplatform.documents.notification.utils;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.documents.rest.util.EntityBuilder;
 import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
@@ -29,10 +30,15 @@ import org.exoplatform.social.core.space.spi.SpaceService;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 
 public class NotificationUtils {
 
-  public static final String JCR_CONTENT            = "jcr:content";
+  public static final String JCR_CONTENT      = "jcr:content";
+
+  public static final String EXO_SYMLINK_UUID = "exo:uuid";
+
+  public static final String NT_FILE          = "nt:file";
 
   public static String getDocumentLink(Node node, SpaceService spaceService, IdentityManager identityManager) throws RepositoryException {
     StringBuilder stringBuilder = new StringBuilder();
@@ -52,7 +58,7 @@ public class NotificationUtils {
     return stringBuilder.toString() ;
   }
 
-  public static String getSharedDocumentLink(String nodeUuid, SpaceService spaceService, String spacePrettyName) {
+  public static String getSharedDocumentLink(Node sharedNode, SpaceService spaceService, String spacePrettyName) throws RepositoryException {
     StringBuilder stringBuilder = new StringBuilder();
     String portalOwner = CommonsUtils.getCurrentPortalOwner();
     String domain = CommonsUtils.getCurrentDomain();
@@ -62,16 +68,17 @@ public class NotificationUtils {
     if (spaceService!= null && spacePrettyName != null) {
       Space space = spaceService.getSpaceByPrettyName(spacePrettyName);
       String groupId = space.getGroupId().replace("/", ":");
-      stringBuilder.append("g/")
-                   .append(groupId)
-                   .append("/")
-                   .append(spacePrettyName)
-                   .append("/documents/Shared?documentPreviewId=");
+      stringBuilder.append("g/").append(groupId).append("/").append(spacePrettyName).append("/documents");
     } else {
-      stringBuilder.append(portalOwner)
-                   .append("/documents/Private/Documents/Shared?documentPreviewId=");
+      stringBuilder.append(portalOwner).append("/documents/Private/Documents");
     }
-    stringBuilder.append(nodeUuid);
+    boolean isTargetNodeFile = isNodeFile(sharedNode);
+    if (isTargetNodeFile) {
+      stringBuilder.append("?documentPreviewId=");
+    } else {
+      stringBuilder.append("?folderId=");
+    }
+    stringBuilder.append(((NodeImpl) sharedNode).getIdentifier());
     return stringBuilder.toString();
   }
 
@@ -95,5 +102,12 @@ public class NotificationUtils {
   public static Profile getUserProfile(IdentityManager identityManager, String userName) {
     Identity identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, userName);
     return identity.getProfile();
+  }
+
+  public static boolean isNodeFile(Node node) throws RepositoryException {
+      Session session = node.getSession();
+      Node targetNode = session.getNodeByUUID(node.getProperty(EXO_SYMLINK_UUID).getString());
+      return targetNode.isNodeType(NT_FILE);
+
   }
 }

--- a/documents-services/src/test/java/org/exoplatform/documents/listener/ShareDocumentNotificationListenerTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/listener/ShareDocumentNotificationListenerTest.java
@@ -9,6 +9,7 @@ import org.exoplatform.commons.notification.impl.NotificationContextImpl;
 import org.exoplatform.commons.notification.impl.setting.NotificationPluginContainer;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.documents.notification.plugin.AddDocumentCollaboratorPlugin;
+import org.exoplatform.documents.notification.utils.NotificationUtils;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.security.ConversationState;
@@ -32,6 +33,7 @@ import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.Value;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -39,7 +41,7 @@ import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore({ "javax.management.*" })
-@PrepareForTest({CommonsUtils.class, ConversationState.class, NotificationContextImpl.class, PluginKey.class, LinkProvider.class})
+@PrepareForTest({CommonsUtils.class, ConversationState.class, NotificationContextImpl.class, PluginKey.class, LinkProvider.class, NotificationUtils.class})
 public class ShareDocumentNotificationListenerTest {
 
 
@@ -75,6 +77,7 @@ public class ShareDocumentNotificationListenerTest {
     PowerMockito.mockStatic(CommonsUtils.class);
     PowerMockito.mockStatic(LinkProvider.class);
     PowerMockito.mockStatic(PluginKey.class);
+    PowerMockito.mockStatic(NotificationUtils.class);
     ConversationState conversationState = mock(ConversationState.class);
     when(ConversationState.getCurrent()).thenReturn(conversationState);
     org.exoplatform.services.security.Identity identity = Mockito.mock(org.exoplatform.services.security.Identity.class);
@@ -113,6 +116,9 @@ public class ShareDocumentNotificationListenerTest {
     when(targetNode.getProperty("exo:title")).thenReturn(propertyTitle);
     when(targetIdentity.getRemoteId()).thenReturn("user");
     when(targetNode.hasProperty("exo:uuid")).thenReturn(true);
+    when(NotificationUtils.isNodeFile(any(Node.class))).thenReturn(true);
+    when(NotificationUtils.getSharedDocumentLink(any(Node.class), any(), any())).thenReturn("document/link");
+    when(NotificationUtils.getDocumentTitle(any(Node.class))).thenReturn("document");
     shareDocumentNotificationListener.onEvent(event);
     verifyStatic(PluginKey.class, times(1));
     PluginKey.key(AddDocumentCollaboratorPlugin.ID);

--- a/documents-services/src/test/java/org/exoplatform/documents/notification/utils/NotificationUtilsTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/notification/utils/NotificationUtilsTest.java
@@ -1,9 +1,25 @@
 package org.exoplatform.documents.notification.utils;
 
 
+import static org.exoplatform.documents.notification.utils.NotificationUtils.EXO_SYMLINK_UUID;
+import static org.exoplatform.documents.notification.utils.NotificationUtils.NT_FILE;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+import org.exoplatform.services.jcr.impl.core.SessionImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.documents.rest.util.EntityBuilder;
 import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
@@ -11,11 +27,6 @@ import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.service.LinkProvider;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -26,9 +37,6 @@ import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore({ "javax.management.*" })
@@ -70,14 +78,29 @@ public class NotificationUtilsTest {
     assertEquals("http://domain/portal/g/:spaces:spacex/spacex/documents?documentPreviewId=123", link);
   }
   @Test
-  public void getSharedDocumentLink() {
+  public void getSharedDocumentLink() throws RepositoryException {
     Space space = new Space();
     space.setGroupId("/spaces/spacename");
     when(spaceService.getSpaceByPrettyName("space_name")).thenReturn(space);
-    String link = NotificationUtils.getSharedDocumentLink("123", null,null);
-    assertEquals("http://domain/portal/dw/documents/Private/Documents/Shared?documentPreviewId=123", link);
-    String link1 = NotificationUtils.getSharedDocumentLink("123", spaceService,"space_name");
-    assertEquals("http://domain/portal/g/:spaces:spacename/space_name/documents/Shared?documentPreviewId=123", link1);
+    SessionImpl session = Mockito.mock(SessionImpl.class);
+    Node node = Mockito.mock(NodeImpl.class);
+    Node targetNode = Mockito.mock(NodeImpl.class);
+    Property property = Mockito.mock(Property.class);
+    when(((NodeImpl) node).getIdentifier()).thenReturn("123");
+    when(node.getSession()).thenReturn(session);
+    when(node.getProperty(EXO_SYMLINK_UUID)).thenReturn(property);
+    when(property.getString()).thenReturn("id123");
+    when(session.getNodeByUUID(anyString())).thenReturn(targetNode);
+    when(targetNode.isNodeType(NT_FILE)).thenReturn(true);
+    String link = NotificationUtils.getSharedDocumentLink(node, null,null);
+    assertEquals("http://domain/portal/dw/documents/Private/Documents?documentPreviewId=123", link);
+    link = NotificationUtils.getSharedDocumentLink(node, spaceService,"space_name");
+    assertEquals("http://domain/portal/g/:spaces:spacename/space_name/documents?documentPreviewId=123", link);
+    when(targetNode.isNodeType(NT_FILE)).thenReturn(false);
+    link = NotificationUtils.getSharedDocumentLink(node, null,null);
+    assertEquals("http://domain/portal/dw/documents/Private/Documents?folderId=123", link);
+    link = NotificationUtils.getSharedDocumentLink(node, spaceService,"space_name");
+    assertEquals("http://domain/portal/g/:spaces:spacename/space_name/documents?folderId=123", link);
   }
 
   @Test


### PR DESCRIPTION
prior to this change, after sharing a folder when clicking on sharing notification the user is not directed inside the shared folder since the URL redirection is only for attachments (documentPreviewId: for previewing attachments" after this change, the URL is well built with documentPreviewId for attachments and folderId for folders