### PR TITLE
fix : After collaborating on a document group permission isn't displayed in the access manage drawer  -EXO-63772 (#904)

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1112,6 +1112,14 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
               permissions.put("redactor:" + groupId, new String[] { PermissionType.READ });
             }
           }
+        } else if (permission.getIdentity().getProviderId().equals("group")) {
+          String groupId = permission.getIdentity().getRemoteId();
+          if (permission.getPermission().equals("edit")) {
+            permissions.put("*:"+groupId, PermissionType.ALL);
+          }
+          if (permission.getPermission().equals("read")) {
+            permissions.put("*:"+groupId, new String[]{PermissionType.READ});
+          }
         } else {
           if (permission.getPermission().equals("edit")) {
             permissions.put(permission.getIdentity().getRemoteId(), PermissionType.ALL);

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -41,6 +41,8 @@ import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.Group;
+import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.security.*;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
@@ -477,6 +479,8 @@ public class JCRDocumentsUtil {
           if(identity!=null){
             permissions.add(new PermissionEntry(identity, accessControlEntry.getPermission(),getPermissionRole(accessControlEntry.getMembershipEntry().getMembershipType())));
           }
+        } else if (groupToIdentity(membershipEntry.getGroup()) != null) {
+          permissions.add(new PermissionEntry(groupToIdentity(membershipEntry.getGroup()), accessControlEntry.getPermission(),PermissionRole.ALL.name()));
         }
       } else{
         org.exoplatform.social.core.identity.model.Identity identity = identityManager.getOrCreateUserIdentity(nodeAclIdentity);
@@ -744,5 +748,26 @@ public class JCRDocumentsUtil {
       return false;
     }
     return true;
+  }
+  /*
+  * Build a group to identity model to display it on the manage access drawer collaborators .
+  * Like the built model by the identity suggester for group suggester .
+  */
+  public static org.exoplatform.social.core.identity.model.Identity groupToIdentity(String groupId){
+
+    OrganizationService organizationService = CommonsUtils.getService(OrganizationService.class);
+    try {
+      Group group = organizationService.getGroupHandler().findGroupById(groupId);
+      org.exoplatform.social.core.identity.model.Identity identity = new org.exoplatform.social.core.identity.model.Identity();
+      Profile profile = new Profile();
+      profile.setProperty("fullName", group.getLabel());
+      identity.setId("group:"+group.getGroupName());
+      identity.setRemoteId(groupId);
+      identity.setProviderId("group");
+      identity.setProfile(profile);
+      return identity;
+    } catch (Exception e){
+      return null ;
+    }
   }
 }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -1247,4 +1247,41 @@ public class JCRDocumentFileStorageTest {
     assertThrows(Exception.class, () -> jcrDocumentFileStorage.moveDocuments(1, 1L, documents, "destPath", identity, 1L));
   }
 
+  @Test
+  public void TestUpdatePermission() throws RepositoryException {
+    org.exoplatform.services.security.Identity aclIdentity = mock(org.exoplatform.services.security.Identity.class);
+    org.exoplatform.social.core.identity.model.Identity identity = mock(org.exoplatform.social.core.identity.model.Identity.class);
+    org.exoplatform.social.core.identity.model.Identity identity1 = mock(org.exoplatform.social.core.identity.model.Identity.class);
+    when(identity.getProviderId()).thenReturn("group");
+    when(identity.getRemoteId()).thenReturn("/platform/users");
+    when(identity1.getProviderId()).thenReturn("user");
+    when(identity1.getRemoteId()).thenReturn("John");
+    when(aclIdentity.getUserId()).thenReturn("user");
+    ManageableRepository manageableRepository = mock(ManageableRepository.class);
+    lenient().when(repositoryService.getCurrentRepository()).thenReturn(manageableRepository);
+    Session session = mock(Session.class);
+    SessionProvider sessionProvider = mock(SessionProvider.class);
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getUserSessionProvider(repositoryService, aclIdentity))
+                      .thenReturn(sessionProvider);
+    lenient().when(sessionProvider.getSession("collaboration", manageableRepository)).thenReturn(session);
+    ExtendedNode node = mock(ExtendedNode.class);
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getNodeByIdentifier(session, "123")).thenReturn(node);
+    lenient().when(node.canAddMixin(NodeTypeConstants.EXO_DATE_MODIFIED)).thenReturn(true);
+    lenient().when(node.canAddMixin(NodeTypeConstants.EXO_LAST_MODIFIED_DATE)).thenReturn(true);
+    lenient().when(node.canAddMixin(NodeTypeConstants.EXO_PRIVILEGEABLE)).thenReturn(true);
+    lenient().when(node.hasNode(NodeTypeConstants.JCR_CONTENT)).thenReturn(true);
+    NodePermission nodePermission = mock(NodePermission.class);
+    // permissionsList including group permission
+    List<PermissionEntry> permissionsList = new ArrayList<>();
+    permissionsList.add(new PermissionEntry(identity, "read", null));
+    permissionsList.add(new PermissionEntry(identity1, "edit", null));
+    when(nodePermission.getPermissions()).thenReturn(permissionsList);
+    //When
+    jcrDocumentFileStorage.updatePermissions("123",  nodePermission, aclIdentity);
+    //Then
+    verify(node).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("*:/platform/administrators") && Arrays.equals(map.get("*:/platform/administrators"),PermissionType.ALL)));
+    verify(node).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("*:/platform/users") && Arrays.equals(map.get("*:/platform/users"),new String[]{"read"})));
+    verify(node).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("John") && Arrays.equals(map.get("John"),PermissionType.ALL)));
+  }
+
 }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -32,6 +32,9 @@ import javax.jcr.version.Version;
 
 import org.exoplatform.services.jcr.access.PermissionType;
 import org.exoplatform.services.jcr.impl.core.SessionImpl;
+import org.exoplatform.services.organization.Group;
+import org.exoplatform.services.organization.GroupHandler;
+import org.exoplatform.services.organization.OrganizationService;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -352,4 +355,23 @@ public class JCRDocumentsUtilTest {
     doThrow(new RuntimeException()).when(session).checkPermission("path", PermissionType.SET_PROPERTY);
     assertFalse(JCRDocumentsUtil.hasEditPermission(session, node));
   }
+
+  @Test
+  public void testGroupToIdentity() throws Exception {
+    OrganizationService organizationService = mock(OrganizationService.class);
+    Group group = mock(Group.class);
+    when(group.getGroupName()).thenReturn("users");
+    when(group.getLabel()).thenReturn("Users");
+    when(group.getId()).thenReturn("/platform/users");
+    COMMONS_UTILS_UTIL.when(()-> CommonsUtils.getService(OrganizationService.class)).thenReturn(organizationService);
+    GroupHandler groupHandler = mock(GroupHandler.class);
+    when(organizationService.getGroupHandler()).thenReturn(groupHandler);
+    when(groupHandler.findGroupById("/platform/users")).thenReturn(group);
+    org.exoplatform.social.core.identity.model.Identity identity = JCRDocumentsUtil.groupToIdentity(group.getId());
+    assertNotNull(identity);
+    assertEquals("group:users", identity.getId());
+    assertEquals(group.getId(), identity.getRemoteId());
+    assertEquals("group", identity.getProviderId());
+  }
+
 }

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsVisibilityDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsVisibilityDrawer.vue
@@ -284,7 +284,7 @@ export default {
           'fullName': fullName,
         },
         'name': collaborator.displayName || fullName,
-        'remoteId': collaborator.remoteId,
+        'remoteId': collaborator.providerId === 'group' ? collaborator.spaceId : collaborator.remoteId,
         'providerId': collaborator.providerId,
         'avatar': collaborator.profile.avatarUrl
 
@@ -340,6 +340,9 @@ export default {
             'providerId': user.providerId,
           }
         };
+        if (user.groupId) {
+          collaborator.identity.groupId = user.groupId;
+        }
         collaborators.push(collaborator);      }
       this.file.acl.collaborators=collaborators;
       if (this.file.acl.visibilityChoice==='SPECIFIC_COLLABORATOR'){


### PR DESCRIPTION
Before to this change when collaborating on a document with a group permission by adding the group as collaborators from the manage access drawer the document permission wouldn't be updated and the group wouldn't be displayed on the manage access drawer , This change will update the permission update method to allow the addition of the provided group permission to the document's permission and create an identity model for the group , similar to the one built by the identity suggester in order to display it in the collaborators suggester list .