### PR TITLE
fix: navigate between folders using history button of browser - EXO-63527

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1022,7 +1022,9 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
   }
 
   private Node getNodeByPath(Node node, String folderPath, SessionProvider sessionProvider) throws ObjectNotFoundException {
+    String parentPath = "";
     try {
+      parentPath = node.getPath();
       if ((node.getName().equals(USER_PRIVATE_ROOT_NODE))) {
         if (folderPath.startsWith(USER_PRIVATE_ROOT_NODE)) {
           folderPath = folderPath.split(USER_PRIVATE_ROOT_NODE + SLASH)[1];
@@ -1036,8 +1038,8 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
           node = parent.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8).replace("%", "%25"));
           Session session = sessionProvider.getSession(sessionProvider.getCurrentWorkspace(),
                                                        sessionProvider.getCurrentRepository());
-          if (session.itemExists(node.getPath())) {
-            return (Node) session.getItem(node.getPath());
+          if (session.itemExists(parentPath)) {
+            return (Node) session.getItem(parentPath);
           }
           return null;
         }
@@ -1054,7 +1056,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       }
       return (node.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8).replace("%", "%25")));
     } catch (RepositoryException repositoryException) {
-      throw new ObjectNotFoundException("Folder with path : " + folderPath + " isn't found");
+      throw new ObjectNotFoundException("Folder with path : " + parentPath + folderPath + " isn't found");
     }
   }
 

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -946,7 +946,7 @@ export default {
     setCurrentFolder(folder) {
       this.currentFolder = folder;
     },
-    getDocumentDataFromUrl() {
+    getDocumentDataFromUrl(path) {
       const currentUrlSearchParams = window.location.search;
       const queryParams = new URLSearchParams(currentUrlSearchParams);
       if (!eXo.env.portal.spaceName && queryParams.has('userId')) {
@@ -973,11 +973,15 @@ export default {
         const path = queryParams.get('path') || '';
         this.selectFile(path);
       } else {
-        const path = window.location.pathname;
+        if (!path) {
+          path = window.location.pathname;
+        }
         const pathParts  = path.split( `${eXo.env.portal.selectedNodeUri.toLowerCase()}/`);
         if (pathParts.length > 1) {
           this.folderPath = pathParts[1];
           this.selectedView = 'folder';
+        } else {
+          this.folderPath = '';
         }
         if (queryParams.has('view')) {
           const view = queryParams.get('view');
@@ -995,10 +999,11 @@ export default {
       }
       return this.$nextTick();
     },
-    onBrowserNavChange() {
-      this.getDocumentDataFromUrl();
+    onBrowserNavChange(event) {
+      this.parentFolderId = null;
+      this.getDocumentDataFromUrl(event.currentTarget.location.pathname);
       this.refreshFiles()
-        .finally(() => this.$root.$emit('update-breadcrumb'));
+        .finally(() => this.$root.$emit('update-breadcrumb', this.folderPath));
     },
     displayMessage(message) {
       this.message = message.message;

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -167,6 +167,8 @@ export default {
         const pathParts  = path.split( `${eXo.env.portal.selectedNodeUri.toLowerCase()}/`);
         if (pathParts.length > 1) {
           this.folderPath = pathParts[1];
+        } else {
+          this.folderPath = '';
         }
         if (!eXo.env.portal.spaceName) {
           if (path.includes('/Private/')){


### PR DESCRIPTION
Browsing history backward/forward with Docuents application was not working because the variables used to retrieve and list documents inside a folder were not correctly updated when back/forward buttons are pressed. This fix updates correctly the variables and manages also the case when the selected folder is the root.