### PR TITLE
fix : Enable to upload a file with name contains a special character from the download menu action - EXO-64549

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DownloadMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DownloadMenuAction.vue
@@ -40,7 +40,8 @@ export default {
       if (!this.isMultiSelection) {
         this.$attachmentService.getAttachmentById(this.file.id)
           .then(attachment => {
-            this.downloadUrl = attachment.downloadUrl;
+            const nodeName = attachment.path.substring(attachment.path.lastIndexOf('/') + 1 );
+            this.downloadUrl = attachment.downloadUrl.replace(nodeName, encodeURIComponent(nodeName).replaceAll('%', '%25')) ;
           })
           .catch(e => console.error(e))
           .finally(() => {


### PR DESCRIPTION

Before this change, we were unable to download a document that contained a '+' character from the download menu action. The problem was that the '+' character was being replaced by a space in the document's download URL. This change will encode the document's download URL.