### PR TITLE
fix : share document with user who have left the space - EXO-63717

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -361,14 +361,14 @@ public class EntityBuilder {
           } else {
             try {
               //check if the owner is a space and the destination is a member of this space
-              if (ownerId.isSpace() && spaceService.isMember(spaceService.getSpaceByDisplayName(ownerId.getRemoteId()), permissionEntryEntity.getIdentity().getRemoteId())) {
+              if (ownerId.isSpace() && spaceService.isMember(spaceService.getSpaceByPrettyName(ownerId.getRemoteId()), permissionEntryEntity.getIdentity().getRemoteId())) {
                 toNotify.put(Long.valueOf(identityManager.getOrCreateUserIdentity(permissionEntryEntity.getIdentity().getRemoteId()).getId()),permissionEntryEntity.getPermission());
               } else {
                 toShare.put(Long.valueOf(identityManager.getOrCreateUserIdentity(permissionEntryEntity.getIdentity().getRemoteId()).getId()),permissionEntryEntity.getPermission());
               }
               permissions.add(toPermissionEntry(permissionEntryEntity, identityManager));
             } catch (Exception exception) {
-              LOG.warn("Cannot get user Identity");
+              LOG.error(exception.getMessage(), exception);
             }
           }
         }

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -360,10 +360,11 @@ public class EntityBuilder {
               permissions.add(toPermissionEntry(permissionEntryEntity, identityManager));
           } else {
             try {
-              if (!documentFileService.canAccess(node.getId(), documentFileService.getAclUserIdentity(permissionEntryEntity.getIdentity().getRemoteId()))) {
-                toShare.put(Long.valueOf(identityManager.getOrCreateUserIdentity(permissionEntryEntity.getIdentity().getRemoteId()).getId()),permissionEntryEntity.getPermission());
-              } else {
+              //check if the owner is a space and the destination is a member of this space
+              if (ownerId.isSpace() && spaceService.isMember(spaceService.getSpaceByDisplayName(ownerId.getRemoteId()), permissionEntryEntity.getIdentity().getRemoteId())) {
                 toNotify.put(Long.valueOf(identityManager.getOrCreateUserIdentity(permissionEntryEntity.getIdentity().getRemoteId()).getId()),permissionEntryEntity.getPermission());
+              } else {
+                toShare.put(Long.valueOf(identityManager.getOrCreateUserIdentity(permissionEntryEntity.getIdentity().getRemoteId()).getId()),permissionEntryEntity.getPermission());
               }
               permissions.add(toPermissionEntry(permissionEntryEntity, identityManager));
             } catch (Exception exception) {

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/util/EntityBuilderTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/util/EntityBuilderTest.java
@@ -84,7 +84,7 @@ public class EntityBuilderTest {
         when(identity.getId()).thenReturn("3");
         when(identity.isSpace()).thenReturn(true);
         when(identity.getRemoteId()).thenReturn("spaceTest");
-        when(spaceService.getSpaceByDisplayName(identity.getRemoteId())).thenReturn(space);
+        when(spaceService.getSpaceByPrettyName(identity.getRemoteId())).thenReturn(space);
         // Destination user isn't member of the space
         when(spaceService.isMember(space, "userRemoteId")).thenReturn(false);
         // When

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/util/EntityBuilderTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/util/EntityBuilderTest.java
@@ -1,7 +1,6 @@
 package org.exoplatform.documents.rest.util;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -71,5 +70,35 @@ public class EntityBuilderTest {
         nodePermissionEntity.setCollaborators(List.of(permissionEntryEntity));
         NodePermission nodePermission2 = EntityBuilder.toNodePermission(abstractNodeEntity,documentFileService, spaceService, identityManager);
         assertNotNull(nodePermission2);
+
+        IdentityEntity useridentityEntity = new IdentityEntity();
+        useridentityEntity.setId("1");
+        useridentityEntity.setRemoteId("userRemoteId");
+        useridentityEntity.setProviderId("user");
+        permissionEntryEntity.setIdentity(useridentityEntity);
+        permissionEntryEntity.setPermission("edit");
+        Identity destinationIdentity = mock(Identity.class);
+        when(destinationIdentity.getRemoteId()).thenReturn("userRemoteId");
+        when(destinationIdentity.getId()).thenReturn(useridentityEntity.getId());
+        when(identityManager.getOrCreateUserIdentity(destinationIdentity.getRemoteId())).thenReturn(destinationIdentity);
+        when(identity.getId()).thenReturn("3");
+        when(identity.isSpace()).thenReturn(true);
+        when(identity.getRemoteId()).thenReturn("spaceTest");
+        when(spaceService.getSpaceByDisplayName(identity.getRemoteId())).thenReturn(space);
+        // Destination user isn't member of the space
+        when(spaceService.isMember(space, "userRemoteId")).thenReturn(false);
+        // When
+        NodePermission nodePermission3 = EntityBuilder.toNodePermission(abstractNodeEntity,documentFileService, spaceService, identityManager);
+        // assert to share with destination user
+        assertNotNull(nodePermission3);
+        assertEquals(Long.valueOf(useridentityEntity.getId()), nodePermission3.getToShare().keySet().toArray()[0]);
+
+        // Destination user is member of the space
+        when(spaceService.isMember(space, "userRemoteId")).thenReturn(true);
+        // When
+        NodePermission nodePermission4 = EntityBuilder.toNodePermission(abstractNodeEntity,documentFileService, spaceService, identityManager);
+        // assert to notify destination user
+        assertNotNull(nodePermission3);
+        assertEquals(Long.valueOf(useridentityEntity.getId()), nodePermission4.getToNotify().keySet().toArray()[0]);
     }
 }


### PR DESCRIPTION
Before this change, when we shared a document with a user who was already a member of the space and then re-shared it after the user had left the space, no symlink would be created on the user's personal document. The problem stemmed from an incorrect check that verified whether the destination user had access to the document to be shared, which always returned true due to the initial share action.
This change is going to check if the owner is a space and the destination user is already a member of this space.