### PR TITLE
fix: fix saving document public access without options - EXO-64350,EXO-63866

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
@@ -1052,8 +1052,10 @@ public class DocumentFileRest implements ResourceContainer {
     if (userIdentityId == 0) {
       return Response.status(Response.Status.UNAUTHORIZED).build();
     }
-    
-    if (publicDocumentAccessOptionsEntity.getPassword() != null) {
+    String password = publicDocumentAccessOptionsEntity != null ? publicDocumentAccessOptionsEntity.getPassword() : null;
+    Long expirationDate = publicDocumentAccessOptionsEntity != null ? publicDocumentAccessOptionsEntity.getExpirationDate() : 0L;
+    boolean hasPassword = publicDocumentAccessOptionsEntity != null && publicDocumentAccessOptionsEntity.isHasPassword();
+    if (password != null) {
       String errorMessage = PASSWORD_VALIDATOR.validate(locale, publicDocumentAccessOptionsEntity.getPassword());
       if (StringUtils.isNotBlank(errorMessage)) {
         return Response.status(Response.Status.BAD_REQUEST).entity(errorMessage).build();
@@ -1067,9 +1069,9 @@ public class DocumentFileRest implements ResourceContainer {
 
       return Response.ok(EntityBuilder.toPublicDocumentAccessEntity(publicDocumentAccessService.createPublicDocumentAccess(userIdentityId,
                                                                                                                            nodeId,
-                                                                                                                           publicDocumentAccessOptionsEntity.getPassword(),
-                                                                                                                           publicDocumentAccessOptionsEntity.getExpirationDate(),
-                                                                                                                           publicDocumentAccessOptionsEntity.isHasPassword())))
+                                                                                                                           password,
+                                                                                                                           expirationDate,
+                                                                                                                           hasPassword)))
                      .build();
 
     } catch (Exception e) {

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -387,7 +387,8 @@ public class EntityBuilder {
           }
         }
       }
-      if(nodePermissionEntity.getVisibilityChoice().equals(Visibility.ALL_MEMBERS.name())){
+      if (nodePermissionEntity.getVisibilityChoice().equals(Visibility.ALL_MEMBERS.name())
+          || nodePermissionEntity.getVisibilityChoice().equals(Visibility.COLLABORATORS_AND_PUBLIC_ACCESS.name())) {
         permissions.add(new PermissionEntry(identity,"read", PermissionRole.ALL.name()));
         if(nodePermissionEntity.isAllMembersCanEdit()){
           permissions.add(new PermissionEntry(identity,"edit",PermissionRole.ALL.name()));

--- a/documents-services/src/main/java/org/exoplatform/documents/service/PublicDocumentAccessServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/PublicDocumentAccessServiceImpl.java
@@ -139,6 +139,9 @@ public class PublicDocumentAccessServiceImpl implements PublicDocumentAccessServ
     if (publicDocumentAccess == null) {
       return false;
     }
+    if (publicDocumentAccess.getPasswordHashKey() == null) {
+      return true;
+    }
     return validatePassword(password, publicDocumentAccess.getPasswordHashKey());
   }
 

--- a/documents-webapp/src/main/webapp/skin/less/documents.less
+++ b/documents-webapp/src/main/webapp/skin/less/documents.less
@@ -675,6 +675,7 @@
   align-self: center;
   left: inherit !important;
   margin-bottom: 70px !important;
+  z-index: 1041;
 }
 
   /* switch */

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsVisibilityDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsVisibilityDrawer.vue
@@ -72,7 +72,7 @@
                     <span class="text-color body-2 mr-6">
                       {{ $t('document.visibility.publicAccess.message') }}
                     </span>
-                    <p class="caption"> {{ $t('document.visibility.publicAccess.choice.info') }} </p>
+                    <p class="caption pe-8"> {{ $t('document.visibility.publicAccess.choice.info') }} </p>
                   </v-label>
                 </div>
                 <div class="d-flex flex-column">

--- a/documents-webapp/src/main/webapp/vue-app/documents/js/DocumentFileService.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/js/DocumentFileService.js
@@ -548,7 +548,11 @@ export function createDocumentPublicAccess(nodeId, publicAccessOptions) {
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(publicAccessOptions),
+    body: JSON.stringify(publicAccessOptions, (key, value) => {
+      if (value !== null) {
+        return value;
+      }
+    }),
   }).then(resp => {
     if (!resp?.ok) {
       throw resp;


### PR DESCRIPTION
Prior to this change, when saving a public document access without password, the validation of the access remains always based on the password. 
This PR will make sure to check if the password exist to validate it