### PR TITLE
fix: Remove 3-dots menu actions role redactor filter - EXO-63325

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
@@ -29,11 +29,7 @@ export default {
     menuExtensionApp: 'DocumentMenu',
     menuExtensionType: 'menuActionMenu',
     menuExtensions: {},
-    mobileOnlyExtensions: ['favorite','details'],
-    desktopOnlyExtensions: ['edit'],
     editExtensions: ['edit'],
-    fileOnlyExtension: ['download','favorite'],
-    redactorExtension: ['download', 'versionHistory','details', 'copyLink'],
     sharedDocumentSuspended: true,
     downloadDocumentSuspended: true,
     supportedDocuments: null
@@ -41,11 +37,7 @@ export default {
   created() {
     document.addEventListener(`extension-${this.menuExtensionApp}-${this.menuExtensionType}-updated`, this.refreshMenuExtensions);
     document.addEventListener('documents-supported-document-types-updated', this.refreshSupportedDocumentExtensions);
-    this.$transferRulesService.getDocumentsTransferRules().then(rules => {
-      this.sharedDocumentSuspended = rules.sharedDocumentStatus === 'true';
-      this.downloadDocumentSuspended = rules.downloadDocumentStatus === 'true';
-      this.refreshMenuExtensions();
-    });
+    this.refreshMenuExtensions();
     this.refreshSupportedDocumentExtensions();
   },
   computed: {
@@ -61,51 +53,18 @@ export default {
     }
   },
   methods: {
-    checkTransferRules(extension) {
-      if (extension.id === 'download') {
-        return !this.downloadDocumentSuspended;
-      }
-      if (extension.id === 'visibility') {
-        return !this.sharedDocumentSuspended;
-      }
-      return true;
-    },
-    refreshSupportedDocumentExtensions () {
+    refreshSupportedDocumentExtensions() {
       this.supportedDocuments = extensionRegistry.loadExtensions('documents', 'supported-document-types');
     },
     refreshMenuExtensions() {
       let extensions = extensionRegistry.loadExtensions(this.menuExtensionApp, this.menuExtensionType);
-      if (!this.file.canAdd){
-        extensions = extensions.filter(extension => this.redactorExtension.includes(extension.id));    }
 
       if (!this.fileCanEdit) {
         extensions = extensions.filter(extension => !this.editExtensions.includes(extension.id));
       }
-      if (this.file.path.includes('News Attachments')) {
-        extensions = extensions.filter(extension => extension.id !== 'visibility');
-      }
-      if (this.file.cloudDriveFolder) {
-        extensions = extensions.filter(extension => extension.id === 'copyLink');
-      }
-      extensions = extensions.filter(extension => this.checkTransferRules(extension)
-                                                     && extension.enabled(this.file));
-     
+      extensions = extensions.filter(extension => extension.enabled(this.file));
 
-      let changed = false;
-      extensions.forEach(extension => {
-        if (extension.id && (!this.menuExtensions[extension.id] || this.menuExtensions[extension.id] !== extension)) {
-          if (((!this.isMobile && !this.mobileOnlyExtensions.includes(extension.id))
-              || (this.isMobile && !this.desktopOnlyExtensions.includes(extension.id)))
-          && (!this.file.folder || (this.file.folder && !this.fileOnlyExtension.includes(extension.id)))) {
-            this.menuExtensions[extension.id] = extension;
-            changed = true;
-          }
-        }
-      });
-      // force update of attribute to re-render switch new extension id
-      if (changed) {
-        this.menuExtensions = Object.assign({}, this.menuExtensions);
-      }
+      this.menuExtensions = extensions;
     },
   }
 };

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenuMobile.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenuMobile.vue
@@ -35,10 +35,6 @@ export default {
     menuExtensionApp: 'DocumentMenu',
     menuExtensionType: 'menuActionMenu',
     menuExtensions: {},
-    mobileOnlyExtensions: ['favorite'],
-    desktopOnlyExtensions: ['edit'],
-    editExtensions: 'edit',
-    fileOnlyExtension: ['download','favorite']
   }),
   computed: {
     params() {
@@ -46,10 +42,6 @@ export default {
         file: this.file,
         isMobile: this.isMobile
       };
-    },
-    fileCanEdit(){
-      const type = this.file && this.file.mimeType || '';
-      return ( type.includes('word') || type.includes('presentation') || type.includes('sheet') );
     }
   },
   created() {
@@ -67,24 +59,11 @@ export default {
     },
     refreshMenuExtensions() {
       let extensions = extensionRegistry.loadExtensions(this.menuExtensionApp, this.menuExtensionType);
-      if (!this.fileCanEdit) {
-        extensions = extensions.filter(extension => extension.id !== this.editExtensions);
-      }
-      let changed = false;
-      extensions.forEach(extension => {
-        if (extension.id && (!this.menuExtensions[extension.id] || this.menuExtensions[extension.id] !== extension)) {
-          if ( ((!this.isMobile && !this.mobileOnlyExtensions.includes(extension.id))
-              || (this.isMobile && !this.desktopOnlyExtensions.includes(extension.id)))
-              && (!this.file.folder || (this.file.folder && !this.fileOnlyExtension.includes(extension.id)))) {
-            this.menuExtensions[extension.id] = extension;
-            changed = true;
-          }
-        }
-      });
-      // force update of attribute to re-render switch new extension id
-      if (changed) {
-        this.menuExtensions = Object.assign({}, this.menuExtensions);
-      }
+
+      extensions = extensions.filter(extension => extension.enabled(this.file, true));
+
+      this.menuExtensions = extensions;
+
     },
   }
 };

--- a/documents-webapp/src/main/webapp/vue-app/documents/extensions.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/extensions.js
@@ -75,7 +75,9 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   cssClass: 'font-weight-bold text-no-wrap',
   width: '190px',
   rank: 40,
-  enabled: () => true,
+  enabled: (file, isMobile) => {
+    return file && !file.folder && !file.cloudDriveFolder && isMobile;
+  },
   componentOptions: {
     vueComponent: Vue.options.components['favorite-menu-action'],
   },
@@ -103,8 +105,8 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   cssClass: 'font-weight-bold text-no-wrap',
   width: '190px',
   rank: 2,
-  enabled: (file) => {
-    return file && file.acl.canEdit;
+  enabled: (file, isMobile) => {
+    return file && !file.cloudDriveFolder && file.acl.canEdit && !isMobile;
   },
   componentOptions: {
     vueComponent: Vue.options.components['edit-menu-action'],
@@ -120,7 +122,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 3,
   enabled: (file) => {
-    return file && file.acl.canEdit;
+    return file && !file.cloudDriveFolder && file.acl.canEdit;
   },
   componentOptions: {
     vueComponent: Vue.options.components['rename-menu-action'],
@@ -136,7 +138,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 4,
   enabled: (file) => {
-    return file && file.acl.canEdit;
+    return file && !file.cloudDriveFolder && file.acl.canEdit;
   },
   componentOptions: {
     vueComponent: Vue.options.components['move-menu-action'],
@@ -152,7 +154,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 5,
   enabled: (file) => {
-    return file && file.acl.canEdit;
+    return file && !file.cloudDriveFolder && file.acl.canEdit;
   },
   componentOptions: {
     vueComponent: Vue.options.components['duplicate-menu-action'],
@@ -168,7 +170,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 6,
   enabled: (file) => {
-    return file && file.acl.canEdit && !file.sourceID;
+    return file && !file.cloudDriveFolder && file.acl.canEdit && !file.sourceID;
   },
   componentOptions: {
     vueComponent: Vue.options.components['shortcut-menu-action'],
@@ -185,7 +187,13 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 7,
   enabled: (file) => {
-    return file && file.acl.canEdit && !file.sourceID;
+    if (Vue.prototype.$shareDocumentSuspended) {
+      return false;
+    }
+    return file && !file.cloudDriveFolder
+                && file.acl.canEdit
+                && !file.sourceID
+                && !file.path.includes('News Attachments');
   },
   componentOptions: {
     vueComponent: Vue.options.components['visibility-menu-action'],
@@ -201,7 +209,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 8,
   enabled: (file) => {
-    return file && file.versionable;
+    return file && !file.cloudDriveFolder && file.versionable;
   },
   componentOptions: {
     vueComponent: Vue.options.components['versionHistory-menu-action'],
@@ -218,7 +226,12 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 9,
   enabled: (file) => {
-    return file && file.acl.canEdit || file.sourceID;
+    if (Vue.prototype.$downloadDocumentSuspended) {
+      return false;
+    }
+    return file && !file.cloudDriveFolder
+                && !file.folder
+                && (file.acl.canEdit || file.sourceID);
   },
   componentOptions: {
     vueComponent: Vue.options.components['download-menu-action'],
@@ -233,7 +246,9 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   cssClass: 'font-weight-bold text-no-wrap',
   width: '190px',
   rank: 40,
-  enabled: () => true,
+  enabled: (file, isMobile) => {
+    return file && !file.cloudDriveFolder && !file.folder && isMobile;
+  },
   componentOptions: {
     vueComponent: Vue.options.components['details-menu-action'],
   },
@@ -248,7 +263,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 10,
   enabled: (file) => {
-    return file && file.acl.canEdit;
+    return file && !file.cloudDriveFolder && file.acl.canEdit;
   },
   componentOptions: {
     vueComponent: Vue.options.components['delete-menu-action'],

--- a/documents-webapp/src/main/webapp/vue-app/documents/main.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/main.js
@@ -39,6 +39,7 @@ const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale
 
 Vue.prototype.$transferRulesService.getDocumentsTransferRules().then(rules => {
   Vue.prototype.$shareDocumentSuspended = rules.sharedDocumentStatus === 'true';
+  Vue.prototype.$downloadDocumentSuspended = rules.downloadDocumentStatus === 'true';
 });
 export function init() {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {


### PR DESCRIPTION
Prior to this change, 3-dots menu actions are filtered by a redactor role inside a redactor space. This PR removes the redactor role actions filter and enhance the extensions filtering.