### PR TITLE
fix: Document-Alignment issue with the column Access - EXO-62971 (#808)

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
@@ -2,7 +2,8 @@
   <v-tooltip bottom>
     <template #activator="{ on, attrs }">
       <v-btn
-        class="ms-2 visibility-btn"
+        class="visibility-btn"
+        :class="btnClass"
         icon
         @click="changeVisibility">
         <v-icon
@@ -30,7 +31,11 @@ export default {
     selectedView: {
       type: String,
       default: null
-    }
+    },
+    isMobile: {
+      type: Boolean,
+      default: false
+    },
   },
   data: () => ({
     unit: 'bytes',
@@ -92,6 +97,9 @@ export default {
         }
       }
       return false;
+    },
+    btnClass(){
+      return this.isMobile && 'ms-2' || 'me-4' ;
     }
   },
   methods: {


### PR DESCRIPTION
prior to this change, the column Access is not aligned with the icon below after this change, the icon and the column access are aligned

(cherry picked from commit d4963ffa04764d5b7db8d046f317727c5738e8c3)