### PR TITLE
fix : Enable to upload document in folder with name contains '.' character  - EXO-64403 - EXO-64406 (#920)

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -595,7 +595,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       }
       //no need to this object later make it eligible to the garbage collactor
       nodeAccessList = null;
-      String name = Text.escapeIllegalJcrChars(cleanName(title.toLowerCase()));
+      String name = Text.escapeIllegalJcrChars(cleanName(title.toLowerCase(), NodeTypeConstants.NT_FOLDER ));
       if (node.hasNode(name)) {
         throw new ObjectAlreadyExistsException("Folder'" + name + "' already exist");
       }
@@ -645,14 +645,14 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
           throw new ObjectNotFoundException("Folder with path : " + folderPath + " isn't found");
         }
       }
-      String name = Text.escapeIllegalJcrChars(cleanName(title.toLowerCase()));
+      String name = Text.escapeIllegalJcrChars(cleanName(title.toLowerCase(), NodeTypeConstants.NT_FOLDER));
       int i =0;
       String newName = name;
       String newTitle = title;
       while((node.hasNode(newName))){
         i++;
         newTitle = title + " (" + i + ")";
-        newName = Text.escapeIllegalJcrChars(cleanName(newTitle.toLowerCase()));
+        newName = Text.escapeIllegalJcrChars(cleanName(newTitle.toLowerCase(), NodeTypeConstants.NT_FOLDER));
       }
       return newTitle;
     } catch (Exception e) {
@@ -683,7 +683,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       } else {
         node = getNodeByIdentifier(session, documentID);
       }
-      String name = Text.escapeIllegalJcrChars(cleanName(title.toLowerCase()));
+      String name = Text.escapeIllegalJcrChars(cleanName(title.toLowerCase(), node.getPrimaryNodeType().getName()));
       //clean node name
       name = URLDecoder.decode(name, "UTF-8");
       if (name.indexOf('.') == -1) {

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -634,9 +634,12 @@ public class JCRDocumentsUtil {
    * @return the string
    */
   public static String cleanName(String oldName) {
+    return cleanName(oldName, NodeTypeConstants.NT_FILE);
+  }
+  public static String cleanName(String oldName, String nodeType) {
     if (org.apache.commons.lang.StringUtils.isEmpty(oldName)) return oldName;
     String extension = "" ;
-    if(oldName.lastIndexOf(".") > -1){
+    if(nodeType.equals(NodeTypeConstants.NT_FILE) && oldName.lastIndexOf(".") > -1){
       extension = oldName.substring(oldName.lastIndexOf("."));
       oldName = oldName.substring(0,oldName.lastIndexOf(".")) ;
     }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -599,10 +599,13 @@ public class JCRDocumentFileStorageTest {
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getUserSessionProvider(repositoryService,identity)).thenReturn(sessionProvider);
     when(sessionProvider.getSession("collaboration", manageableRepository)).thenReturn(session);
     Node node = mock(Node.class);
+    NodeType nodeType = mock(NodeType.class);
+    when(node.getPrimaryNodeType()).thenReturn(nodeType);
+    when(nodeType.getName()).thenReturn(NodeTypeConstants.NT_FILE);
     when(getNodeByIdentifier(session, "123")).thenReturn(node);
     when(identity.getUserId()).thenReturn("user");
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.isValidDocumentTitle(anyString())).thenCallRealMethod();
-    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.cleanName(anyString())).thenCallRealMethod();
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.cleanName(anyString(), anyString())).thenCallRealMethod();
     when(node.getName()).thenReturn("oldName");
     when(node.canAddMixin(NodeTypeConstants.EXO_MODIFY)).thenReturn(true);
     when(node.canAddMixin(NodeTypeConstants.EXO_SORTABLE)).thenReturn(true);
@@ -623,7 +626,6 @@ public class JCRDocumentFileStorageTest {
     when(node.getParent()).thenReturn(parent);
     when(parent.hasNode("exist")).thenReturn(true);
     when(parent.getNode("exist")).thenReturn(existNode);
-    NodeType nodeType = mock(NodeType.class);
     when(nodeType.getName()).thenReturn("nt:file");
     when(existNode.getPrimaryNodeType()).thenReturn(nodeType);
     when(node.getPrimaryNodeType()).thenReturn(nodeType);

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -374,4 +374,27 @@ public class JCRDocumentsUtilTest {
     assertEquals("group", identity.getProviderId());
   }
 
+  @Test
+  public void testCleanName(){
+    //legal document name
+    String fileName = "fileName.text";
+    String folderName = "folderName";
+    assertEquals(fileName, JCRDocumentsUtil.cleanName(fileName, NodeTypeConstants.NT_FILE));
+    assertEquals(folderName, JCRDocumentsUtil.cleanName(folderName, NodeTypeConstants.NT_FOLDER));
+
+    // illegal document name
+    String illeglFileName = "illegal&file#Name.text";
+    String illegalFolderName = "illegal&folder#Name";
+    assertEquals("illegal_file_Name.text", JCRDocumentsUtil.cleanName(illeglFileName, NodeTypeConstants.NT_FILE));
+    assertEquals("illegal_folder_Name", JCRDocumentsUtil.cleanName(illegalFolderName, NodeTypeConstants.NT_FOLDER));
+
+    // folder name with '.' character
+    String folderNameWithPointChar = "folderNameWithPoint.char";
+    assertEquals("folderNameWithPoint_char", JCRDocumentsUtil.cleanName(folderNameWithPointChar, NodeTypeConstants.NT_FOLDER));
+
+    //folder name with '.' character followed by a special character
+    String folderNameWithPointfollowedBySpChar = "folder&Name.followedBy#character";
+    assertEquals("folder_Name_followedBy_character", JCRDocumentsUtil.cleanName(folderNameWithPointfollowedBySpChar, NodeTypeConstants.NT_FOLDER));
+  }
+
 }


### PR DESCRIPTION
Before to this change we weren't able to create a folder with name containing a '.' followed by a special character , the issue stemmed to the cleanName method which uses the '.' character to identify the file's extension and remove it from the name , so if we have a folder name like test.test#test the last part after the '.' character wouldn't be cleaned , resulting this problem .

To address this issue, we will update the method cleanName to check the document type before cleaning the name of document.