### PR TITLE
fix: Create/upload a document in My Drive is automatically done in Public folder - EXO-63311

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -917,11 +917,12 @@ export default {
           name: 'Personal Documents',
           title: 'Personal Documents'
         };
+        attachmentAppConfiguration.defaultFolder = '/';
         let pathparts = window.location.pathname.split(`${eXo.env.portal.selectedNodeUri}/`);
         if (pathparts.length > 1 && pathparts[1].startsWith('Private/')){
           pathparts = pathparts[1].split('Private/');
         }
-        if (pathparts.length>1){
+        if (pathparts.length > 1) {
           attachmentAppConfiguration.defaultFolder = `${this.extractDefaultFolder(true)}`;
         }
       }


### PR DESCRIPTION
Prior to this change, When upload or create a document in root path of the personal drive, the document is automatically created inside the public folder because the `defaultFolder` param wasn't specified in this case case, so the attachment drawer assign the public folder as a value of the undefined defaultFolder. 
This PR ensures to set the root path as default value of the defaultFolder param.