### PR TITLE
fix: treeview label is not translated in folder view in documents app - EXO-64461

### DIFF
--- a/documents-webapp/src/main/resources/locale/portlet/Documents_de.properties
+++ b/documents-webapp/src/main/resources/locale/portlet/Documents_de.properties
@@ -85,6 +85,7 @@ documents.label.no-content.folder=Dieser Ordner ist leer
 documents.label.no-content.addFolder=Ordner hinzuf\u00FCgen
 documents.label.no-content.addDocument=oder Dokument
 documents.label.userHomeDocuments=Personenbezogene Unterlagen
+documents.label.spaceHomeDocuments=Dokumente
 documents.drawer.tree=Ordnerbaum
 documents.label.extension.visibility=Zugriff
 documents.label.visibility.specific.collaborator=Nur Gastgeber und benannte Mitarbeiter k\u00F6nnen editieren

--- a/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
+++ b/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
@@ -85,6 +85,7 @@ documents.label.no-content.folder=This folder is empty
 documents.label.no-content.addFolder=Add Folder
 documents.label.no-content.addDocument=or document
 documents.label.userHomeDocuments=Personal Documents
+documents.label.spaceHomeDocuments=Documents
 documents.drawer.tree=Folder tree
 documents.label.extension.visibility=Access
 documents.label.visibility.specific.collaborator=Only hosts and designated collaborators can edit

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -142,6 +142,8 @@ export default {
     getName(name){
       if (name==='Private'){
         return this.$t('documents.label.userHomeDocuments');
+      } else if (name==='Documents'){
+        return this.$t('documents.label.spaceHomeDocuments');
       }
       return name;
     },


### PR DESCRIPTION
prior to this change, the treeview label in docs app in folder view wasn't translated.
after this change it would be well translated