### PR TITLE
fix: Enable to upload a file containing an '+' character in its name - EXO-64192

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -301,6 +301,7 @@ export default {
         const id = this.file.id;
         this.$attachmentService.getAttachmentById(id)
           .then(attachment => {
+            const nodeName = attachment.path.substring(attachment.path.lastIndexOf('/') + 1 );
             documentPreview.init({
               doc: {
                 id: id,
@@ -308,7 +309,7 @@ export default {
                 workspace: 'collaboration',
                 //concat the file type if attachement title haven't extension on preview mode
                 title: decodeURI(attachment.title).lastIndexOf('.') >= 0 ? decodeURI(attachment.title) : decodeURI(attachment.title).concat(this.fileType),
-                downloadUrl: attachment.downloadUrl,
+                downloadUrl: attachment.downloadUrl.replace(nodeName, encodeURIComponent(nodeName).replace('%', '%25')),
                 openUrl: attachment.openUrl,
                 breadCrumb: attachment.previewBreadcrumb,
                 fileInfo: this.fileInfo(),

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -309,7 +309,7 @@ export default {
                 workspace: 'collaboration',
                 //concat the file type if attachement title haven't extension on preview mode
                 title: decodeURI(attachment.title).lastIndexOf('.') >= 0 ? decodeURI(attachment.title) : decodeURI(attachment.title).concat(this.fileType),
-                downloadUrl: attachment.downloadUrl.replace(nodeName, encodeURIComponent(nodeName).replace('%', '%25')),
+                downloadUrl: attachment.downloadUrl.replace(nodeName, encodeURIComponent(nodeName).replaceAll('%', '%25')),
                 openUrl: attachment.openUrl,
                 breadCrumb: attachment.previewBreadcrumb,
                 fileInfo: this.fileInfo(),


### PR DESCRIPTION
Before this change, when we uploaded a file with a name containing the '+' character, we were unable to preview or download it. The problem was that the '+' character in the file's path was being replaced by a space.
With this change, we will encode the node name part on the document's download url.
