### PR TITLE
fix : Enable to preview and download file with name contains a special character - EXO-64575 (#969)

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -631,7 +631,7 @@ public class JCRDocumentsUtil {
       oldName = oldName.substring(0,oldName.lastIndexOf(".")) ;
     }
     oldName = oldName.trim();
-    String specialChar = "&#*@.'\"\t\r\n$\\><:;[]/|";
+    String specialChar = "&#*@.'\"\t\r\n$\\><:;[]/|’";
     StringBuilder ret = new StringBuilder();
     for (int i = 0; i < oldName.length(); i++) {
       char currentChar = oldName.charAt(i);


### PR DESCRIPTION
Before this change, we were unable to preview or upload a document with a name that contained the character " ’ ". This change will add this character to the list of special characters that will be replaced by an underscore