### PR TITLE
fix: Document not visible in recent view after empty the description - EXO-63280

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -400,7 +400,8 @@ public class JCRDocumentsUtil {
   }
 
   public static void retrieveFileContentProperties(Node content, FileNode fileNode) throws RepositoryException {
-    if (content.hasProperty(NodeTypeConstants.DC_DESCRIPTION)) {
+    if (content.hasProperty(NodeTypeConstants.DC_DESCRIPTION)
+        && content.getProperty(NodeTypeConstants.DC_DESCRIPTION).getValues().length > 0) {
       fileNode.setDescription(content.getProperty(NodeTypeConstants.DC_DESCRIPTION).getValues()[0].getString());
     }
     if (content.hasProperty(NodeTypeConstants.JCR_MIME_TYPE)) {

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -10,10 +10,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
@@ -31,7 +28,9 @@ import javax.jcr.version.VersionIterator;
 
 import org.exoplatform.services.jcr.access.AccessControlEntry;
 import org.exoplatform.services.jcr.access.PermissionType;
-import org.exoplatform.services.security.MembershipEntry;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.metadata.tag.TagService;
+import org.exoplatform.social.metadata.tag.model.TagName;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -111,6 +110,9 @@ public class JCRDocumentFileStorageTest {
 
   @Mock
   private ActivityManager                activityManager;
+  
+  @Mock
+  private TagService                     tagService;
 
 
   private JCRDocumentFileStorage         jcrDocumentFileStorage;
@@ -756,5 +758,48 @@ public class JCRDocumentFileStorageTest {
     assertEquals(false, accessList1.isEmpty());
     assertEquals(true, accessList1.get("canAccess"));
     assertEquals(true, accessList1.get("canEdit"));
+  }
+
+  @Test
+  public void updateDocumentDescription() throws RepositoryException {
+    org.exoplatform.services.security.Identity identity = mock(org.exoplatform.services.security.Identity.class);
+    when(identity.getUserId()).thenReturn("user");
+    ManageableRepository manageableRepository = mock(ManageableRepository.class);
+    lenient().when(repositoryService.getCurrentRepository()).thenReturn(manageableRepository);
+    Session session = mock(Session.class);
+    SessionProvider sessionProvider = mock(SessionProvider.class);
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getUserSessionProvider(repositoryService, identity))
+                      .thenReturn(sessionProvider);
+    lenient().when(sessionProvider.getSession("collaboration", manageableRepository)).thenReturn(session);
+    ExtendedNode node = mock(ExtendedNode.class);
+    Node contentNode = mock(Node.class);
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getNodeByIdentifier(session, "123")).thenReturn(node);
+    lenient().when(node.canAddMixin(NodeTypeConstants.EXO_MODIFY)).thenReturn(true);
+    lenient().when(node.canAddMixin(NodeTypeConstants.DC_ELEMENT_SET)).thenReturn(true);
+    lenient().when(node.hasProperty(NodeTypeConstants.DC_DESCRIPTION)).thenReturn(false);
+    lenient().when(node.hasNode(NodeTypeConstants.JCR_CONTENT)).thenReturn(true);
+    lenient().when(node.getNode(NodeTypeConstants.JCR_CONTENT)).thenReturn(contentNode);
+    lenient().when(node.getSession()).thenReturn(session);
+    COMMONS_UTILS_UTIL.when(() -> CommonsUtils.getService(TagService.class)).thenReturn(tagService);
+    Set<TagName> tagNames = new HashSet<>();
+    tagNames.add(new TagName("test"));
+    lenient().when(tagService.detectTagNames(anyString())).thenReturn(tagNames);
+    lenient().when(node.getPath()).thenReturn("path");
+    Identity audienceIdentity = mock(Identity.class);
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getOwnerIdentityFromNodePath("path", identityManager, spaceService))
+                      .thenReturn(audienceIdentity);
+    lenient().when(audienceIdentity.getProviderId()).thenReturn("space");
+    Space space = new Space();
+    space.setId("1");
+    lenient().when(audienceIdentity.getRemoteId()).thenReturn("testSpace");
+    lenient().when(audienceIdentity.getId()).thenReturn("1");
+    Identity userIdentity = mock(Identity.class);
+    lenient().when(userIdentity.getId()).thenReturn("1");
+    lenient().when(identityManager.getOrCreateUserIdentity("user")).thenReturn(userIdentity);
+    lenient().when(spaceService.getSpaceByPrettyName("testSpace")).thenReturn(space);
+    lenient().when(node.getIdentifier()).thenReturn("123");
+    this.jcrDocumentFileStorage.updateDocumentDescription(1L, "123", "test description", identity);
+    verify(session, times(1)).save();
+    verify(sessionProvider, times(1)).close();
   }
 }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -20,11 +20,7 @@ import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.getNod
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.util.Calendar;
@@ -266,5 +262,38 @@ public class JCRDocumentsUtilTest {
     //then
     List <AbstractNode> listNodes2 = JCRDocumentsUtil.toNodes(identityManager, extendedSession, nodeIterator, identity, spaceService,false);
     assertEquals(1, listNodes2.size());
+  }
+
+  @Test
+  public void retrieveFileContentProperties() throws RepositoryException, IOException {
+    Node contentNode = mock(Node.class);
+    FileNode fileNode = mock(FileNode.class);
+
+    lenient().when(contentNode.hasProperty(NodeTypeConstants.DC_DESCRIPTION)).thenReturn(true);
+    lenient().when(contentNode.hasProperty(NodeTypeConstants.JCR_MIME_TYPE)).thenReturn(true);
+    lenient().when(contentNode.hasProperty(NodeTypeConstants.JCR_DATA)).thenReturn(true);
+
+    Property descriptionProperty = mock(Property.class);
+    Property mimeTypeProperty = mock(Property.class);
+    Property dataProperty = mock(Property.class);
+
+    lenient().when(contentNode.getProperty(NodeTypeConstants.DC_DESCRIPTION)).thenReturn(descriptionProperty);
+    lenient().when(contentNode.getProperty(NodeTypeConstants.JCR_MIME_TYPE)).thenReturn(mimeTypeProperty);
+    lenient().when(contentNode.getProperty(NodeTypeConstants.JCR_DATA)).thenReturn(dataProperty);
+
+    lenient().when(descriptionProperty.getValues()).thenReturn(new Value[0]);
+    lenient().when(mimeTypeProperty.getString()).thenReturn("application/pdf");
+    lenient().when(dataProperty.getLength()).thenReturn(1024L);
+    
+    JCRDocumentsUtil.retrieveFileContentProperties(contentNode, fileNode);
+
+    verify(fileNode, times(0)).setDescription(anyString());
+    verify(fileNode, times(1)).setMimeType(anyString());
+    verify(fileNode, times(1)).setSize(anyLong());
+
+    lenient().when(descriptionProperty.getValues()).thenReturn(new Value[] { new StringValue("test description") });
+    JCRDocumentsUtil.retrieveFileContentProperties(contentNode, fileNode);
+
+    verify(fileNode, times(1)).setDescription(anyString());
   }
   }


### PR DESCRIPTION
Prior to this change, After creation a document a fill the description and empty it again, the document disappears from recent view because of a missing check on description property leads to and `ArrayOutOfBoundException`.
This PR ensures that the multi-valued description property array is not empty before accessing its elements