### PR TITLE
fix : Adding documents and folders in a read only shared folder should not be possible - EXO-63084

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsAddNewFile.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsAddNewFile.vue
@@ -97,7 +97,7 @@ export default {
       return this.selectedView === 'folder';
     },
     disableButton(){
-      return this.currentFolder && this.currentFolder.accessPermissions && this.currentFolder.accessPermissions.canEdit === false ;
+      return this.currentFolder && this.currentFolder.accessList && this.currentFolder.accessList.canEdit === false ;
     }
   },
   created() {


### PR DESCRIPTION
This change is going to disallow the ability to add a new folder inside a shared folder with read only permission