### PR TITLE
fix: load correctly contents of folder : subfolders then files with symlinks included - EXO-62645

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -961,7 +961,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
             .append(folderPath)
             .append("/%/%' ")
             .append(hiddenableQuery)
-            .append(" ORDER BY jcr:primaryType DESC,")
+            .append(" ORDER BY ")
             .append(sortField)
             .append(" ")
             .append(sortDirection)

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -319,7 +319,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
           //((QueryImpl)jcrQuery).setLimit(limit);
           QueryResult queryResult = jcrQuery.execute();
           NodeIterator nodeIterator = queryResult.getNodes();
-          List<AbstractNode> fileItems = toNodes(identityManager, session, nodeIterator, aclIdentity, spaceService, includeHiddenFiles);
+          List<AbstractNode> fileItems = toNodes(identityManager, session, nodeIterator, aclIdentity, spaceService, limit, includeHiddenFiles);
           if(fileItems.size() < limit) {
             limit = fileItems.size();
           }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -172,6 +172,7 @@ public class JCRDocumentsUtil {
                                            NodeIterator nodeIterator,
                                            Identity aclIdentity,
                                            SpaceService spaceService,
+                                           int limit,
                                            boolean includeHiddenFiles) {
     List<AbstractNode> fileNodes = new ArrayList<>();
     while (nodeIterator.hasNext()) {
@@ -196,6 +197,9 @@ public class JCRDocumentsUtil {
           FileNode fileNode = toFileNode(identityManager, aclIdentity, node, sourceID, spaceService);
           fileNode.setMimeType(getMimeType(sourceNode));
           fileNodes.add(fileNode);
+        }
+        if(limit > 0 && fileNodes.size() == limit) {
+          break;
         }
       } catch (RepositoryException e) {
         LOG.warn("Error getting Folder Node for search result with path {}", node, e);

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -202,6 +202,15 @@ public class JCRDocumentsUtil {
       }
     }
 
+    fileNodes.sort((o1, o2) -> {
+      if ((o1.isFolder() && o2.isFolder()) || (!o1.isFolder() && !o2.isFolder())) {
+        return o1.getName().compareTo(o2.getName());
+      } else if (o1.isFolder()) {
+        return -1;
+      } else {
+        return 1;
+      }
+    });
     return fileNodes;
   }
 

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDeleteFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDeleteFileStorageTest.java
@@ -172,6 +172,7 @@ public class JCRDeleteFileStorageTest {
     when(node.isCheckedOut()).thenReturn(true);
     when(trashStorage.moveToTrash(node, sessionProvider)).thenReturn(trashId);
     when(trashStorage.getNodeByTrashId(trashId)).thenReturn(node);
+    when(nodeType.getName()).thenReturn(NodeTypeConstants.NT_FILE);
     when(node.getPrimaryNodeType()).thenReturn(nodeType);
 
     jcrDeleteFileStorage.deleteDocument(path ,"1", false, true, 0, userID,  currentOwnerId);

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -10,10 +10,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
@@ -31,11 +28,8 @@ import javax.jcr.version.VersionIterator;
 
 import org.exoplatform.services.jcr.access.AccessControlEntry;
 import org.exoplatform.services.jcr.access.PermissionType;
-import org.exoplatform.services.security.MembershipEntry;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
+import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -116,7 +110,7 @@ public class JCRDocumentFileStorageTest {
   private JCRDocumentFileStorage         jcrDocumentFileStorage;
 
   @AfterClass
-  public static void afterRunBare() throws Exception { // NOSONAR
+  public static void afterRunBare() {
     JCR_DOCUMENTS_UTIL.close();
     UTILS.close();
     SESSION_PROVIDER.close();
@@ -125,7 +119,7 @@ public class JCRDocumentFileStorageTest {
   }
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     this.jcrDocumentFileStorage = new JCRDocumentFileStorage(nodeHierarchyCreator,
                                                              repositoryService,
                                                              documentSearchServiceConnector,
@@ -279,44 +273,54 @@ public class JCRDocumentFileStorageTest {
     folderWithSpecificName.setName("15f");
     FolderNode folderWithSpecificName1 = new FolderNode();
     folderWithSpecificName1.setName("16L");
-    when(nodeIterator.hasNext()).thenReturn(true, true, false);
-    Node fileNode = mock(Node.class);
-    Node folderNode1 = mock(Node.class);
-    Node folderNode2 = mock(Node.class);
-    Node folderNode3 = mock(Node.class);
-    Node folderNode4 = mock(Node.class);
-    Node folderNode5 = mock(Node.class);
+    NodeImpl fileNode = mock(NodeImpl.class);
+    NodeImpl folderNode1 = mock(NodeImpl.class);
+    NodeImpl folderNode2 = mock(NodeImpl.class);
+    NodeImpl folderNode3 = mock(NodeImpl.class);
+    NodeImpl folderNode4 = mock(NodeImpl.class);
+    NodeImpl folderNode5 = mock(NodeImpl.class);
     when(fileNode.isNodeType(NodeTypeConstants.NT_FILE)).thenReturn(true);
+    AccessControlList accessControlList = mock(AccessControlList.class);
+    when(accessControlList.getPermissionEntries()).thenReturn(new ArrayList<>());
+    when(((ExtendedNode)folderNode1).getACL()).thenReturn(accessControlList);
+    when(((ExtendedNode)folderNode2).getACL()).thenReturn(accessControlList);
+    when(((ExtendedNode)folderNode3).getACL()).thenReturn(accessControlList);
+    when(((ExtendedNode)folderNode4).getACL()).thenReturn(accessControlList);
+    when(((ExtendedNode)folderNode5).getACL()).thenReturn(accessControlList);
     when(folderNode1.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
     when(folderNode2.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
     when(folderNode3.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
     when(folderNode4.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
     when(folderNode5.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
-    when(nodeIterator.nextNode()).thenReturn(fileNode, folderNode1);
-    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toNodes(
-                                                           identityManager,
-                                                           userSession,
-                                                           nodeIterator,
-                                                           identity,
-                                                           spaceService,
-                                                           100,
-                                                           false))
-                      .thenCallRealMethod();
-    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toFileNode(identityManager, identity, fileNode, "", spaceService)).thenReturn(file);
+
+    when(nodeIterator.nextNode()).thenReturn(folderNode2, folderNode1);
+    when(nodeIterator.hasNext()).thenReturn(true, true, false);
+
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.computeDocumentAcl(any(), any(), any(), any(), any())).thenCallRealMethod();
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode1, "", spaceService)).thenReturn(folder1);
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode2, "", spaceService)).thenReturn(folder2);
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode3, "", spaceService)).thenReturn(folderWithNumericName);
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode4, "", spaceService)).thenReturn(folderWithSpecificName);
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode5, "", spaceService)).thenReturn(folderWithSpecificName1);
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toFileNode(identityManager, identity, fileNode, "", spaceService)).thenReturn(file);
+
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toNodes(identityManager,
+                                                           userSession,
+                                                           nodeIterator,
+                                                           identity,
+                                                           spaceService,
+                                                           false,
+                                                           filter))
+                      .thenCallRealMethod();
+
+
 
     List<AbstractNode> nodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 2);
     assertEquals(2, nodes.size());
     when(nodeIterator.hasNext()).thenReturn(true, false);
     when(nodeIterator.nextNode()).thenReturn(folderNode2);
-    nodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 2);
-    assertEquals(1, nodes.size());// the list contains just one element and should have one page
     nodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 2, 4);
-    assertEquals(0, nodes.size());// the list contains just one element and should have one page
+    assertEquals(1, nodes.size());
 
     // case of folderNodeId empty
     filter.setParentFolderId(null);
@@ -333,21 +337,20 @@ public class JCRDocumentFileStorageTest {
     NodeIterator nodeIterator1 = mock(NodeIterator.class);
     when(queryResult.getNodes()).thenReturn(nodeIterator1);
     when(nodeIterator1.hasNext()).thenReturn(true, true, false);
-    when(nodeIterator1.nextNode()).thenReturn(fileNode, folderNode1);
+    when(nodeIterator1.nextNode()).thenReturn(folderNode2, folderNode1);
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toNodes(
                                                            identityManager,
                                                            userSession,
                                                            nodeIterator1,
                                                            identity,
                                                            spaceService,
-                                                           100,
-                                                           false))
+                                                           false, filter))
                       .thenCallRealMethod();
     List<AbstractNode> nodes1 = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 2);
     assertEquals(2, nodes1.size());
     when(nodeIterator1.hasNext()).thenReturn(true, false);
     when(nodeIterator1.nextNode()).thenReturn(folderNode2);
-    nodes1 = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 4);
+    nodes1 = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 2, 4);
     assertEquals(1, nodes1.size());
 
     // case folder with specific name
@@ -361,8 +364,7 @@ public class JCRDocumentFileStorageTest {
                                                            nodeIterator2,
                                                            identity,
                                                            spaceService,
-                                                           100,
-                                                           false))
+                                                           false, filter))
                       .thenCallRealMethod();
 
     //assert NumberFormatException when try to parse specific folder name
@@ -742,7 +744,7 @@ public class JCRDocumentFileStorageTest {
     lenient().when(aclIdentity.isMemberOf(accessControlEntry.getMembershipEntry())).thenReturn(true);
     lenient().when(extendedNode.getACL()).thenReturn(acl1);
     //when
-    Map<String, Boolean> accessList = jcrDocumentFileStorage.countNodeAccessList(extendedNode,aclIdentity);
+    Map<String, Boolean> accessList = jcrDocumentFileStorage.countNodeAccessList(extendedNode, aclIdentity);
     //then
     assertEquals(false, accessList.isEmpty());
     assertEquals(true, accessList.get("canAccess"));
@@ -750,16 +752,210 @@ public class JCRDocumentFileStorageTest {
     assertEquals(false, accessList.get("canDelete"));
 
     AccessControlEntry accessControlEntry1 = new AccessControlEntry("*:/spaces/testspace", PermissionType.SET_PROPERTY);
-    AccessControlList acl2 = new AccessControlList("john", Arrays.asList(accessControlEntry,accessControlEntry1));
+    AccessControlList acl2 = new AccessControlList("john", Arrays.asList(accessControlEntry, accessControlEntry1));
     lenient().when(aclIdentity.isMemberOf(accessControlEntry1.getMembershipEntry())).thenReturn(true);
     lenient().when(extendedNode.getACL()).thenReturn(acl2);
 
     //when
-    Map<String, Boolean> accessList1 = jcrDocumentFileStorage.countNodeAccessList(extendedNode,aclIdentity);
+    Map<String, Boolean> accessList1 = jcrDocumentFileStorage.countNodeAccessList(extendedNode, aclIdentity);
 
     //then
     assertEquals(false, accessList1.isEmpty());
     assertEquals(true, accessList1.get("canAccess"));
     assertEquals(true, accessList1.get("canEdit"));
+  }
+
+  @Test
+  public void testFoldersThenFilesLoading() throws RepositoryException, ObjectNotFoundException, IllegalAccessException {
+    Node parentNode = mock(Node.class);
+    Session userSession = mock(Session.class);
+    org.exoplatform.services.security.Identity identity = mock(org.exoplatform.services.security.Identity.class);
+    when(identity.getUserId()).thenReturn("user");
+    DocumentFolderFilter filter = new DocumentFolderFilter("12e2", "documents/path", 1L, "");
+
+    // mock session
+    SessionProvider sessionProvider = mock(SessionProvider.class);
+    ManageableRepository manageableRepository = mock(ManageableRepository.class);
+    RepositoryEntry repositoryEntry = mock(RepositoryEntry.class);
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getUserSessionProvider(repositoryService, identity))
+                      .thenReturn(sessionProvider);
+    when(repositoryService.getCurrentRepository()).thenReturn(manageableRepository);
+    when(manageableRepository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
+    when(sessionProvider.getSession("collaboration", manageableRepository)).thenReturn(userSession);
+
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getNodeByIdentifier(userSession, filter.getParentFolderId()))
+                      .thenReturn(parentNode);
+    when(parentNode.getName()).thenReturn("documents");
+    when(parentNode.getNode(filter.getFolderPath())).thenReturn(parentNode);
+    filter.setSortField(DocumentSortField.MODIFIED_DATE);
+    filter.setAscending(true);
+    filter.setIncludeHiddenFiles(false);
+    when(parentNode.getPath()).thenReturn("/documents/path");
+
+    // mock the query creation and execution
+    Workspace workspace = mock(Workspace.class);
+    QueryManager queryManager = mock(QueryManager.class);
+    QueryImpl jcrQuery = mock(QueryImpl.class);
+    NodeIterator subItemsIterator = mock(NodeIterator.class);
+    QueryResult queryResult = mock(QueryResult.class);
+    when(userSession.getWorkspace()).thenReturn(workspace);
+
+    Node folderAbc = createFolderMock("Abc", Calendar.getInstance(), userSession);
+    Node folderXyz = createFolderMock("Xyz", Calendar.getInstance(), userSession);
+    Node folderEfg = createFolderMock("Efg", Calendar.getInstance(), userSession);
+    Node file1 = createFileMock("file1", Calendar.getInstance(), userSession);
+    Node file2 = createFileMock("file2", Calendar.getInstance(), userSession);
+    Node symlinkFile2 = createSymlinkMock("file2FileIdentifier", "file2");
+
+    Node symlinkFolderEfg = createSymlinkMock("EfgIdentifier", "Efg");
+
+    when(subItemsIterator.hasNext()).thenReturn(true, true, true, true, true, false);
+    when(subItemsIterator.nextNode()).thenReturn(file1, symlinkFile2, folderXyz, folderAbc, symlinkFolderEfg);
+
+    when(queryResult.getNodes()).thenReturn(subItemsIterator);
+    when(workspace.getQueryManager()).thenReturn(queryManager);
+    when(queryManager.createQuery(anyString(), anyString())).thenReturn(jcrQuery);
+    when(jcrQuery.execute()).thenReturn(queryResult);
+
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toNodes(any(), any(), any(), any(), any(), anyBoolean(), any()))
+                      .thenCallRealMethod();
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toFolderNode(any(), any(), any(), any(), any())).thenCallRealMethod();
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.retrieveFileProperties(any(), any(), any(), any(), any()))
+                      .thenCallRealMethod();
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toFileNode(any(IdentityManager.class),
+                                                              any(org.exoplatform.services.security.Identity.class),
+                                                              any(Node.class),
+                                                              anyString(),
+                                                              any(SpaceService.class)))
+                      .thenCallRealMethod();
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toFileNode(any(IdentityManager.class),
+                                                              any(org.exoplatform.services.security.Identity.class),
+                                                              any(Node.class),
+                                                              any(FileNode.class),
+                                                              any(SpaceService.class)))
+                      .thenCallRealMethod();
+
+    // creation date
+    filter.setSortField(DocumentSortField.CREATED_DATE);
+    filter.setAscending(true);
+    List<AbstractNode> fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 5);
+    assertNotNull(fileNodes);
+    assertEquals("Abc", fileNodes.get(0).getName());
+    assertEquals("Xyz", fileNodes.get(1).getName());
+    assertEquals("Efg.lnk", fileNodes.get(2).getName());
+
+    filter.setAscending(false);
+    when(subItemsIterator.hasNext()).thenReturn(true, true, true, false);
+    when(subItemsIterator.nextNode()).thenReturn(folderXyz, folderAbc, symlinkFolderEfg);
+    fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 5);
+    assertEquals("Abc", fileNodes.get(2).getName());
+    assertEquals("Xyz", fileNodes.get(1).getName());
+    assertEquals("Efg.lnk", fileNodes.get(0).getName());
+
+    // modified date
+    when(subItemsIterator.hasNext()).thenReturn(true, true, true, false);
+    when(subItemsIterator.nextNode()).thenReturn(folderXyz, folderAbc, symlinkFolderEfg);
+
+    filter.setSortField(DocumentSortField.MODIFIED_DATE);
+    filter.setAscending(true);
+
+    fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 5);
+    assertNotNull(fileNodes);
+    assertEquals("Abc", fileNodes.get(0).getName());
+    assertEquals("Xyz", fileNodes.get(1).getName());
+    assertEquals("Efg.lnk", fileNodes.get(2).getName());
+
+    when(subItemsIterator.hasNext()).thenReturn(true, true, true, false);
+    when(subItemsIterator.nextNode()).thenReturn(folderXyz, folderAbc, symlinkFolderEfg);
+
+    filter.setAscending(false);
+
+    fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 5);
+    assertEquals("Abc", fileNodes.get(2).getName());
+    assertEquals("Xyz", fileNodes.get(1).getName());
+    assertEquals("Efg.lnk", fileNodes.get(0).getName());
+
+    when(subItemsIterator.hasNext()).thenReturn(true, true, true, false);
+    when(subItemsIterator.nextNode()).thenReturn(folderXyz, folderAbc, symlinkFolderEfg);
+    // name
+    filter.setSortField(DocumentSortField.NAME);
+    filter.setAscending(true);
+
+    fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 5);
+    assertNotNull(fileNodes);
+    assertEquals("Abc", fileNodes.get(0).getName());
+    assertEquals("Xyz", fileNodes.get(2).getName());
+    assertEquals("Efg.lnk", fileNodes.get(1).getName());
+
+    when(subItemsIterator.hasNext()).thenReturn(true, true, true, false);
+    when(subItemsIterator.nextNode()).thenReturn(folderXyz, folderAbc, symlinkFolderEfg);
+
+    filter.setAscending(false);
+    when(subItemsIterator.hasNext()).thenReturn(true, true, true, false);
+    when(subItemsIterator.nextNode()).thenReturn(folderXyz, folderAbc, symlinkFolderEfg);
+    fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 5);
+    assertEquals("Abc", fileNodes.get(2).getName());
+    assertEquals("Xyz", fileNodes.get(0).getName());
+    assertEquals("Efg.lnk", fileNodes.get(1).getName());
+  }
+
+  private Node createFolderMock(String name, Calendar createdDate, Session session) throws RepositoryException {
+    Node folderMock = mock(NodeImpl.class);
+    Property namePropertyXyz = mock(Property.class);
+    when(namePropertyXyz.getString()).thenReturn(name);
+    when(folderMock.getProperty(NodeTypeConstants.EXO_TITLE)).thenReturn(namePropertyXyz);
+    when(folderMock.getName()).thenReturn(name);
+    when(folderMock.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
+    when(folderMock.hasProperty("ecd:connected")).thenReturn(false);
+    when(folderMock.getPath()).thenReturn("/path/to/" + name);
+    when(((NodeImpl)folderMock).getIdentifier()).thenReturn(name + "Identifier");
+    when(folderMock.hasProperty(NodeTypeConstants.EXO_DATE_CREATED)).thenReturn(true);
+    Property createdDateProperty = mock(Property.class);
+    when(createdDateProperty.getDate()).thenReturn(createdDate);
+    when(folderMock.getProperty(NodeTypeConstants.EXO_DATE_CREATED)).thenReturn(createdDateProperty);
+    when(getNodeByIdentifier(session, name + "Identifier")).thenReturn(folderMock);
+    when(getNodeByIdentifier(null, name + "Identifier")).thenReturn(folderMock);
+    return folderMock;
+  }
+
+  private Node createFileMock(String name, Calendar createdDate, Session session) throws RepositoryException {
+    Node fileMock = mock(NodeImpl.class);
+    Property nameProperty = mock(Property.class);
+    when(nameProperty.getString()).thenReturn(name);
+    when(fileMock.getProperty(NodeTypeConstants.EXO_TITLE)).thenReturn(nameProperty);
+    when(fileMock.getName()).thenReturn(name);
+    when(fileMock.isNodeType(NodeTypeConstants.NT_FILE)).thenReturn(true);
+    when(fileMock.hasProperty("ecd:connected")).thenReturn(false);
+    when(fileMock.getPath()).thenReturn("/path/to/" + name);
+    when(((NodeImpl)fileMock).getIdentifier()).thenReturn(name + "FileIdentifier");
+    when(fileMock.hasProperty(NodeTypeConstants.EXO_DATE_CREATED)).thenReturn(true);
+    Property createdDateProperty = mock(Property.class);
+    when(createdDateProperty.getDate()).thenReturn(createdDate);
+    when(fileMock.getProperty(NodeTypeConstants.EXO_DATE_CREATED)).thenReturn(createdDateProperty);
+    when(getNodeByIdentifier(session, name + "FileIdentifier")).thenReturn(fileMock);
+    when(getNodeByIdentifier(null, name + "FileIdentifier")).thenReturn(fileMock);
+    return fileMock;
+  }
+
+  private Node createSymlinkMock(String nodeIdentifier, String nodeName) throws RepositoryException {
+    Node symlink = mock(NodeImpl.class);
+    when(symlink.isNodeType(NodeTypeConstants.EXO_SYMLINK)).thenReturn(true);
+    Property symlinkUUIDProperty = mock(Property.class);
+    when(symlinkUUIDProperty.getString()).thenReturn(nodeIdentifier);
+    when(symlink.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID)).thenReturn(symlinkUUIDProperty);
+    when(symlink.getName()).thenReturn(nodeName + ".lnk");
+    when(symlink.getPath()).thenReturn("/path/to/" + nodeName);
+    Property createdDate = mock(Property.class);
+    when(createdDate.getDate()).thenReturn(Calendar.getInstance());
+    when(symlink.getProperty(NodeTypeConstants.EXO_DATE_CREATED)).thenReturn(createdDate);
+    when(symlink.hasProperty(NodeTypeConstants.EXO_DATE_CREATED)).thenReturn(true);
+    when(((NodeImpl)symlink).getIdentifier()).thenReturn(nodeName + "LinkIdentifier");
+    return symlink;
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    JCR_DOCUMENTS_UTIL.reset();
   }
 }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -299,6 +299,7 @@ public class JCRDocumentFileStorageTest {
                                                            nodeIterator,
                                                            identity,
                                                            spaceService,
+                                                           100,
                                                            false))
                       .thenCallRealMethod();
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toFileNode(identityManager, identity, fileNode, "", spaceService)).thenReturn(file);
@@ -339,6 +340,7 @@ public class JCRDocumentFileStorageTest {
                                                            nodeIterator1,
                                                            identity,
                                                            spaceService,
+                                                           100,
                                                            false))
                       .thenCallRealMethod();
     List<AbstractNode> nodes1 = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 2);
@@ -359,6 +361,7 @@ public class JCRDocumentFileStorageTest {
                                                            nodeIterator2,
                                                            identity,
                                                            spaceService,
+                                                           100,
                                                            false))
                       .thenCallRealMethod();
 

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -312,8 +312,10 @@ public class JCRDocumentFileStorageTest {
     assertEquals(2, nodes.size());
     when(nodeIterator.hasNext()).thenReturn(true, false);
     when(nodeIterator.nextNode()).thenReturn(folderNode2);
+    nodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 2);
+    assertEquals(1, nodes.size());// the list contains just one element and should have one page
     nodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 2, 4);
-    assertEquals(1, nodes.size());
+    assertEquals(0, nodes.size());// the list contains just one element and should have one page
 
     // case of folderNodeId empty
     filter.setParentFolderId(null);
@@ -343,7 +345,7 @@ public class JCRDocumentFileStorageTest {
     assertEquals(2, nodes1.size());
     when(nodeIterator1.hasNext()).thenReturn(true, false);
     when(nodeIterator1.nextNode()).thenReturn(folderNode2);
-    nodes1 = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 2, 4);
+    nodes1 = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 4);
     assertEquals(1, nodes1.size());
 
     // case folder with specific name

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 
@@ -247,7 +248,7 @@ public class JCRDocumentsUtilTest {
     when(file1.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID)).thenReturn(symlinkUUID1);
     when(extendedSession.getNodeByIdentifier("file1Identifier")).thenReturn(null);
     //then
-    List <AbstractNode> listNodes1 = JCRDocumentsUtil.toNodes(identityManager, extendedSession, nodeIterator, identity, spaceService,false);
+    List <AbstractNode> listNodes1 = JCRDocumentsUtil.toNodes(identityManager, extendedSession, nodeIterator, identity, spaceService,false, null);
     assertEquals(0, listNodes1.size());
 
     //when
@@ -262,9 +263,14 @@ public class JCRDocumentsUtilTest {
     when(file2.getPrimaryNodeType()).thenReturn(filePrimaryNT);
     when(file2.getPrimaryNodeType().getName()).thenReturn("");
     when(nodeIterator.hasNext()).thenReturn(true, true, false);
+    AccessControlList accessControlList = mock(AccessControlList.class);
+    when(accessControlList.getPermissionEntries()).thenReturn(new ArrayList<>());
+    when(((ExtendedNode)file1).getACL()).thenReturn(accessControlList);
+    when(((ExtendedNode)file2).getACL()).thenReturn(accessControlList);
+
     when(nodeIterator.nextNode()).thenReturn(file1, file2);
     //then
-    List <AbstractNode> listNodes2 = JCRDocumentsUtil.toNodes(identityManager, extendedSession, nodeIterator, identity, spaceService,false);
+    List <AbstractNode> listNodes2 = JCRDocumentsUtil.toNodes(identityManager, extendedSession, nodeIterator, identity, spaceService,false, null);
     assertEquals(1, listNodes2.size());
   }
   }

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -35,9 +35,9 @@
             class="document-type ms-0">
           </div>
           <v-icon
-              v-if="file.sourceID"
-              size="13"
-              class="pe-1 iconStyle ms-1">
+            v-if="file.sourceID"
+            size="13"
+            class="pe-1 iconStyle ms-1">
             mdi-link-variant
           </v-icon>
         </div>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
@@ -17,7 +17,7 @@
         </v-icon>
       </v-btn>
     </template>
-    <span class="center">{{ sharedDocumentSuspended ? sharedDocumentSuspendedLabel : icon.title }}</span>
+    <span class="center">{{ $shareDocumentSuspended ? shareDocumentSuspendedLabel : icon.title }}</span>
   </v-tooltip>
 </template>
 
@@ -39,7 +39,6 @@ export default {
   },
   data: () => ({
     unit: 'bytes',
-    sharedDocumentSuspended: true,
   }),
   computed: {
     icon() {
@@ -99,21 +98,16 @@ export default {
       }
       return false;
     },
-    sharedDocumentSuspendedLabel(){
+    shareDocumentSuspendedLabel(){
       return this.$t('documents.label.share.document.suspend');
     },
     btnClass(){
       return this.isMobile && 'ms-2' || 'me-4' ;
     }
   },
-  created() {
-    this.$transferRulesService.getDocumentsTransferRules().then(rules => {
-      this.sharedDocumentSuspended = rules.sharedDocumentStatus === 'true';
-    });
-  },
   methods: {
     changeVisibility() {
-      if (!this.file.acl.canEdit || this.sharedDocumentSuspended) {
+      if (!this.file.acl.canEdit || this.$shareDocumentSuspended) {
         return;
       }
       this.$root.$emit('open-visibility-drawer', this.file);

--- a/documents-webapp/src/main/webapp/vue-app/documents/main.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/main.js
@@ -39,7 +39,6 @@ const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale
 
 Vue.prototype.$transferRulesService.getDocumentsTransferRules().then(rules => {
   Vue.prototype.$shareDocumentSuspended = rules.sharedDocumentStatus === 'true';
-  console.log(`value is ${Vue.prototype.shareDocumentSuspended}`);
 });
 export function init() {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {

--- a/documents-webapp/src/main/webapp/vue-app/documents/main.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/main.js
@@ -37,6 +37,10 @@ const lang = eXo && eXo.env.portal.language || 'en';
 //should expose the locale ressources as REST API 
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Documents-${lang}.json`;
 
+Vue.prototype.$transferRulesService.getDocumentsTransferRules().then(rules => {
+  Vue.prototype.$shareDocumentSuspended = rules.sharedDocumentStatus === 'true';
+  console.log(`value is ${Vue.prototype.shareDocumentSuspended}`);
+});
 export function init() {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
     // init Vue app when locale ressources are ready


### PR DESCRIPTION
This fix will reorder folders & files retrieved from backend by sending first folders and symlinks of folders, then files and symlinks of files.