### PR TITLE
 fix: [Document] Can't disable document edition on which there are all rights - EXO-63201

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1106,11 +1106,11 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       if (node.canAddMixin(NodeTypeConstants.EXO_PRIVILEGEABLE)) {
         node.addMixin(NodeTypeConstants.EXO_PRIVILEGEABLE);
       }
+      Calendar now = Calendar.getInstance();
+      node.setProperty(NodeTypeConstants.EXO_DATE_MODIFIED, now);
+      node.setProperty(NodeTypeConstants.EXO_LAST_MODIFIED_DATE, now);
+      node.save();
       ((ExtendedNode) node).setPermissions(permissions);
-      if (node.isNodeType(NodeTypeConstants.EXO_MODIFY)) {
-        node.setProperty(NodeTypeConstants.EXO_DATE_MODIFIED, Calendar.getInstance());
-        node.setProperty(NodeTypeConstants.EXO_LAST_MODIFIED_DATE, Calendar.getInstance());
-      }
       session.save();
     } catch (Exception e) {
       throw new IllegalStateException("Error updating permissi" +


### PR DESCRIPTION
Prior to this change, when open the manage access drawer of file then switch the button 'Allow everyone to edit and saves', an error message 'Update of the access failed' displays and the manage access drawer is forever loading. To fix that, save the node after set the `dateModified` and `lastModifiedDate` in the function `updatePermissions()`. after this change, the document is modifiable and no error message is displayed .