### PR TITLE
fix : Disable the ability to open the access manage drawer when the sharing of documents is suspended  - EXO-62870

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
@@ -30,6 +30,10 @@ import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.common.http.HTTPStatus;
 import org.exoplatform.commons.ObjectAlreadyExistsException;
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.api.settings.data.Scope;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.documents.constant.DocumentSortField;
 import org.exoplatform.documents.constant.FileListingType;
@@ -68,14 +72,18 @@ public class DocumentFileRest implements ResourceContainer {
 
   private final IdentityManager     identityManager;
 
+  private final SettingService       settingService;
+
   public DocumentFileRest(DocumentFileService documentFileService,
                           SpaceService spaceService,
                           IdentityManager identityManager,
-                          MetadataService metadataService) {
+                          MetadataService metadataService,
+                          SettingService settingService) {
     this.documentFileService = documentFileService;
     this.identityManager = identityManager;
     this.spaceService = spaceService;
     this.metadataService = metadataService;
+    this.settingService = settingService;
   }
   
   @GET
@@ -560,6 +568,14 @@ public class DocumentFileRest implements ResourceContainer {
 
     if (nodePermissionEntity == null) {
       return Response.status(Response.Status.BAD_REQUEST).entity("permissions_object_is_mandatory").build();
+    }
+    SettingValue<?> sharedDocumentSettingValue = settingService.get(Context.GLOBAL.id("sharedDocumentStatus"),
+                                                                    Scope.APPLICATION.id("sharedDocumentStatus"),
+                                                                    "exo:sharedDocumentStatus");
+    boolean isSharedDocumentSuspended = sharedDocumentSettingValue != null && !sharedDocumentSettingValue.getValue().toString().isEmpty() ? Boolean.valueOf(sharedDocumentSettingValue.getValue().toString()) : false;
+    if (isSharedDocumentSuspended){
+      //return forbidden response status if the share documents forbidden by the administrators
+      return Response.status(Response.Status.FORBIDDEN).build();
     }
     long userIdentityId = RestUtils.getCurrentUserIdentityId(identityManager);
 

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
@@ -23,11 +23,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -38,6 +34,10 @@ import java.util.Map;
 import javax.jcr.RepositoryException;
 import javax.ws.rs.core.Response;
 
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.api.settings.data.Scope;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -121,6 +121,8 @@ public class DocumentFileRestTest {
 
   private ListenerService                          listenerService;
 
+  private SettingService                           settingService;
+
   @Before
   public void setUp() {
     spaceService = mock(SpaceService.class);
@@ -131,6 +133,7 @@ public class DocumentFileRestTest {
     documentFileStorage = mock(DocumentFileStorage.class);
     jcrDeleteFileStorage = mock(JCRDeleteFileStorage.class);
     listenerService = mock(ListenerService.class);
+    settingService = mock(SettingService.class);
     documentFileService = new DocumentFileServiceImpl(documentFileStorage,
                                                       jcrDeleteFileStorage,
                                                       authenticator,
@@ -138,7 +141,7 @@ public class DocumentFileRestTest {
                                                       identityManager,
                                                       identityRegistry,
                                                       listenerService);
-    documentFileRest = new DocumentFileRest(documentFileService, spaceService, identityManager, metadataService);
+    documentFileRest = new DocumentFileRest(documentFileService, spaceService, identityManager, metadataService,settingService);
   }
 
   @After
@@ -878,7 +881,7 @@ public class DocumentFileRestTest {
   public void testUpdatePermissions() throws Exception {
     DocumentFileService documentFileService = mock(DocumentFileService.class);
     DocumentFileRest documentFileRest1 =
-                                       new DocumentFileRest(documentFileService, spaceService, identityManager, metadataService);
+                                       new DocumentFileRest(documentFileService, spaceService, identityManager, metadataService,settingService);
 
     FileNodeEntity nodeEntity = new FileNodeEntity();
     NodePermission nodePermission = mock(NodePermission.class);
@@ -898,13 +901,20 @@ public class DocumentFileRestTest {
     doThrow(new IllegalAccessException()).when(documentFileService).updatePermissions("123", nodePermission, 1L);
     Response response3 = documentFileRest1.updatePermissions(nodeEntity);
     assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response3.getStatus());
+    //assert forbidden response status when the share documents forbidden by administrators
+    when(settingService.get(Context.GLOBAL.id("sharedDocumentStatus"),
+                            Scope.APPLICATION.id("sharedDocumentStatus"),
+                            "exo:sharedDocumentStatus")).thenReturn((SettingValue) SettingValue.create("true"));
+    Response response4 = documentFileRest1.updatePermissions(nodeEntity);
+    assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response4.getStatus());
+
   }
 
   @Test
   public void testCreateShortcut() throws Exception {
     mockRestUtils().when(() -> RestUtils.getCurrentUser()).thenReturn("user");
     DocumentFileService documentFileService = mock(DocumentFileService.class);
-    DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService, spaceService, identityManager, metadataService);
+    DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService, spaceService, identityManager, metadataService,settingService);
 
     Response response = documentFileRest1.createShortcut(null, null, null);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
@@ -972,7 +982,7 @@ public class DocumentFileRestTest {
   @Test
   public void updateDocumentDescription() throws IllegalAccessException, RepositoryException {
     DocumentFileService documentFileService1 = mock(DocumentFileService.class);
-    DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService);
+    DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService,settingService);
     mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(1L);
     doNothing().when(documentFileService1).updateDocumentDescription(1L, "123", "hello", 1L);
     Response response = documentFileRest1.updateDocumentDescription(1L, "123", "hello");
@@ -985,7 +995,7 @@ public class DocumentFileRestTest {
   @Test
   public void getFullTreeData() {
     DocumentFileService documentFileService1 = mock(DocumentFileService.class);
-    DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService);
+    DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService,settingService);
     Response response = documentFileRest1.getFullTreeData(null, null);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     when(documentFileRest1.getFullTreeData(1L, "123")).thenThrow(IllegalAccessException.class);
@@ -1013,7 +1023,7 @@ public class DocumentFileRestTest {
     fileVersion.setAuthorFullName("user user");
     fileVersion.setAuthor("user");
     DocumentFileService documentFileService1 = mock(DocumentFileService.class);
-    DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService);
+    DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService,settingService);
     Response response = documentFileRest1.updateVersionSummary(summary, null, null);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     response = documentFileRest1.updateVersionSummary(summary, "1225", null);
@@ -1039,7 +1049,7 @@ public class DocumentFileRestTest {
     Map<String, String> summary = new HashMap<>();
     summary.put("value", "test");
     DocumentFileService documentFileService1 = mock(DocumentFileService.class);
-    DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService);
+    DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService, settingService);
     mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(1L);
     when(documentFileService1.updateVersionSummary(anyString(),
                                                    anyString(),
@@ -1061,7 +1071,7 @@ public class DocumentFileRestTest {
     fileVersion.setAuthorFullName("user user");
     fileVersion.setAuthor("user");
     DocumentFileService documentFileService1 = mock(DocumentFileService.class);
-    DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService);
+    DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService, settingService);
     Response response = documentFileRest1.restoreVersion(null);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(0L);
@@ -1080,7 +1090,7 @@ public class DocumentFileRestTest {
   public void testRenameDocumentWithExistTitle() throws Exception {
     mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(2L);
     DocumentFileService documentFileService1 = mock(DocumentFileService.class);
-    DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService);
+    DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService, settingService);
     doThrow(new ObjectAlreadyExistsException("exist")).when(documentFileService1).renameDocument(1L, "123", "test", 2L);
     Response response = documentFileRest1.renameDocument("123", 1L, "test");
     assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
@@ -1090,7 +1100,7 @@ public class DocumentFileRestTest {
   public void testMoveWithExistTitle() throws Exception {
     mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(2L);
     DocumentFileService documentFileService1 = mock(DocumentFileService.class);
-    DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService);
+    DocumentFileRest documentFileRest1 = new DocumentFileRest(documentFileService1, spaceService, identityManager, metadataService, settingService);
     doThrow(new ObjectAlreadyExistsException("exist")).when(documentFileService1).moveDocument(1L, "123", "test", 2L, "");
     Response response = documentFileRest1.moveDocument("123", 1L, "test", "");
     assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());

--- a/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
+++ b/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
@@ -93,6 +93,7 @@ documents.label.visibility=Manage access
 documents.label.visibilityTitle=Manage Access to : {0}
 documents.label.saveVisibility.success=Access successfully updated
 documents.label.saveVisibility.error=Update of the access failed
+documents.label.share.document.suspend=Administrators have locked the ability to share a document
 documents.label.owner=Owner
 documents.label.apply=Save
 documents.label.visibility.choice=Who can access this document?

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
@@ -17,7 +17,7 @@
         </v-icon>
       </v-btn>
     </template>
-    <span class="center">{{ icon.title }}</span>
+    <span class="center">{{ sharedDocumentSuspended ? sharedDocumentSuspendedLabel : icon.title }}</span>
   </v-tooltip>
 </template>
 
@@ -39,6 +39,7 @@ export default {
   },
   data: () => ({
     unit: 'bytes',
+    sharedDocumentSuspended: true,
   }),
   computed: {
     icon() {
@@ -100,11 +101,19 @@ export default {
     },
     btnClass(){
       return this.isMobile && 'ms-2' || 'me-4' ;
+    },
+    sharedDocumentSuspendedLabel(){
+      return this.$t('documents.label.share.document.suspend');
     }
+  },
+  created() {
+    this.$transferRulesService.getDocumentsTransferRules().then(rules => {
+      this.sharedDocumentSuspended = rules.sharedDocumentStatus === 'true';
+    });
   },
   methods: {
     changeVisibility() {
-      if (!this.file.acl.canEdit) {
+      if (!this.file.acl.canEdit || this.sharedDocumentSuspended) {
         return;
       }
       this.$root.$emit('open-visibility-drawer', this.file);


### PR DESCRIPTION

This change is going to disable the management access icon from begin clickable when the sharing documents is suspended.