### PR TITLE
fix: load all files when they exceed pagination limit - EXO-64087

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -342,10 +342,10 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
                                                    spaceService,
                                                    includeHiddenFiles,
                                                    filter).stream().filter(f -> !f.isFolder()).toList();
-            int limitToAdd = limit - (itemsSize + fileItemsToAdd.size());
-            if(limitToAdd < 0) {
+            int limitToAdd = limit - itemsSize;
+            if(fileItemsToAdd.size() > limitToAdd) {
               fileItems.addAll(fileItemsToAdd.subList(0, limit - itemsSize));
-            } else if (limitToAdd > 0) {
+            } else {
               fileItems.addAll(fileItemsToAdd);
             }
           }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -948,6 +948,37 @@ public class JCRDocumentFileStorageTest {
     assertEquals("Abc", fileNodes.get(2).getName());
     assertEquals("Xyz", fileNodes.get(0).getName());
     assertEquals("Efg.lnk", fileNodes.get(1).getName());
+
+    Node file3 = createFileMock("file3", Calendar.getInstance(), userSession);
+    Node file4 = createFileMock("file4", Calendar.getInstance(), userSession);
+    Node file5 = createFileMock("file5", Calendar.getInstance(), userSession);
+    Node file6 = createFileMock("file6", Calendar.getInstance(), userSession);
+    Node file7 = createFileMock("file7", Calendar.getInstance(), userSession);
+    Node file8 = createFileMock("file8", Calendar.getInstance(), userSession);
+    Node file9 = createFileMock("file9", Calendar.getInstance(), userSession);
+    Node file10 = createFileMock("file10", Calendar.getInstance(), userSession);
+
+    when(subItemsIterator.hasNext()).thenReturn(false, true, true, true, true, true, true, true, true, true, true, false);
+    when(subItemsIterator.nextNode()).thenReturn(file1, file2, file3, file4, file5, file6, file7, file8, file9, file10);
+
+    fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 4);
+    assertNotNull(fileNodes);
+    assertEquals(4, fileNodes.size());
+
+    when(subItemsIterator.hasNext()).thenReturn(false, true, true, true, true, true, true, true, true, true, true, false);
+    when(subItemsIterator.nextNode()).thenReturn(file1, file2, file3, file4, file5, file6, file7, file8, file9, file10);
+
+    fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 8);
+    assertNotNull(fileNodes);
+    assertEquals(8, fileNodes.size());
+
+    when(subItemsIterator.hasNext()).thenReturn(false, true, true, true, true, true, true, true, true, true, true, false);
+    when(subItemsIterator.nextNode()).thenReturn(file1, file2, file3, file4, file5, file6, file7, file8, file9, file10);
+
+    fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 12);
+    assertNotNull(fileNodes);
+    assertEquals(10, fileNodes.size());
+
   }
 
   private Node createFolderMock(String name, Calendar createdDate, Session session) throws RepositoryException {

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -949,36 +949,6 @@ public class JCRDocumentFileStorageTest {
     assertEquals("Xyz", fileNodes.get(0).getName());
     assertEquals("Efg.lnk", fileNodes.get(1).getName());
 
-    Node file3 = createFileMock("file3", Calendar.getInstance(), userSession);
-    Node file4 = createFileMock("file4", Calendar.getInstance(), userSession);
-    Node file5 = createFileMock("file5", Calendar.getInstance(), userSession);
-    Node file6 = createFileMock("file6", Calendar.getInstance(), userSession);
-    Node file7 = createFileMock("file7", Calendar.getInstance(), userSession);
-    Node file8 = createFileMock("file8", Calendar.getInstance(), userSession);
-    Node file9 = createFileMock("file9", Calendar.getInstance(), userSession);
-    Node file10 = createFileMock("file10", Calendar.getInstance(), userSession);
-
-    when(subItemsIterator.hasNext()).thenReturn(false, true, true, true, true, true, true, true, true, true, true, false);
-    when(subItemsIterator.nextNode()).thenReturn(file1, file2, file3, file4, file5, file6, file7, file8, file9, file10);
-
-    fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 4);
-    assertNotNull(fileNodes);
-    assertEquals(4, fileNodes.size());
-
-    when(subItemsIterator.hasNext()).thenReturn(false, true, true, true, true, true, true, true, true, true, true, false);
-    when(subItemsIterator.nextNode()).thenReturn(file1, file2, file3, file4, file5, file6, file7, file8, file9, file10);
-
-    fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 8);
-    assertNotNull(fileNodes);
-    assertEquals(8, fileNodes.size());
-
-    when(subItemsIterator.hasNext()).thenReturn(false, true, true, true, true, true, true, true, true, true, true, false);
-    when(subItemsIterator.nextNode()).thenReturn(file1, file2, file3, file4, file5, file6, file7, file8, file9, file10);
-
-    fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 12);
-    assertNotNull(fileNodes);
-    assertEquals(10, fileNodes.size());
-
   }
 
   private Node createFolderMock(String name, Calendar createdDate, Session session) throws RepositoryException {


### PR DESCRIPTION
Calculating the remaining number of files to load was wrong when the folder contains just files (no folders), it caused that folders having a number of files that exceeds the fetch limit (50) to return empty list of files. The fix recalculates the remaining number of files correctly to load them with each pagination fetch.