### PR TITLE
fix : Adding documents and folders in a read only shared folder should not be possible - EXO-63084

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/model/BreadCrumbItem.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/model/BreadCrumbItem.java
@@ -16,6 +16,7 @@
  */
 package org.exoplatform.documents.model;
 
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -28,4 +29,5 @@ public class BreadCrumbItem {
   private String                                name;
   private String                                path;
   private boolean                               isSymlink;
+  private Map<String, Boolean>                  accessList;
 }

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
@@ -419,6 +419,9 @@ public class DocumentFileRest implements ResourceContainer {
                                                                                  null,
                                                                                  userIdentityId);
       return Response.ok(abstractNodeEntity).build();
+    } catch (IllegalAccessException e) {
+      LOG.warn(e.getMessage());
+      return Response.status(HTTPStatus.UNAUTHORIZED).build();
     } catch (ObjectAlreadyExistsException e) {
       LOG.warn("Folder with same name already exists", e);
       return Response.status(HTTPStatus.CONFLICT).build();

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/model/BreadCrumbItemEntity.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/model/BreadCrumbItemEntity.java
@@ -16,13 +16,10 @@
  */
 package org.exoplatform.documents.rest.model;
 
-import java.util.List;
 import java.util.Map;
 
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
-import org.exoplatform.documents.model.NodePermission;
-import org.exoplatform.social.rest.entity.MetadataItemEntity;
 
 import lombok.Data;
 
@@ -35,4 +32,5 @@ public class BreadCrumbItemEntity {
   private String                                path;
 
   private boolean isSymlink;
+  private Map<String, Boolean> accessList ;
 }

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -180,7 +180,8 @@ public class EntityBuilder {
                     .map(document -> new BreadCrumbItemEntity(document.getId(),
                                                               document.getName(),
                                                               document.getPath(),
-                                                              document.isSymlink()))
+                                                              document.isSymlink(),
+                                                              document.getAccessList()))
                     .collect(Collectors.toList());
     Collections.reverse(brList);
     return brList;

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
@@ -582,8 +582,8 @@ public class DocumentFileRestTest {
     when(identityRegistry.getIdentity(username)).thenReturn(userID);
     when(identityManager.getIdentity(eq(String.valueOf(currentOwnerId)))).thenReturn(currentIdentity);
 
-    BreadCrumbItem breadCrumbItem1 = new BreadCrumbItem("1", "Folder1", "", false);
-    BreadCrumbItem breadCrumbItem2 = new BreadCrumbItem("2", "Folder2", "", false);
+    BreadCrumbItem breadCrumbItem1 = new BreadCrumbItem("1", "Folder1", "", false,new HashMap<>());
+    BreadCrumbItem breadCrumbItem2 = new BreadCrumbItem("2", "Folder2", "", false,new HashMap<>());
     BreadCrumbItem breadCrumbItem3 = new BreadCrumbItem();
     breadCrumbItem3.setId("3");
     breadCrumbItem3.setName("Folder3");
@@ -725,8 +725,12 @@ public class DocumentFileRestTest {
     response = documentFileRest.createFolder("11111111",null,2L,"test");
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
-    when(documentFileRest.createFolder("11111111",null,2L,"test")).thenThrow(RuntimeException.class);
-    response =  documentFileRest.createFolder("11111111",null,2L,"test");
+    when(documentFileStorage.createFolder(2L, "11111111", null, "222", userID)).thenThrow(IllegalAccessException.class);
+    response = documentFileRest.createFolder("11111111", null, 2L, "222");
+    assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
+
+    when(documentFileRest.createFolder("11111111", null, 2L, "test")).thenThrow(RuntimeException.class);
+    response = documentFileRest.createFolder("11111111", null, 2L, "test");
     assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
 
     response = documentFileRest.renameDocument(null,null,"");

--- a/documents-services/src/test/java/org/exoplatform/documents/service/DocumentFileServiceTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/service/DocumentFileServiceTest.java
@@ -385,8 +385,8 @@ public class DocumentFileServiceTest {
     when(identityRegistry.getIdentity(username)).thenReturn(userID);
     when(identityManager.getIdentity(eq(String.valueOf(currentOwnerId)))).thenReturn(currentIdentity);
 
-    BreadCrumbItem breadCrumbItem1 = new BreadCrumbItem("1", "Folder1", "", false);
-    BreadCrumbItem breadCrumbItem2 = new BreadCrumbItem("2", "Folder2", "", false);
+    BreadCrumbItem breadCrumbItem1 = new BreadCrumbItem("1", "Folder1", "", false,new HashMap<>());
+    BreadCrumbItem breadCrumbItem2 = new BreadCrumbItem("2", "Folder2", "", false,new HashMap<>());
     BreadCrumbItem breadCrumbItem3 = new BreadCrumbItem();
     breadCrumbItem3.setId("3");
     breadCrumbItem3.setName("Folder3");

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -19,7 +19,6 @@ package org.exoplatform.documents.storage.jcr;
 import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.*;
 import static org.gatein.common.net.URLTools.SLASH;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
@@ -382,7 +381,8 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         parents.add(new BreadCrumbItem(((NodeImpl) node).getIdentifier(),
                                        nodeName,
                                        node.getPath(),
-                                       node.isNodeType(NodeTypeConstants.EXO_SYMLINK)));
+                                       node.isNodeType(NodeTypeConstants.EXO_SYMLINK),
+                                       countNodeAccessList(node,aclIdentity)));
         if (node.getPath().contains(SPACE_PATH_PREFIX)) {
           String[] pathParts = node.getPath().split(SPACE_PATH_PREFIX)[1].split("/");
           homePath = SPACE_PATH_PREFIX + pathParts[0] + "/" + pathParts[1];
@@ -404,7 +404,8 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
                 parents.add(new BreadCrumbItem(((NodeImpl) node).getIdentifier(),
                                                nodeName,
                                                node.getPath(),
-                                               node.isNodeType(NodeTypeConstants.EXO_SYMLINK)));
+                                               node.isNodeType(NodeTypeConstants.EXO_SYMLINK),
+                                               countNodeAccessList(node,aclIdentity)));
               }
               break;
             } else{
@@ -415,7 +416,8 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
                 parents.add(new BreadCrumbItem(((NodeImpl) node).getIdentifier(),
                                                nodeName,
                                                node.getPath(),
-                                               node.isNodeType(NodeTypeConstants.EXO_SYMLINK)));
+                                               node.isNodeType(NodeTypeConstants.EXO_SYMLINK),
+                                               countNodeAccessList(node,aclIdentity)));
               }
             }
           } catch (RepositoryException repositoryException) {
@@ -525,7 +527,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
                            String folderId,
                            String folderPath,
                            String title,
-                           Identity aclIdentity) throws ObjectAlreadyExistsException {
+                           Identity aclIdentity) throws ObjectAlreadyExistsException, IllegalAccessException {
     if (!JCRDocumentsUtil.isValidDocumentTitle(title)) {
       throw new IllegalArgumentException("folder title is not valid");
     }
@@ -550,6 +552,13 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
           throw new ObjectNotFoundException("Folder with path : " + folderPath + " isn't found");
         }
       }
+      Map<String, Boolean> nodeAccessList = countNodeAccessList(node,aclIdentity) ;
+      String canEdit = "canEdit";
+      if ( nodeAccessList.containsKey(canEdit) && !nodeAccessList.get(canEdit).booleanValue() ) {
+        throw new IllegalAccessException("Permission to add folder is missing");
+      }
+      //no need to this object later make it eligible to the garbage collactor
+      nodeAccessList = null;
       String name = Text.escapeIllegalJcrChars(cleanName(title.toLowerCase()));
       if (node.hasNode(name)) {
         throw new ObjectAlreadyExistsException("Folder'" + name + "' already exist");
@@ -561,6 +570,8 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       }
       node.save();
       return toFolderNode(identityManager, aclIdentity, addedNode, "", spaceService);
+    } catch (IllegalAccessException exception){
+      throw new IllegalAccessException(exception.getMessage());
     } catch (ObjectAlreadyExistsException e) {
       throw new ObjectAlreadyExistsException(e);
     } catch (Exception e) {
@@ -1463,5 +1474,40 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       throw new IllegalStateException("Error while restoring version", e);
     }
     return versionFileNode;
+  }
+
+  public Map<String, Boolean> countNodeAccessList(Node node, Identity aclIdentity) throws RepositoryException {
+
+    Map<String, Boolean> keyValuePermission = new HashMap<>();
+    if (node == null) return keyValuePermission;
+    boolean canAccess = false;
+    boolean canEdit = false;
+    boolean canDelete = false;
+    String userId = aclIdentity.getUserId();
+    try {
+      ExtendedNode extendedNode = (ExtendedNode) node;
+      List<AccessControlEntry> permsList = extendedNode.getACL().getPermissionEntries();
+      for (AccessControlEntry accessControlEntry : permsList) {
+        String nodeAclIdentity = accessControlEntry.getIdentity();
+        MembershipEntry membershipEntry = accessControlEntry.getMembershipEntry();
+        if (StringUtils.equals(nodeAclIdentity, userId)
+            || StringUtils.equals(IdentityConstants.ANY, userId)
+            || (membershipEntry != null && aclIdentity.isMemberOf(membershipEntry))) {
+          canEdit = canEdit || accessControlEntry.getPermission().contains(PermissionType.ADD_NODE) || accessControlEntry.getPermission()
+                                                                                                                         .contains(PermissionType.SET_PROPERTY);
+          canDelete = canDelete || accessControlEntry.getPermission().contains(PermissionType.REMOVE);
+          canAccess = canAccess || accessControlEntry.getPermission().contains(PermissionType.READ);
+        }
+        if (StringUtils.equals(nodeAclIdentity, userId) || StringUtils.equals(IdentityConstants.ANY, userId) || (membershipEntry != null && aclIdentity.isMemberOf(membershipEntry) && !StringUtils.equals(membershipEntry.toString(), GROUP_ADMINISTRATORS))) {
+          canAccess = true;
+        }
+      }
+    } catch (Exception e) {
+      throw new IllegalStateException("Error checking access permission for node'" + node.getUUID() + " for user " + aclIdentity.getUserId(), e);
+    }
+    keyValuePermission.put("canAccess", canAccess);
+    keyValuePermission.put("canEdit", canEdit);
+    keyValuePermission.put("canDelete", canDelete);
+    return keyValuePermission;
   }
 }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -985,4 +985,5 @@ public class JCRDocumentFileStorageTest {
     assertEquals(false, accessList1.isEmpty());
     assertEquals(true, accessList1.get("canAccess"));
     assertEquals(true, accessList1.get("canEdit"));
+  }
 }

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsAddNewFile.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsAddNewFile.vue
@@ -19,6 +19,7 @@
         :id="isMobile ? 'addItemMenu mobile' : 'addItemMenu'"
         class="btn btn-primary primary px-2 py-0"
         :key="postKey"
+        :disabled="disableButton"
         @click="openAddItemMenu()">
         <v-icon
           size="13"
@@ -89,11 +90,15 @@ export default {
     showMobileFilter: false,
     addMenu: false,
     waitTimeUntilCloseMenu: 200,
+    currentFolder: null
   }),
   computed: {
     isFolderView() {
       return this.selectedView === 'folder';
     },
+    disableButton(){
+      return this.currentFolder && this.currentFolder.accessList && this.currentFolder.accessList.canEdit === false ;
+    }
   },
   created() {
     $(document).on('mousedown', () => {
@@ -107,6 +112,7 @@ export default {
       this.showMobileFilter= data;
     });
     document.addEventListener('entity-attachments-updated', this.refreshFilesList);
+    this.$root.$on('set-current-folder', this.setCurrentFolder);
   },
   destroyed() {
     document.removeEventListener('entity-attachments-updated', this.refreshFilesList);
@@ -138,6 +144,9 @@ export default {
     hideAddMenuMobile() {
       this.$refs.documentAddItemMenu.close();
     },
+    setCurrentFolder(folder){
+      this.currentFolder =folder;
+    }
   },
 };
 </script>


### PR DESCRIPTION
This change is going to disallow the ability to add a new folder inside a shared folder with read only permission