### PR TITLE
fix: Notification redirection issue after sharing document with personal drive -EXO-63618

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/notification/utils/NotificationUtils.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/notification/utils/NotificationUtils.java
@@ -70,7 +70,7 @@ public class NotificationUtils {
       String groupId = space.getGroupId().replace("/", ":");
       stringBuilder.append("g/").append(groupId).append("/").append(spacePrettyName).append("/documents");
     } else {
-      stringBuilder.append(portalOwner).append("/documents/Private/Documents");
+      stringBuilder.append(portalOwner).append("/documents");
     }
     boolean isTargetNodeFile = isNodeFile(sharedNode);
     if (isTargetNodeFile) {

--- a/documents-services/src/test/java/org/exoplatform/documents/notification/utils/NotificationUtilsTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/notification/utils/NotificationUtilsTest.java
@@ -93,12 +93,12 @@ public class NotificationUtilsTest {
     when(session.getNodeByUUID(anyString())).thenReturn(targetNode);
     when(targetNode.isNodeType(NT_FILE)).thenReturn(true);
     String link = NotificationUtils.getSharedDocumentLink(node, null,null);
-    assertEquals("http://domain/portal/dw/documents/Private/Documents?documentPreviewId=123", link);
+    assertEquals("http://domain/portal/dw/documents?documentPreviewId=123", link);
     link = NotificationUtils.getSharedDocumentLink(node, spaceService,"space_name");
     assertEquals("http://domain/portal/g/:spaces:spacename/space_name/documents?documentPreviewId=123", link);
     when(targetNode.isNodeType(NT_FILE)).thenReturn(false);
     link = NotificationUtils.getSharedDocumentLink(node, null,null);
-    assertEquals("http://domain/portal/dw/documents/Private/Documents?folderId=123", link);
+    assertEquals("http://domain/portal/dw/documents?folderId=123", link);
     link = NotificationUtils.getSharedDocumentLink(node, spaceService,"space_name");
     assertEquals("http://domain/portal/g/:spaces:spacename/space_name/documents?folderId=123", link);
   }


### PR DESCRIPTION
Prior to this change when sharing a folder with personal drive and clicking on sharing notification the user is not directed inside the shared folder, That was due to the wrong URL generated by the getsharedDocumentLink method.
After this change users will be redirected inside the shared folder .