### PR TITLE
fix : After collaborating on a document group permission isn't displayed in the access manage drawer -EXO-63772

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -57,6 +57,8 @@ public class EntityBuilder {
 
   public static final String         USER_PUBLIC_ROOT_NODE           = "/Public";
 
+  public static final String         GROUP_PROVIDER_ID               = "group";
+
   private EntityBuilder() {
   }
 
@@ -335,23 +337,7 @@ public class EntityBuilder {
             toShare.put(Long.valueOf(identityManager.getOrCreateSpaceIdentity(permissionEntryEntity.getIdentity().getRemoteId()).getId()), permissionEntryEntity.getPermission());
             permissions.add(toPermissionEntry(permissionEntryEntity, identityManager));
           } else if(permissionEntryEntity.getIdentity().getProviderId().equals("group")){
-            try {
-              ExoContainer container = ExoContainerContext.getCurrentContainer();
-              OrganizationService orgService = container.getComponentInstanceOfType(OrganizationService.class);
-              invitedGroupId = permissionEntryEntity.getIdentity().getRemoteId();
-              ListAccess<User> listAccess = orgService.getUserHandler().findUsersByGroupId(invitedGroupId);
-              User[] users = listAccess.load(0, listAccess.getSize());
-              for(User u : users) {
-                if (!documentFileService.canAccess(node.getId(), documentFileService.getAclUserIdentity(u.getUserName()))) {
-                  toShare.put(Long.valueOf(identityManager.getOrCreateUserIdentity(u.getUserName()).getId()), permissionEntryEntity.getPermission());
-                } else {
-                  toNotify.put(Long.valueOf(identityManager.getOrCreateUserIdentity(u.getUserName()).getId()), permissionEntryEntity.getPermission());
-                }
-              }
               permissions.add(toPermissionEntry(permissionEntryEntity, identityManager));
-            } catch (Exception e) {
-              LOG.warn("Failed to invite users from group " + invitedGroupId, e);
-            }
           } else {
             try {
               if (!documentFileService.canAccess(node.getId(), documentFileService.getAclUserIdentity(permissionEntryEntity.getIdentity().getRemoteId()))) {
@@ -502,7 +488,8 @@ public class EntityBuilder {
         identityEntity.setName(space.getDisplayName());
         identityEntity.setAvatar(space.getAvatarUrl());
       }
-    }
+    } else if (identity.getProviderId().equals(GROUP_PROVIDER_ID))
+      identityEntity.setName(identity.getProfile().getFullName());
     return identityEntity;
   }
   private static boolean isEditPermission(String permission){

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1086,6 +1086,14 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
               permissions.put("redactor:" + groupId, new String[] { PermissionType.READ });
             }
           }
+        } else if (permission.getIdentity().getProviderId().equals("group")) {
+          String groupId = permission.getIdentity().getRemoteId();
+          if (permission.getPermission().equals("edit")) {
+            permissions.put("*:"+groupId, PermissionType.ALL);
+          }
+          if (permission.getPermission().equals("read")) {
+            permissions.put("*:"+groupId, new String[]{PermissionType.READ});
+          }
         } else {
           if (permission.getPermission().equals("edit")) {
             permissions.put(permission.getIdentity().getRemoteId(), PermissionType.ALL);

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -41,6 +41,8 @@ import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.Group;
+import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.security.*;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
@@ -464,6 +466,8 @@ public class JCRDocumentsUtil {
           if(identity!=null){
             permissions.add(new PermissionEntry(identity, accessControlEntry.getPermission(),getPermissionRole(accessControlEntry.getMembershipEntry().getMembershipType())));
           }
+        } else if (groupToIdentity(membershipEntry.getGroup()) != null) {
+          permissions.add(new PermissionEntry(groupToIdentity(membershipEntry.getGroup()), accessControlEntry.getPermission(),PermissionRole.ALL.name()));
         }
       } else{
         org.exoplatform.social.core.identity.model.Identity identity = identityManager.getOrCreateUserIdentity(nodeAclIdentity);
@@ -720,4 +724,25 @@ public class JCRDocumentsUtil {
     return exoTitle;
   }
 
+  /*
+  * Build a group to identity model to display it on the manage access drawer collaborators .
+  * Like the built model by the identity suggester for group suggester .
+  */
+  public static org.exoplatform.social.core.identity.model.Identity groupToIdentity(String groupId){
+
+    OrganizationService organizationService = CommonsUtils.getService(OrganizationService.class);
+    try {
+      Group group = organizationService.getGroupHandler().findGroupById(groupId);
+      org.exoplatform.social.core.identity.model.Identity identity = new org.exoplatform.social.core.identity.model.Identity();
+      Profile profile = new Profile();
+      profile.setProperty("fullName", group.getLabel());
+      identity.setId("group:"+group.getGroupName());
+      identity.setRemoteId(groupId);
+      identity.setProviderId("group");
+      identity.setProfile(profile);
+      return identity;
+    } catch (Exception e){
+      return null ;
+    }
+  }
 }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -33,6 +33,9 @@ import javax.jcr.nodetype.NodeType;
 import javax.jcr.version.Version;
 
 import org.exoplatform.services.jcr.impl.core.SessionImpl;
+import org.exoplatform.services.organization.Group;
+import org.exoplatform.services.organization.GroupHandler;
+import org.exoplatform.services.organization.OrganizationService;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -356,4 +359,23 @@ public class JCRDocumentsUtilTest {
     String[] expectedSortedArray = new String[]{"1", "2", "2 test", "3", "Afile", "bfile", "file1", "file2", "file3" ,"file10", "file20"};
     assertEquals(expectedSortedArray, list.toArray(new String[list.size()]));
   }
+
+  @Test
+  public void testGroupToIdentity() throws Exception {
+    OrganizationService organizationService = mock(OrganizationService.class);
+    Group group = mock(Group.class);
+    when(group.getGroupName()).thenReturn("users");
+    when(group.getLabel()).thenReturn("Users");
+    when(group.getId()).thenReturn("/platform/users");
+    when(CommonsUtils.getService(OrganizationService.class)).thenReturn(organizationService);
+    GroupHandler groupHandler = mock(GroupHandler.class);
+    when(organizationService.getGroupHandler()).thenReturn(groupHandler);
+    when(groupHandler.findGroupById("/platform/users")).thenReturn(group);
+    org.exoplatform.social.core.identity.model.Identity identity = JCRDocumentsUtil.groupToIdentity(group.getId());
+    assertNotNull(identity);
+    assertEquals("group:users", identity.getId());
+    assertEquals(group.getId(), identity.getRemoteId());
+    assertEquals("group", identity.getProviderId());
+  }
+
 }

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsVisibilityDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsVisibilityDrawer.vue
@@ -284,7 +284,7 @@ export default {
           'fullName': fullName,
         },
         'name': collaborator.displayName || fullName,
-        'remoteId': collaborator.remoteId,
+        'remoteId': collaborator.providerId === 'group' ? collaborator.spaceId : collaborator.remoteId,
         'providerId': collaborator.providerId,
         'avatar': collaborator.profile.avatarUrl
 
@@ -340,6 +340,9 @@ export default {
             'providerId': user.providerId,
           }
         };
+        if (user.groupId) {
+          collaborator.identity.groupId = user.groupId;
+        }
         collaborators.push(collaborator);      }
       this.file.acl.collaborators=collaborators;
       if (this.file.acl.visibilityChoice==='SPECIFIC_COLLABORATOR'){


### PR DESCRIPTION
Before to this change when collaborating on a document with a group permission by adding the group as collaborators from the manage access drawer the document permission wouldn't be updated and the group wouldn't be displayed on the manage access drawer , This change will update the permission update method to allow the addition of the provided group permission to the document's permission and create an identity model for the group , similar to the one built by the identity suggester in order to display it in the collaborators suggester list .