### PR TITLE
fix : add new folder/document button labels not displayed on mobile view - EXO-64606 (#976)

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentAddNewMobile.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentAddNewMobile.vue
@@ -12,7 +12,7 @@
             class="clickable pr-2">
             fa-folder
           </v-icon>
-          <span v-if="!isMobile" class="body-2 text-color">{{ $t('documents.button.addNewFolder') }}</span>
+          <span class="body-2 text-color">{{ $t('documents.button.addNewFolder') }}</span>
         </v-list-item>
         <v-list-item
           @click="openDrawer()"
@@ -22,7 +22,7 @@
             class="clickable pr-2">
             fa-file-alt
           </v-icon>
-          <span v-if="!isMobile" class="body-2 text-color">{{ $t('documents.button.addNewFile') }}</span>
+          <span class="body-2 text-color">{{ $t('documents.button.addNewFile') }}</span>
         </v-list-item>
       </v-list>
       <exo-drawer />


### PR DESCRIPTION
This change is going to display the add new folder or document button labels on mobile view