### PR TITLE
fix: Document not visible in recent view after empty the description - EXO-63282 (#822)

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -400,7 +400,8 @@ public class JCRDocumentsUtil {
   }
 
   public static void retrieveFileContentProperties(Node content, FileNode fileNode) throws RepositoryException {
-    if (content.hasProperty(NodeTypeConstants.DC_DESCRIPTION)) {
+    if (content.hasProperty(NodeTypeConstants.DC_DESCRIPTION)
+        && content.getProperty(NodeTypeConstants.DC_DESCRIPTION).getValues().length > 0) {
       fileNode.setDescription(content.getProperty(NodeTypeConstants.DC_DESCRIPTION).getValues()[0].getString());
     }
     if (content.hasProperty(NodeTypeConstants.JCR_MIME_TYPE)) {

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -17,6 +17,29 @@
 package org.exoplatform.documents.storage.jcr.util;
 
 import org.apache.commons.lang3.StringUtils;
+
+import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.getNodeByIdentifier;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.List;
+
+import javax.jcr.*;
+import javax.jcr.nodetype.NodeType;
+import javax.jcr.version.Version;
+
+import org.exoplatform.services.jcr.impl.core.SessionImpl;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.documents.model.AbstractNode;
 import org.exoplatform.documents.model.FileNode;
@@ -255,5 +278,38 @@ public class JCRDocumentsUtilTest {
     //then
     List <AbstractNode> listNodes2 = JCRDocumentsUtil.toNodes(identityManager, extendedSession, nodeIterator, identity, spaceService,false);
     assertEquals(1, listNodes2.size());
+  }
+
+  @Test
+  public void retrieveFileContentProperties() throws RepositoryException, IOException {
+    Node contentNode = mock(Node.class);
+    FileNode fileNode = mock(FileNode.class);
+
+    lenient().when(contentNode.hasProperty(NodeTypeConstants.DC_DESCRIPTION)).thenReturn(true);
+    lenient().when(contentNode.hasProperty(NodeTypeConstants.JCR_MIME_TYPE)).thenReturn(true);
+    lenient().when(contentNode.hasProperty(NodeTypeConstants.JCR_DATA)).thenReturn(true);
+
+    Property descriptionProperty = mock(Property.class);
+    Property mimeTypeProperty = mock(Property.class);
+    Property dataProperty = mock(Property.class);
+
+    lenient().when(contentNode.getProperty(NodeTypeConstants.DC_DESCRIPTION)).thenReturn(descriptionProperty);
+    lenient().when(contentNode.getProperty(NodeTypeConstants.JCR_MIME_TYPE)).thenReturn(mimeTypeProperty);
+    lenient().when(contentNode.getProperty(NodeTypeConstants.JCR_DATA)).thenReturn(dataProperty);
+
+    lenient().when(descriptionProperty.getValues()).thenReturn(new Value[0]);
+    lenient().when(mimeTypeProperty.getString()).thenReturn("application/pdf");
+    lenient().when(dataProperty.getLength()).thenReturn(1024L);
+    
+    JCRDocumentsUtil.retrieveFileContentProperties(contentNode, fileNode);
+
+    verify(fileNode, times(0)).setDescription(anyString());
+    verify(fileNode, times(1)).setMimeType(anyString());
+    verify(fileNode, times(1)).setSize(anyLong());
+
+    lenient().when(descriptionProperty.getValues()).thenReturn(new Value[] { new StringValue("test description") });
+    JCRDocumentsUtil.retrieveFileContentProperties(contentNode, fileNode);
+
+    verify(fileNode, times(1)).setDescription(anyString());
   }
   }


### PR DESCRIPTION
Prior to this change, After creation a document a fill the description and empty it again, the document disappears from recent view because of a missing check on description property leads to and ArrayOutOfBoundException.
This PR ensures that the multivalued description property array is not empty before accessing its elements

(cherry picked from commit 276ad5461fba92bcfd36e6774c4ade91bf5cc397)