### PR TITLE
fix: load correctly contents of folder : subfolders then files with symlinks included - EXO-62645

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -172,7 +172,8 @@ public class JCRDocumentsUtil {
                                            NodeIterator nodeIterator,
                                            Identity aclIdentity,
                                            SpaceService spaceService,
-                                           boolean includeHiddenFiles) {
+                                           boolean includeHiddenFiles,
+                                           DocumentFolderFilter filter) {
     List<AbstractNode> fileNodes = new ArrayList<>();
     while (nodeIterator.hasNext()) {
       Node node = nodeIterator.nextNode();
@@ -202,6 +203,33 @@ public class JCRDocumentsUtil {
       }
     }
 
+    fileNodes.sort((o1, o2) -> {
+      if ((o1.isFolder() && o2.isFolder()) || (!o1.isFolder() && !o2.isFolder())) {
+        if(filter.getSortField().equals(DocumentSortField.MODIFIED_DATE)) {
+          if(filter.isAscending()) {
+            return (int) (o1.getModifiedDate() - o2.getModifiedDate());
+          } else {
+            return (int) (o2.getModifiedDate() - o1.getModifiedDate());
+          }
+        } else if(filter.getSortField().equals(DocumentSortField.CREATED_DATE)) {
+          if (filter.isAscending()) {
+            return (int) (o1.getCreatedDate() - o2.getCreatedDate());
+          } else {
+            return (int) (o2.getCreatedDate() - o1.getCreatedDate());
+          }
+        } else {
+          if(filter.isAscending()) {
+            return o1.getName().compareTo(o2.getName());
+          } else {
+            return o2.getName().compareTo(o1.getName());
+          }
+        }
+      } else if (o1.isFolder()) {
+        return -1;
+      } else {
+        return 1;
+      }
+    });
     return fileNodes;
   }
 
@@ -319,7 +347,7 @@ public class JCRDocumentsUtil {
                                             AbstractNode documentNode,
                                             SpaceService spaceService) throws RepositoryException {
     documentNode.setId(((NodeImpl) node).getIdentifier());
-    documentNode.setPath(((NodeImpl) node).getPath());
+    documentNode.setPath(node.getPath());
 
     try {
       Node parent = node.getParent();

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDeleteFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDeleteFileStorageTest.java
@@ -166,10 +166,11 @@ public class JCRDeleteFileStorageTest {
 
     jcrDeleteFileStorage.deleteDocument(path ,"1", true, true, 0, userID,  currentOwnerId);
 
-    lenient().when(node.isCheckedOut()).thenReturn(true);
-    lenient().when(trashStorage.moveToTrash(node, sessionProvider)).thenReturn(trashId);
-    lenient().when(trashStorage.getNodeByTrashId(trashId)).thenReturn(node);
-    lenient().when(node.getPrimaryNodeType()).thenReturn(nodeType);
+    when(node.isCheckedOut()).thenReturn(true);
+    when(trashStorage.moveToTrash(node, sessionProvider)).thenReturn(trashId);
+    when(trashStorage.getNodeByTrashId(trashId)).thenReturn(node);
+    when(nodeType.getName()).thenReturn(NodeTypeConstants.NT_FILE);
+    when(node.getPrimaryNodeType()).thenReturn(nodeType);
 
     jcrDeleteFileStorage.deleteDocument(path ,"1", false, true, 0, userID,  currentOwnerId);
 

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -32,6 +32,15 @@ import org.exoplatform.social.metadata.tag.model.TagName;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.exoplatform.services.jcr.access.AccessControlEntry;
+import org.exoplatform.services.jcr.access.PermissionType;
+import org.exoplatform.services.security.MembershipEntry;
+
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.metadata.tag.TagService;
+import org.exoplatform.social.metadata.tag.model.TagName;
+import org.junit.*;
 import org.junit.runner.RunWith;
 
 import org.exoplatform.commons.ObjectAlreadyExistsException;
@@ -109,7 +118,7 @@ public class JCRDocumentFileStorageTest {
   private JCRDocumentFileStorage         jcrDocumentFileStorage;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     this.jcrDocumentFileStorage = new JCRDocumentFileStorage(nodeHierarchyCreator,
                                                              repositoryService,
                                                              documentSearchServiceConnector,
@@ -284,15 +293,14 @@ public class JCRDocumentFileStorageTest {
     when(folderNode3.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
     when(folderNode4.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
     when(folderNode5.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
-    when(nodeIterator.nextNode()).thenReturn(fileNode, folderNode1);
-    doCallRealMethod().when(JCRDocumentsUtil.class,
-                            "toNodes",
-                            identityManager,
-                            userSession,
-                            nodeIterator,
-                            identity,
-                            spaceService,
-                            false);
+    when(nodeIterator.nextNode()).thenReturn(folderNode2, folderNode1);
+    when(JCRDocumentsUtil.toNodes(identityManager,
+                                  userSession,
+                                  nodeIterator,
+                                  identity,
+                                  spaceService,
+                                  false,
+                                  filter)).thenCallRealMethod();
     when(JCRDocumentsUtil.toFileNode(identityManager, identity, fileNode, "", spaceService)).thenReturn(file);
     when(JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode1, "", spaceService)).thenReturn(folder1);
     when(JCRDocumentsUtil.toFolderNode(identityManager, identity, folderNode2, "", spaceService)).thenReturn(folder2);
@@ -323,15 +331,15 @@ public class JCRDocumentFileStorageTest {
     NodeIterator nodeIterator1 = mock(NodeIterator.class);
     when(queryResult.getNodes()).thenReturn(nodeIterator1);
     when(nodeIterator1.hasNext()).thenReturn(true, true, false);
-    when(nodeIterator1.nextNode()).thenReturn(fileNode, folderNode1);
-    doCallRealMethod().when(JCRDocumentsUtil.class,
-                            "toNodes",
+    when(nodeIterator1.nextNode()).thenReturn(folderNode2, folderNode1);
+    when(JCRDocumentsUtil.toNodes(
                             identityManager,
                             userSession,
                             nodeIterator1,
                             identity,
                             spaceService,
-                            false);
+                            false,
+            filter)).thenCallRealMethod();
     List<AbstractNode> nodes1 = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 2);
     assertEquals(2, nodes1.size());
     when(nodeIterator1.hasNext()).thenReturn(true, false);
@@ -344,14 +352,13 @@ public class JCRDocumentFileStorageTest {
     when(queryResult.getNodes()).thenReturn(nodeIterator2);
     when(nodeIterator2.hasNext()).thenReturn(true, true, true,false);
     when(nodeIterator2.nextNode()).thenReturn(folderNode3, folderNode4, folderNode5);
-    doCallRealMethod().when(JCRDocumentsUtil.class,
-                            "toNodes",
-                            identityManager,
+    when(JCRDocumentsUtil.toNodes(identityManager,
                             userSession,
                             nodeIterator2,
                             identity,
                             spaceService,
-                            false);
+                            false,
+            filter)).thenCallRealMethod();
 
     //assert NumberFormatException when try to parse specific folder name
     String folderName = folderWithSpecificName.getName();
@@ -762,5 +769,186 @@ public class JCRDocumentFileStorageTest {
     this.jcrDocumentFileStorage.updateDocumentDescription(1L, "123", "test description", identity);
     verify(session, times(1)).save();
     verify(sessionProvider, times(1)).close();
+  }
+  @Test
+  public void testFoldersThenFilesLoading() throws Exception {
+    Node parentNode = mock(Node.class);
+    Session userSession = mock(Session.class);
+    org.exoplatform.services.security.Identity identity = mock(org.exoplatform.services.security.Identity.class);
+    when(identity.getUserId()).thenReturn("user");
+    DocumentFolderFilter filter = new DocumentFolderFilter("12e2", "documents/path", 1L, "");
+
+    // mock session
+    SessionProvider sessionProvider = mock(SessionProvider.class);
+    ManageableRepository manageableRepository = mock(ManageableRepository.class);
+    RepositoryEntry repositoryEntry = mock(RepositoryEntry.class);
+    when(JCRDocumentsUtil.getUserSessionProvider(repositoryService, identity))
+                      .thenReturn(sessionProvider);
+    when(repositoryService.getCurrentRepository()).thenReturn(manageableRepository);
+    when(manageableRepository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
+    when(sessionProvider.getSession("collaboration", manageableRepository)).thenReturn(userSession);
+
+    when(JCRDocumentsUtil.getNodeByIdentifier(userSession, filter.getParentFolderId()))
+                      .thenReturn(parentNode);
+    when(parentNode.getName()).thenReturn("documents");
+    when(parentNode.getNode(filter.getFolderPath())).thenReturn(parentNode);
+    filter.setSortField(DocumentSortField.MODIFIED_DATE);
+    filter.setAscending(true);
+    filter.setIncludeHiddenFiles(false);
+    when(parentNode.getPath()).thenReturn("/documents/path");
+
+    // mock the query creation and execution
+    Workspace workspace = mock(Workspace.class);
+    QueryManager queryManager = mock(QueryManager.class);
+    QueryImpl jcrQuery = mock(QueryImpl.class);
+    NodeIterator subItemsIterator = mock(NodeIterator.class);
+    QueryResult queryResult = mock(QueryResult.class);
+    when(userSession.getWorkspace()).thenReturn(workspace);
+
+    Node folderAbc = createFolderMock("Abc", Calendar.getInstance(), userSession);
+    Node folderXyz = createFolderMock("Xyz", Calendar.getInstance(), userSession);
+    Node folderEfg = createFolderMock("Efg", Calendar.getInstance(), userSession);
+    Node file1 = createFileMock("file1", Calendar.getInstance(), userSession);
+    Node file2 = createFileMock("file2", Calendar.getInstance(), userSession);
+    Node symlinkFile2 = createSymlinkMock("file2FileIdentifier", "file2");
+
+    Node symlinkFolderEfg = createSymlinkMock("EfgIdentifier", "Efg");
+
+    when(subItemsIterator.hasNext()).thenReturn(true, true, true, true, true, false);
+    when(subItemsIterator.nextNode()).thenReturn(file1, symlinkFile2, folderXyz, folderAbc, symlinkFolderEfg);
+
+    when(queryResult.getNodes()).thenReturn(subItemsIterator);
+    when(workspace.getQueryManager()).thenReturn(queryManager);
+    when(queryManager.createQuery(anyString(), anyString())).thenReturn(jcrQuery);
+    when(jcrQuery.execute()).thenReturn(queryResult);
+
+    when(JCRDocumentsUtil.toNodes(any(), any(), any(), any(), any(), anyBoolean(), any()))
+                      .thenCallRealMethod();
+    when(JCRDocumentsUtil.toFolderNode(any(), any(), any(), any(), any())).thenCallRealMethod();
+    doCallRealMethod().when(JCRDocumentsUtil.class,"retrieveFileProperties",any(), any(), any(), any(), any());
+    when(JCRDocumentsUtil.toFileNode(any(IdentityManager.class),
+                                                              any(org.exoplatform.services.security.Identity.class),
+                                                              any(Node.class),
+                                                              anyString(),
+                                                              any(SpaceService.class)))
+                      .thenCallRealMethod();
+
+     //creation date
+    filter.setSortField(DocumentSortField.CREATED_DATE);
+    filter.setAscending(true);
+    List<AbstractNode> fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 5);
+    assertNotNull(fileNodes);
+    assertEquals("Abc", fileNodes.get(0).getName());
+    assertEquals("Xyz", fileNodes.get(1).getName());
+    assertEquals("Efg.lnk", fileNodes.get(2).getName());
+
+    filter.setAscending(false);
+    when(subItemsIterator.hasNext()).thenReturn(true, true, true, false);
+    when(subItemsIterator.nextNode()).thenReturn(folderXyz, folderAbc, symlinkFolderEfg);
+    fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 5);
+    assertEquals("Abc", fileNodes.get(2).getName());
+    assertEquals("Xyz", fileNodes.get(1).getName());
+    assertEquals("Efg.lnk", fileNodes.get(0).getName());
+
+    // modified date
+    when(subItemsIterator.hasNext()).thenReturn(true, true, true, false);
+    when(subItemsIterator.nextNode()).thenReturn(folderXyz, folderAbc, symlinkFolderEfg);
+
+    filter.setSortField(DocumentSortField.MODIFIED_DATE);
+    filter.setAscending(true);
+
+    fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 5);
+    assertNotNull(fileNodes);
+    assertEquals("Abc", fileNodes.get(0).getName());
+    assertEquals("Xyz", fileNodes.get(1).getName());
+    assertEquals("Efg.lnk", fileNodes.get(2).getName());
+
+    when(subItemsIterator.hasNext()).thenReturn(true, true, true, false);
+    when(subItemsIterator.nextNode()).thenReturn(folderXyz, folderAbc, symlinkFolderEfg);
+
+    filter.setAscending(false);
+
+    fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 5);
+    assertEquals("Abc", fileNodes.get(2).getName());
+    assertEquals("Xyz", fileNodes.get(1).getName());
+    assertEquals("Efg.lnk", fileNodes.get(0).getName());
+
+    when(subItemsIterator.hasNext()).thenReturn(true, true, true, false);
+    when(subItemsIterator.nextNode()).thenReturn(folderXyz, folderAbc, symlinkFolderEfg);
+    // name
+    filter.setSortField(DocumentSortField.NAME);
+    filter.setAscending(true);
+
+    fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 5);
+    assertNotNull(fileNodes);
+    assertEquals("Abc", fileNodes.get(0).getName());
+    assertEquals("Xyz", fileNodes.get(2).getName());
+    assertEquals("Efg.lnk", fileNodes.get(1).getName());
+
+    when(subItemsIterator.hasNext()).thenReturn(true, true, true, false);
+    when(subItemsIterator.nextNode()).thenReturn(folderXyz, folderAbc, symlinkFolderEfg);
+
+    filter.setAscending(false);
+    when(subItemsIterator.hasNext()).thenReturn(true, true, true, false);
+    when(subItemsIterator.nextNode()).thenReturn(folderXyz, folderAbc, symlinkFolderEfg);
+    fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 5);
+    assertEquals("Abc", fileNodes.get(2).getName());
+    assertEquals("Xyz", fileNodes.get(0).getName());
+    assertEquals("Efg.lnk", fileNodes.get(1).getName());
+  }
+
+  private Node createFolderMock(String name, Calendar createdDate, Session session) throws RepositoryException {
+    Node folderMock = mock(NodeImpl.class);
+    Property namePropertyXyz = mock(Property.class);
+    when(namePropertyXyz.getString()).thenReturn(name);
+    when(folderMock.getProperty(NodeTypeConstants.EXO_TITLE)).thenReturn(namePropertyXyz);
+    when(folderMock.getName()).thenReturn(name);
+    when(folderMock.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
+    when(folderMock.hasProperty("ecd:connected")).thenReturn(false);
+    when(folderMock.getPath()).thenReturn("/path/to/" + name);
+    when(((NodeImpl)folderMock).getIdentifier()).thenReturn(name + "Identifier");
+    when(folderMock.hasProperty(NodeTypeConstants.EXO_DATE_CREATED)).thenReturn(true);
+    Property createdDateProperty = mock(Property.class);
+    when(createdDateProperty.getDate()).thenReturn(createdDate);
+    when(folderMock.getProperty(NodeTypeConstants.EXO_DATE_CREATED)).thenReturn(createdDateProperty);
+    when(getNodeByIdentifier(session, name + "Identifier")).thenReturn(folderMock);
+    when(getNodeByIdentifier(null, name + "Identifier")).thenReturn(folderMock);
+    return folderMock;
+  }
+
+  private Node createFileMock(String name, Calendar createdDate, Session session) throws RepositoryException {
+    Node fileMock = mock(NodeImpl.class);
+    Property nameProperty = mock(Property.class);
+    when(nameProperty.getString()).thenReturn(name);
+    when(fileMock.getProperty(NodeTypeConstants.EXO_TITLE)).thenReturn(nameProperty);
+    when(fileMock.getName()).thenReturn(name);
+    when(fileMock.isNodeType(NodeTypeConstants.NT_FILE)).thenReturn(true);
+    when(fileMock.hasProperty("ecd:connected")).thenReturn(false);
+    when(fileMock.getPath()).thenReturn("/path/to/" + name);
+    when(((NodeImpl)fileMock).getIdentifier()).thenReturn(name + "FileIdentifier");
+    when(fileMock.hasProperty(NodeTypeConstants.EXO_DATE_CREATED)).thenReturn(true);
+    Property createdDateProperty = mock(Property.class);
+    when(createdDateProperty.getDate()).thenReturn(createdDate);
+    when(fileMock.getProperty(NodeTypeConstants.EXO_DATE_CREATED)).thenReturn(createdDateProperty);
+    when(getNodeByIdentifier(session, name + "FileIdentifier")).thenReturn(fileMock);
+    when(getNodeByIdentifier(null, name + "FileIdentifier")).thenReturn(fileMock);
+    return fileMock;
+  }
+
+  private Node createSymlinkMock(String nodeIdentifier, String nodeName) throws RepositoryException {
+    Node symlink = mock(NodeImpl.class);
+    when(symlink.isNodeType(NodeTypeConstants.EXO_SYMLINK)).thenReturn(true);
+    Property symlinkUUIDProperty = mock(Property.class);
+    when(symlinkUUIDProperty.getString()).thenReturn(nodeIdentifier);
+    when(symlink.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID)).thenReturn(symlinkUUIDProperty);
+    when(symlink.getName()).thenReturn(nodeName + ".lnk");
+    when(symlink.getPath()).thenReturn("/path/to/" + nodeName);
+    Property createdDate = mock(Property.class);
+    when(createdDate.getDate()).thenReturn(Calendar.getInstance());
+    when(symlink.getProperty(NodeTypeConstants.EXO_DATE_CREATED)).thenReturn(createdDate);
+    when(symlink.hasProperty(NodeTypeConstants.EXO_DATE_CREATED)).thenReturn(true);
+    when(((NodeImpl)symlink).getIdentifier()).thenReturn(nodeName + "LinkIdentifier");
+    return symlink;
   }
 }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 
@@ -259,7 +260,7 @@ public class JCRDocumentsUtilTest {
     when(file1.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID)).thenReturn(symlinkUUID1);
     when(extendedSession.getNodeByIdentifier("file1Identifier")).thenReturn(null);
     //then
-    List <AbstractNode> listNodes1 = JCRDocumentsUtil.toNodes(identityManager, extendedSession, nodeIterator, identity, spaceService,false);
+    List <AbstractNode> listNodes1 = JCRDocumentsUtil.toNodes(identityManager, extendedSession, nodeIterator, identity, spaceService,false, null);
     assertEquals(0, listNodes1.size());
 
     //when
@@ -274,9 +275,14 @@ public class JCRDocumentsUtilTest {
     when(file2.getPrimaryNodeType()).thenReturn(filePrimaryNT);
     when(file2.getPrimaryNodeType().getName()).thenReturn("");
     when(nodeIterator.hasNext()).thenReturn(true, true, false);
+    AccessControlList accessControlList = mock(AccessControlList.class);
+    when(accessControlList.getPermissionEntries()).thenReturn(new ArrayList<>());
+    when(((ExtendedNode)file1).getACL()).thenReturn(accessControlList);
+    when(((ExtendedNode)file2).getACL()).thenReturn(accessControlList);
+
     when(nodeIterator.nextNode()).thenReturn(file1, file2);
     //then
-    List <AbstractNode> listNodes2 = JCRDocumentsUtil.toNodes(identityManager, extendedSession, nodeIterator, identity, spaceService,false);
+    List <AbstractNode> listNodes2 = JCRDocumentsUtil.toNodes(identityManager, extendedSession, nodeIterator, identity, spaceService,false, null);
     assertEquals(1, listNodes2.size());
   }
 

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -35,9 +35,9 @@
             class="document-type ms-0">
           </div>
           <v-icon
-              v-if="file.sourceID"
-              size="13"
-              class="pe-1 iconStyle ms-1">
+            v-if="file.sourceID"
+            size="13"
+            class="pe-1 iconStyle ms-1">
             mdi-link-variant
           </v-icon>
         </div>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
@@ -17,7 +17,7 @@
         </v-icon>
       </v-btn>
     </template>
-    <span class="center">{{ icon.title }}</span>
+    <span class="center">{{ $shareDocumentSuspended ? shareDocumentSuspendedLabel : icon.title }}</span>
   </v-tooltip>
 </template>
 
@@ -100,11 +100,14 @@ export default {
     },
     btnClass(){
       return this.isMobile && 'ms-2' || 'me-4' ;
+    },
+    shareDocumentSuspendedLabel(){
+      return this.$t('documents.label.share.document.suspend');
     }
   },
   methods: {
     changeVisibility() {
-      if (!this.file.acl.canEdit) {
+      if (!this.file.acl.canEdit || this.$shareDocumentSuspended) {
         return;
       }
       this.$root.$emit('open-visibility-drawer', this.file);

--- a/documents-webapp/src/main/webapp/vue-app/documents/main.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/main.js
@@ -37,6 +37,9 @@ const lang = eXo && eXo.env.portal.language || 'en';
 //should expose the locale ressources as REST API 
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Documents-${lang}.json`;
 
+Vue.prototype.$transferRulesService.getDocumentsTransferRules().then(rules => {
+  Vue.prototype.$shareDocumentSuspended = rules.sharedDocumentStatus === 'true';
+});
 export function init() {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
     // init Vue app when locale ressources are ready


### PR DESCRIPTION
When displaying contents of a folder in the Documents application, this fix will reorder folders & files retrieved from backend by sending first folders and symlinks of folders, then files and symlinks of files.