### PR TITLE
fix: multiple zip downloaded on multi-selection when several tabs are opened - EXO-64506

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
@@ -724,10 +724,10 @@ public class DocumentFileRest implements ResourceContainer {
   @Path("bulk/download/{actionId}")
   @RolesAllowed("users")
   @Operation(summary = "Download zipped list of files", method = "GET", description = "This download a zipped list of files.")
-  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"),
-      @ApiResponse(responseCode = "400", description = "Invalid query input"),
-      @ApiResponse(responseCode = "403", description = "Unauthorized operation"),
-      @ApiResponse(responseCode = "404", description = "Resource not found") })
+  @ApiResponses(value = { 
+          @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+          @ApiResponse(responseCode = "400", description = "Invalid query input"),
+          @ApiResponse(responseCode = "410", description = "Resource no more available") })
   public Response getDownloadZip(@Parameter(description = "List items", required = true)
   @PathParam("actionId")
   int actionId) {
@@ -736,6 +736,9 @@ public class DocumentFileRest implements ResourceContainer {
       Identity currentUserIdentity = RestUtils.getCurrentUserIdentity(identityManager);
       byte[] filesBytes = documentFileService.getDownloadZipBytes(actionId,
               currentUserIdentity.getRemoteId());
+      if (filesBytes.length == 0) {
+        return Response.status(Status.GONE).build();
+      }
       return Response.ok(filesBytes)
                      .type("application/zip")
                      .header("Content-Disposition", "attachment; filename=\"documents_Download" + new Date().getTime() + ".zip\"")

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
@@ -1002,8 +1002,11 @@ public class DocumentFileRestTest {
     when(identityManager.getIdentity((String.valueOf(currentOwnerId)))).thenReturn(currentIdentity);
     when(identityManager.getOrCreateUserIdentity(username)).thenReturn(currentIdentity);
     mockRestUtils().when(() -> RestUtils.getCurrentUserIdentity(identityManager)).thenReturn(currentIdentity);
-    when(documentFileStorage.getDownloadZipBytes(123456, username)).thenReturn(null);
+    when(documentFileStorage.getDownloadZipBytes(123456, username)).thenReturn(new byte[0]);
     Response response = documentFileRest.getDownloadZip(123456);
+    assertEquals(Response.Status.GONE.getStatusCode(), response.getStatus());
+    when(documentFileStorage.getDownloadZipBytes(123456, username)).thenReturn(new byte[10]);
+    response = documentFileRest.getDownloadZip(123456);
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
   }
 

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -574,11 +574,15 @@ export default {
           this.$root.$emit('show-alert', {type: 'success', message: this.$t(`documents.bulk.${actionData.actionType.toLowerCase()}.doneSuccessfully`, {0: actionData.numberOfItems})});
         }
       }).catch(e => {
-        console.error('Error when export note page', e);
-        this.$root.$emit('show-alert', {
-          type: 'error',
-          message: this.$t(`documents.bulk.${actionData.actionType.toLowerCase()}.failed`)
-        });
+        if (e.status === 410) {
+          this.$root.$emit('set-download-status',actionData.status);
+        } else {
+          console.error('Error when export note page', e);
+          this.$root.$emit('show-alert', {
+            type: 'error',
+            message: this.$t(`documents.bulk.${actionData.actionType.toLowerCase()}.failed`)
+          });
+        }
       });
     },
     handleAlertClose() {

--- a/documents-webapp/src/main/webapp/vue-app/documents/js/DocumentFileService.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/js/DocumentFileService.js
@@ -479,7 +479,7 @@ export function getDownloadZip(actionId) {
     if (resp && resp.ok) {
       return resp;
     } else { 
-      throw new Error('Error when getting downloaded files');
+      throw resp;
     }
   });
 }


### PR DESCRIPTION

Prior to this change, As web socket event is fired depends on user identity and not browser tab id, then the event will triggered on all opened tabs where the websoket listener intercepts the event. In our case the zipped folder once downloaded the resource folder is deleted.
In this PR,  we managed to set the http response to gone once the download resource is no more available as it's already downloaded, and so the download will not be invoked several times.