### PR TITLE
fix: Prevent group administrators from being displayed in the access management drawer for non-group administrator members - EXO-64412 (#926)

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -32,6 +32,7 @@ import org.exoplatform.documents.constant.DocumentSortField;
 import org.exoplatform.documents.model.*;
 import org.exoplatform.documents.storage.JCRDeleteFileStorage;
 import org.exoplatform.documents.storage.jcr.search.DocumentFileSearchResult;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.access.AccessControlEntry;
 import org.exoplatform.services.jcr.access.PermissionType;
@@ -467,6 +468,10 @@ public class JCRDocumentsUtil {
             permissions.add(new PermissionEntry(identity, accessControlEntry.getPermission(),getPermissionRole(accessControlEntry.getMembershipEntry().getMembershipType())));
           }
         } else if (groupToIdentity(membershipEntry.getGroup()) != null) {
+          UserACL userACL = CommonsUtils.getService(UserACL.class);
+          if (membershipEntry.getGroup().equals(userACL.getAdminGroups()) && !aclIdentity.isMemberOf(membershipEntry)) {
+            continue;
+          }
           permissions.add(new PermissionEntry(groupToIdentity(membershipEntry.getGroup()), accessControlEntry.getPermission(),PermissionRole.ALL.name()));
         }
       } else{


### PR DESCRIPTION
This change is going to prevent group administrators from being displayed in the access management drawer for non-group administrator members .