### PR TITLE
fix : Blank content page displayed when open document app - EXO-63718

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/main.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/main.js
@@ -67,9 +67,11 @@ const lang = eXo && eXo.env.portal.language || 'en';
 //should expose the locale ressources as REST API 
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Documents-${lang}.json`;
 
-Vue.prototype.$transferRulesService.getDocumentsTransferRules().then(rules => {
-  Vue.prototype.$shareDocumentSuspended = rules.sharedDocumentStatus === 'true';
-  Vue.prototype.$downloadDocumentSuspended = rules.downloadDocumentStatus === 'true';
+Vue.prototype.$nextTick(() => {
+  Vue.prototype.$transferRulesService.getDocumentsTransferRules().then(rules => {
+    Vue.prototype.$shareDocumentSuspended = rules.sharedDocumentStatus === 'true';
+    Vue.prototype.$downloadDocumentSuspended = rules.downloadDocumentStatus === 'true';
+  });
 });
 
 export function init() {


### PR DESCRIPTION

Before to this change when we opened the document application a blank page content would be displayed with a console error 'Cannot read properties of undefined (reading 'getDocumentsTransferRules')'. This change is going to pass a callback function to Vue.prototype.$transferRulesService, which will be executed after the next DOM update cycle.