### PR TITLE
fix: Lowercase renamed files technical names and ensure to trim file names on each operation (#827)

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -678,7 +678,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       } else {
         node = getNodeByIdentifier(session, documentID);
       }
-      String name = Text.escapeIllegalJcrChars(cleanName(title));
+      String name = Text.escapeIllegalJcrChars(cleanName(title.toLowerCase()));
       //clean node name
       name = URLDecoder.decode(name, "UTF-8");
       if (name.indexOf('.') == -1) {
@@ -692,7 +692,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         }
       }
 
-      checkNodeExistence(session, node, title);
+      checkNodeExistence(session, node, name);
 
       if (node.canAddMixin(NodeTypeConstants.EXO_MODIFY)) {
         node.addMixin(NodeTypeConstants.EXO_MODIFY);

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 import javax.jcr.*;
 import javax.jcr.version.Version;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.api.search.data.SearchResult;
@@ -617,6 +618,7 @@ public class JCRDocumentsUtil {
       extension = oldName.substring(oldName.lastIndexOf("."));
       oldName = oldName.substring(0,oldName.lastIndexOf(".")) ;
     }
+    oldName = oldName.trim();
     String specialChar = "&#*@.'\"\t\r\n$\\><:;[]/|";
     StringBuilder ret = new StringBuilder();
     for (int i = 0; i < oldName.length(); i++) {
@@ -632,6 +634,9 @@ public class JCRDocumentsUtil {
   }
 
   public static boolean isValidDocumentTitle(String name) {
+    if (StringUtils.isBlank(FilenameUtils.getBaseName(name))) {
+      return false;
+    }
     Pattern regex = Pattern.compile("[<\\\\>:\"/|?*]");
     Matcher matcher = regex.matcher(name);
     return !matcher.find();

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -570,6 +570,9 @@ public class JCRDocumentFileStorageTest {
     Throwable exception = assertThrows(IllegalArgumentException.class,
                                        () -> this.jcrDocumentFileStorage.renameDocument(1L, "123", "test:<*?", identity));
     assertEquals("document title is not valid", exception.getMessage());
+    exception = assertThrows(IllegalArgumentException.class,
+            () -> this.jcrDocumentFileStorage.renameDocument(1L, "123", "   ", identity));
+    assertEquals("document title is not valid", exception.getMessage());
     when(identityRegistry.getIdentity("user")).thenReturn(identity);
     ManageableRepository manageableRepository = mock(ManageableRepository.class);
     when(repositoryService.getCurrentRepository()).thenReturn(manageableRepository);

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -19,8 +19,7 @@ package org.exoplatform.documents.storage.jcr.util;
 import org.apache.commons.lang3.StringUtils;
 
 import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.getNodeByIdentifier;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -318,4 +317,12 @@ public class JCRDocumentsUtilTest {
 
     verify(fileNode, times(1)).setDescription(anyString());
   }
+
+  @Test
+  public void isValidDocumentTitle() {
+    assertFalse(JCRDocumentsUtil.isValidDocumentTitle("test:<*?"));
+    assertFalse(JCRDocumentsUtil.isValidDocumentTitle("   "));
+    assertFalse(JCRDocumentsUtil.isValidDocumentTitle("   .docx"));
+    assertTrue(JCRDocumentsUtil.isValidDocumentTitle("test.docx"));
   }
+}

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileEditNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileEditNameCell.vue
@@ -66,7 +66,7 @@ export default {
     nameRegex: /[<\\>:"/|?*]/
   }),
   created() {
-    this.nameRules = [v => !!v, v => !this.nameRegex.test(v)];
+    this.nameRules = [v => !!v.trim(), v => !this.nameRegex.test(v)];
     this.$root.$on('document-renamed', (file) => {
       if (file.id === this.file.id) {
         this.file.name = this.fileName.concat(this.fileType);


### PR DESCRIPTION
Prior to this change, Inconsistency letter case  issue in technical file names has affected the manage conflicts in some cases. This PR ensures to lowercase the technical name in all file operations (creation, renaming, ...) and also restrict blank names and names that start or ends with spaces.

(cherry picked from commit 0b84ed90acec89ecda402b47414c8b3758ae1579)