### PR TITLE
fix: Implement a Natural Comparator to sort the tree view items - EXO-63141

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -556,16 +556,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
 
       }
     }
-    return folderListNodes.stream().sorted( new Comparator<FullTreeItem>() {
-      public int compare(FullTreeItem o1, FullTreeItem o2) {
-        //sorted the tree item when the name contains numbers
-        if(NumberUtils.isParsable(o1.getName()) && NumberUtils.isParsable(o2.getName())){
-          return Integer.compare(Integer.parseInt(o1.getName()), Integer.parseInt(o2.getName()));
-        }
-        // sorted the tree item when the name contains only characters
-        return o1.getName().compareToIgnoreCase(o2.getName());
-      }
-    }).collect(Collectors.toList());
+    return folderListNodes.stream().sorted((fullTreeItem1, fullTreeItem2)-> new Utils.NaturalComparator().compare(fullTreeItem1.getName(), fullTreeItem2.getName())).toList();
   }
   @Override
   public AbstractNode createFolder(long ownerId,

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/Utils.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/Utils.java
@@ -22,6 +22,7 @@ import org.exoplatform.services.log.Log;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
+import java.util.Comparator;
 
 public class Utils {
 
@@ -40,5 +41,35 @@ public class Utils {
       return node.getProperty(propertyName).getString();
     }
     return "";
+  }
+
+  public static class NaturalComparator implements Comparator<String> {
+    @Override
+    public int compare(String s1, String s2) {
+      /*
+      Split string by matching a position where a non-digit (\\D) precedes and a digit (\\d) follows or vice versa
+      (?<=) matches the position immediately following a non-digit (\\D) or a digit (\\d) character
+      (?=) matches the position immediately preceding a non-digit (\\D) or a digit (\\d) character
+       */
+      String[] arr1 = s1.split("(?<=\\D)(?=\\d)|(?<=\\d)(?=\\D)");
+      String[] arr2 = s2.split("(?<=\\D)(?=\\d)|(?<=\\d)(?=\\D)");
+      int i = 0;
+      while (i < arr1.length && i < arr2.length) {
+        if (Character.isDigit(arr1[i].charAt(0)) && Character.isDigit(arr2[i].charAt(0))) {
+          int num1 = Integer.parseInt(arr1[i]);
+          int num2 = Integer.parseInt(arr2[i]);
+          if (num1 != num2) {
+            return Integer.compare(num1, num2);
+          }
+        } else {
+          int result = arr1[i].compareTo(arr2[i]);
+          if (result != 0) {
+            return result;
+          }
+        }
+        i++;
+      }
+      return s1.compareToIgnoreCase(s2);
+    }
   }
 }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -720,6 +720,43 @@ public class JCRDocumentFileStorageTest {
     assertEquals(1, fullTreeItemList.size());
     assertEquals(3, fullTreeItemList.get(0).getChildren().size());
 
+    // Natural sorted items
+    Node folder1 = mock(NodeImpl.class);
+    when(folder1.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
+    when(folder1.getName()).thenReturn("folder1");
+    when(folder1.getPath()).thenReturn("/root/folder/folder1");
+    when(((NodeImpl)folder1).getIdentifier()).thenReturn("folder1Identifiuer");
+    when(folder1.getNodes()).thenReturn(nodeIteratorFolder);
+
+    Node folder2 = mock(NodeImpl.class);
+    when(folder2.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
+    when(folder2.getName()).thenReturn("folder2");
+    when(folder2.getPath()).thenReturn("/root/folder/folder2");
+    when(((NodeImpl)folder2).getIdentifier()).thenReturn("folder2Identifiuer");
+    when(folder2.getNodes()).thenReturn(nodeIteratorFolder);
+
+    Node folder10 = mock(NodeImpl.class);
+    when(folder10.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
+    when(folder10.getName()).thenReturn("folder10");
+    when(folder10.getPath()).thenReturn("/root/folder/folder10");
+    when(((NodeImpl)folder10).getIdentifier()).thenReturn("folder10Identifiuer");
+    when(folder10.getNodes()).thenReturn(nodeIteratorFolder);
+
+
+    when(nodeIterator.hasNext()).thenReturn(true, true, true, false);
+    when(nodeIterator.nextNode()).thenReturn(folder1, folder10, folder2);
+    when(folderNode.getNodes()).thenReturn(nodeIterator);
+
+    fullTreeItemList = jcrDocumentFileStorage.getFullTreeData(ownerId, folderId, identity);
+    assertEquals(1, fullTreeItemList.size());
+    assertEquals(3, fullTreeItemList.get(0).getChildren().size());
+    //assert that the folder1 on the first position
+    assertEquals("folder1", fullTreeItemList.get(0).getChildren().get(0).getName());
+    //assert that the folder2 on the second position
+    assertEquals("folder2", fullTreeItemList.get(0).getChildren().get(1).getName());
+    //assert that the folder10 on the last position
+    assertEquals("folder10", fullTreeItemList.get(0).getChildren().get(2).getName());
+
     // when folder ID is null, we return user Home folder
     Node userHome = mock(NodeImpl.class);
     when(((NodeImpl)userHome).getIdentifier()).thenReturn("userHomeFolderIdentifier");

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -308,4 +308,35 @@ public class JCRDocumentsUtilTest {
     assertFalse(JCRDocumentsUtil.isValidDocumentTitle("   .docx"));
     assertTrue(JCRDocumentsUtil.isValidDocumentTitle("test.docx"));
   }
+
+  @Test
+  public void TestNaturalCompare(){
+    List<String> list = new ArrayList<>();
+    list.add("1");
+    list.add("3");
+    list.add("2");
+
+    List<String> list1 = list.stream().sorted(new Utils.NaturalComparator()).toList();
+    //assert numeric sort
+    assertEquals("1", list1.get(0));
+    assertEquals("3", list1.get(2));
+
+    list.add("Afile");
+    list.add("bfile");
+    list1 = list.stream().sorted(new Utils.NaturalComparator()).toList();
+    //assert numeric sort then literal sort
+    assertEquals("1", list1.get(0));
+    assertEquals("Afile", list1.get(3));
+
+    list.add("file1");
+    list.add("file10");
+    list.add("file2");
+    list.add("file20");
+    list.add("file3");
+    list.add("2 test");
+
+    list1 = list.stream().sorted(new Utils.NaturalComparator()).toList();
+    String[] expectedSortedArray = new String[]{"1", "2", "2 test", "3", "Afile", "bfile", "file1", "file2", "file3" ,"file10", "file20"};
+    assertEquals(expectedSortedArray, list1.toArray(new String[list1.size()]));
+  }
 }


### PR DESCRIPTION
Before to this change when opening move to or create shortcut drawer the tree-view items displayed not sorted ( folder 10 displayed before folder 2 )
This change is going to implement a natural comparator to sort the tree view items