### PR TITLE
fix: Fix visibility rules when share folder with a user personal drive - EXO-63701

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1178,7 +1178,13 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
                       permissions.put(accessControlEntry.getIdentity(),accessControlEntryPermession.toArray(new String[accessControlEntryPermession.size()]));
                     });
       } else {
-        permissions.put(destIdentity.getRemoteId(), PermissionType.ALL);
+        List<AccessControlEntry> acc = ((ExtendedNode) currentNode).getACL().getPermissionEntries();
+        List<String> accessControlEntryPermession = new ArrayList<>();
+        acc.stream().filter(accessControlEntry -> accessControlEntry.getIdentity().equals(destIdentity.getRemoteId())).toList()
+           .forEach(accessControlEntry -> {
+             accessControlEntryPermession.add(accessControlEntry.getPermission());
+             permissions.put(accessControlEntry.getIdentity(),accessControlEntryPermession.toArray(new String[accessControlEntryPermession.size()]));
+           });
       }
       if (linkNode.canAddMixin(NodeTypeConstants.EXO_PRIVILEGEABLE)) {
         linkNode.addMixin(NodeTypeConstants.EXO_PRIVILEGEABLE);

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
@@ -49,8 +49,8 @@ export default {
           title: this.$t('documents.label.visibility.all'),
         };
       }
-      if (this.isSharedWithCurrentSpace && !this.file.acl.canEdit) {
-        const collaborators = this.file.acl.collaborators.filter(e => e.identity.id === eXo.env.portal.spaceIdentityId );
+      if (this.isSharedWithCurrentSpaceOrDrive && !this.file.acl.canEdit) {
+        const collaborators = this.file.acl.collaborators.filter(e => e.identity.id === eXo.env.portal.spaceIdentityId || eXo.env.portal.userName );
         return collaborators[0].permission === 'read'?
           {
             icon: 'fas fa-eye',
@@ -86,13 +86,20 @@ export default {
         };
       }
     },
-    isSharedWithCurrentSpace(){
+    isSharedWithCurrentSpaceOrDrive(){
       const spaceIdentityId = eXo.env.portal.spaceIdentityId;
       const spaceName = eXo.env.portal.spaceName;
       const collaborators = this.file.acl.collaborators;
-      if (spaceIdentityId && collaborators.length > 0){
+      if (spaceIdentityId && spaceName && collaborators.length > 0){
         for (const collaborator of collaborators) {
           if (collaborator.identity.id === spaceIdentityId && collaborator.identity.remoteId === spaceName) {
+            return true;
+          }
+        }
+      }
+      else if (collaborators.length > 0) {
+        for (const collaborator of collaborators) {
+          if (collaborator.identity.remoteId === eXo.env.portal.userName) {
             return true;
           }
         }


### PR DESCRIPTION

Before this change, when we shared a folder with a user personal drive and gave read-only permissions, the folder would be created but the visibility rules were incorrect. The problem was that when we added a symlink to the destination user personal drive , the symlink was added with all permissions, allowing it to open the visibility drawer.

With this fix, we will add the symlink to the destination space with the provided permissions and correct the wrong visibility rule icon.