### PR TITLE
fix: fix deleting several selected symlinks - EXO-64184

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDeleteFileStorageImpl.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDeleteFileStorageImpl.java
@@ -27,6 +27,7 @@ import javax.jcr.lock.LockException;
 import javax.jcr.version.VersionException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.picocontainer.Startable;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
@@ -203,8 +204,8 @@ public class JCRDeleteFileStorageImpl implements JCRDeleteFileStorage, Startable
       node = JCRDocumentsUtil.getNodeByPath(session, folderPath);
     }
     if (node != null) {
-      if(favorite) {
-        Favorite favoriteDocument = new Favorite("file", node.getUUID(), null, userIdentityId);
+      if (favorite) {
+        Favorite favoriteDocument = new Favorite("file", ((NodeImpl) node).getIdentifier(), null, userIdentityId);
         try {
           favoriteService.deleteFavorite(favoriteDocument);
         } catch (ObjectNotFoundException e) {

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDeleteFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDeleteFileStorageTest.java
@@ -32,6 +32,7 @@ import org.exoplatform.services.jcr.core.ExtendedSession;
 import org.exoplatform.services.jcr.core.ManageableRepository;
 import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
@@ -151,10 +152,10 @@ public class JCRDeleteFileStorageTest {
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getUserSessionProvider(repositoryService, userID)).thenReturn(sessionProvider);
     when(sessionProvider.getSession(Mockito.any(), Mockito.any())).thenReturn(session1);
 
-    Node node = Mockito.mock(ExtendedNode.class);
+    NodeImpl node = Mockito.mock(NodeImpl.class);
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getNodeByPath(session1, path)).thenReturn(node);
     NodeType nodeType = Mockito.mock(NodeType.class);
-    when(node.getUUID()).thenReturn("id123");
+    when(node.getIdentifier()).thenReturn("id123");
     when(node.getName()).thenReturn("name123");
     when(node.getPath()).thenReturn(path);
     when(session.getNodeByUUID(eq("id123"))).thenReturn(node);

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -451,6 +451,7 @@ export default {
         const treatedItems = this.selectedDocuments.filter(file => actionData.treatedItemsIds.includes(file.id));
         this.resetSelections();
         if (actionStatus === 'done_with_errors') {
+          this.setMultiActionLoading(false);
           this.$root.$emit('show-alert', {
             type: 'error',
             message: this.$t(`documents.bulk.${actionName}.doneWithErrors`)


### PR DESCRIPTION
Prior to this change, when deleting a several symlinks and attempts to delete each realated favorite metadata the used `node.getUUID` is not working on symlinks are they are not mix referencable.
Instead in this PR we use the node identifier as it's already the correct value used to create the favorite metadata.