### PR TITLE
fix: fix muliple selection downloaded zip name - EXO-64506

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -519,7 +519,7 @@ export default {
           this.$root.$emit('set-download-status','zip_file_created');
           this.setMultiActionLoading(false);
           this.resetSelections();
-          this.getDownlodedZip(actionData); 
+          this.getDownloadedZip(actionData);
         } else {
           this.$root.$emit('set-download-status',actionData.status);
         }
@@ -559,13 +559,15 @@ export default {
         setTimeout(() => this.openFolder(folder), 500);
       }
     },
-    getDownlodedZip(actionData) {
+    getDownloadedZip(actionData) {
       this.$documentFileService.getDownloadZip(actionData.actionId).then((transfer) => {
         return transfer.blob();
       }).then((bytes) => {
         const today = new Date();
         const formattedDate = `${(today.getMonth() + 1).toString().padStart(2, '0')}_${today.getDate().toString().padStart(2, '0')}_${today.getFullYear().toString()}`;
-        const zipName = eXo.env.portal.spaceDisplayName? `${eXo.env.portal.spaceDisplayName}_${formattedDate}.zip` : `My Drive_${formattedDate}.zip`;
+        const sourceName = localStorage.getItem(`bulkDownloadSourceName${actionData.actionId}`);
+        const zipName = `${sourceName}_${formattedDate}.zip`;
+        localStorage.removeItem(sourceName);
         const elm = document.createElement('a');
         elm.href = URL.createObjectURL(bytes);
         elm.setAttribute('download', zipName);
@@ -817,6 +819,7 @@ export default {
       const random = crypto.getRandomValues(new Uint32Array(1))[0];
       const actionId =random % max; 
       this.$root.$emit('open-download-drawer',actionId);
+      localStorage.setItem(`bulkDownloadSourceName${actionId}`, eXo?.env?.portal?.spaceDisplayName || 'My Drive');
       return this.$documentFileService
         .bulkDownloadDocument(actionId,this.selectedDocuments)
         .catch(e => console.error(e));


### PR DESCRIPTION
prior to this change, when download multiple files while several doc tabs are opened the downloaded zip name will take the first websocket intercepted event in any space tab even if it's the different space name.
This PR ensures to have the correct space source name in the downloaded zip by saving it in the `localStorage`