### PR TITLE
fix: Edit option is no more present in 3 dots menu

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
@@ -37,8 +37,8 @@ export default {
   created() {
     document.addEventListener(`extension-${this.menuExtensionApp}-${this.menuExtensionType}-updated`, this.refreshMenuExtensions);
     document.addEventListener('documents-supported-document-types-updated', this.refreshSupportedDocumentExtensions);
-    this.refreshMenuExtensions();
     this.refreshSupportedDocumentExtensions();
+    this.refreshMenuExtensions();
   },
   computed: {
     params() {


### PR DESCRIPTION
Before this fix, extensions about supported mimetype is loaded after extensions about 3 dots menu, so, for edit action, the supportedMimeType is empty, and so, the file is not editable

This fix ensure to load mimetype extension before 3 dots menu