### PR TITLE
fix : Enable to search document with name contains an elastic search reserved characters - EXO-64651

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
@@ -66,6 +66,7 @@ public class DocumentSearchServiceConnector {
           + "    \"query\": \"*@term@*\""
           + "  }" + "},";
 
+  public static final String           QUERY_TAG_TERM           = "@term@";
   private static final String          IMAGES                   =
                                                   "\"image/bmp\",\"image/jpeg\",\"image/webp\",\"image/png\",\"image/gif\",\"image/avif\",\"image/tiff\"";
 
@@ -424,13 +425,16 @@ public class DocumentSearchServiceConnector {
     if (StringUtils.isBlank(term)) {
       return "";
     }
+    String originalTerm = term;
     term = escapeReservedCharacters(term);
+    boolean isEscapedReservedCharactersTerm = !originalTerm.equals(term);
     List<String> queryParts = Arrays.asList(term.split(" "));
     String escapedQueryWithAndOperator = StringUtils.join(queryParts, "* AND *");
     if (!extendedSearch) {
-      return SEARCH_QUERY_TERM.replace("@term@", escapedQueryWithAndOperator);
+      // If the reserved characters are escaped we will escape also the * character in the search query term.
+      return isEscapedReservedCharactersTerm ? SEARCH_QUERY_TERM.replace("*", "\\\\*").replace(QUERY_TAG_TERM, escapedQueryWithAndOperator) : SEARCH_QUERY_TERM.replace(QUERY_TAG_TERM, escapedQueryWithAndOperator) ;
     }
-    return EXTENDED_SEARCH_QUERY_TERM.replace("@term@", escapedQueryWithAndOperator);
+    return isEscapedReservedCharactersTerm ? EXTENDED_SEARCH_QUERY_TERM.replace("*", "\\\\*").replace(QUERY_TAG_TERM, escapedQueryWithAndOperator) : EXTENDED_SEARCH_QUERY_TERM.replace(QUERY_TAG_TERM, escapedQueryWithAndOperator);
   }
 
   private String retrieveSearchQuery() {

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnectorTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnectorTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2023 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.documents.storage.jcr.search;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.commons.search.es.client.ElasticSearchingClient;
+import org.exoplatform.commons.utils.IOUtil;
+import org.exoplatform.container.configuration.ConfigurationManager;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.PropertiesParam;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.documents.constant.DocumentSortField;
+import org.exoplatform.documents.legacy.search.data.SearchResult;
+import org.exoplatform.documents.model.DocumentFolderFilter;
+import org.exoplatform.documents.model.DocumentNodeFilter;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.services.security.IdentityConstants;
+import org.exoplatform.social.core.manager.IdentityManager;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DocumentSearchServiceConnectorTest {
+
+  public static final String   QUERY_TAG_TERM                    = "@term@";
+
+  private static final String  ES_INDEX                          = "file_alias";
+
+  private static final String  WORKSPACE                         = "collaboration";
+
+  private static final String  SEARCH_QUERY_FILE_PATH_PARAM      = "query.file.path";
+
+  public static String         SEARCH_QUERY_TERM                 = "\"must\":{" + "    \"query_string\":{"
+      + "    \"fields\": [\"title\"]," + "    \"query\": \"*@term@*\"" + "  }" + "},";
+
+  private static String        SEARCH_QUERY;
+
+  @Mock
+  IdentityManager              identityManager;
+
+  @Mock
+  ElasticSearchingClient       client;
+
+  private String               searchResult                      = null;
+
+  private String               searchWithReservedCharacterResult = null;
+
+  private ConfigurationManager configurationManager;
+
+  @Before
+  public void setUp() throws Exception {
+    configurationManager = mock(ConfigurationManager.class);
+    try {
+      SEARCH_QUERY = IOUtil.getStreamContentAsString(getClass().getClassLoader()
+                                                               .getResourceAsStream("documents-search-query.json"));
+      searchResult = IOUtil.getStreamContentAsString(getClass().getClassLoader()
+                                                               .getResourceAsStream("document-search-result.json"));
+      searchWithReservedCharacterResult =
+                                        IOUtil.getStreamContentAsString(getClass().getClassLoader()
+                                                                                  .getResourceAsStream("document-search-reserved-character-result.json"));
+      Mockito.reset(configurationManager);
+      when(configurationManager.getInputStream("FILE_PATH")).thenReturn(new ByteArrayInputStream(SEARCH_QUERY.getBytes()));
+    } catch (Exception e) {
+      throw new IllegalStateException("Error retrieving ES Query content", e);
+    }
+  }
+
+  @Test
+  public void searchTest() {
+
+    Identity userIdentity = mock(Identity.class);
+    when(userIdentity.getUserId()).thenReturn("1");
+    when(userIdentity.getMemberships()).thenReturn(new ArrayList<>());
+    DocumentNodeFilter filter = new DocumentFolderFilter(null, null, 1L, null);
+    filter.setExtendedSearch(false);
+    filter.setFavorites(false);
+    filter.setIncludeHiddenFiles(false);
+    filter.setSortField(DocumentSortField.NAME);
+    filter.setAscending(true);
+    filter.setQuery("test");
+    int limit = 51;
+    int offset = 0;
+    String path = "/Groups/spaces/test/Documents/";
+    String sort_field = "title";
+    String sort_direction = "ASC";
+    String expectedQuery = SEARCH_QUERY.replace("@term_query@", SEARCH_QUERY_TERM.replace(QUERY_TAG_TERM, filter.getQuery()))
+                                       .replace("@favorite_query@", "")
+                                       .replace("@permissions@", getPermissionQuery(userIdentity))
+                                       .replace("@fileTypes_query@", "")
+                                       .replace("@size_query@", "")
+                                       .replace("@date_query@", "")
+                                       .replace("@path@", path)
+                                       .replace("@workspace@", WORKSPACE)
+                                       .replace("@sort_field@", sort_field + ".raw")
+                                       .replace("@sort_direction@", sort_direction)
+                                       .replace("@offset@", String.valueOf(offset))
+                                       .replace("@limit@", String.valueOf(limit));
+    DocumentSearchServiceConnector documentSearchServiceConnector = new DocumentSearchServiceConnector(configurationManager,
+                                                                                                       identityManager,
+                                                                                                       client,
+                                                                                                       getParams());
+    // limit is negative
+    assertThrows(IllegalArgumentException.class,
+                 () -> documentSearchServiceConnector.search(userIdentity,
+                                                             WORKSPACE,
+                                                             path,
+                                                             filter,
+                                                             offset,
+                                                             -limit,
+                                                             sort_field,
+                                                             sort_direction));
+    // identity is null
+    assertThrows(IllegalArgumentException.class,
+                 () -> documentSearchServiceConnector.search(null,
+                                                             WORKSPACE,
+                                                             path,
+                                                             filter,
+                                                             offset,
+                                                             limit,
+                                                             sort_field,
+                                                             sort_direction));
+    // search term is mandatory
+    filter.setQuery(null);
+    assertThrows(IllegalArgumentException.class,
+                 () -> documentSearchServiceConnector.search(userIdentity,
+                                                             WORKSPACE,
+                                                             path,
+                                                             filter,
+                                                             offset,
+                                                             -limit,
+                                                             sort_field,
+                                                             sort_direction));
+
+    // when
+    filter.setQuery("test");
+    when(client.sendRequest(expectedQuery, ES_INDEX)).thenReturn(searchResult);
+    Collection<SearchResult> result = documentSearchServiceConnector.search(userIdentity,
+                                                                            WORKSPACE,
+                                                                            path,
+                                                                            filter,
+                                                                            offset,
+                                                                            limit,
+                                                                            sort_field,
+                                                                            sort_direction);
+
+    // then
+    //verify call with the expected query
+    //assert search result
+    verify(client, times(1)).sendRequest(expectedQuery, ES_INDEX);
+    assertFalse(result.isEmpty());
+
+    // when
+    // search term contains ES reserved character
+    filter.setQuery("term-with-reserved-character");
+    String esquipedReservedCharactersTermQuery = "\\\\*term\\\\-with\\\\-reserved\\\\-character\\\\*";
+    String oldSearchedTermQuery = "*test*";
+    when(client.sendRequest(expectedQuery.replace(oldSearchedTermQuery, esquipedReservedCharactersTermQuery),
+                            ES_INDEX)).thenReturn(searchWithReservedCharacterResult);
+    result = documentSearchServiceConnector.search(userIdentity,
+                                                   WORKSPACE,
+                                                   path,
+                                                   filter,
+                                                   offset,
+                                                   limit,
+                                                   sort_field,
+                                                   sort_direction);
+
+    // verify expected search query
+    //assert search result
+    verify(client, times(1)).sendRequest(expectedQuery.replace(oldSearchedTermQuery, esquipedReservedCharactersTermQuery),
+                                         ES_INDEX);
+    assertFalse(result.isEmpty());
+  }
+
+  private InitParams getParams() {
+    InitParams params = new InitParams();
+    PropertiesParam propertiesParam = new PropertiesParam();
+    propertiesParam.setName("constructor.params");
+    propertiesParam.setProperty("index", ES_INDEX);
+
+    ValueParam valueParam = new ValueParam();
+    valueParam.setName(SEARCH_QUERY_FILE_PATH_PARAM);
+    valueParam.setValue("FILE_PATH");
+
+    params.addParameter(propertiesParam);
+    params.addParameter(valueParam);
+    return params;
+  }
+
+  private String getPermissionQuery(Identity userIdentity) {
+    String permissionQuery = "{\n" + "  \"term\" : { \"permissions\" : \"" + userIdentity.getUserId() + "\" }\n" + "},\n" + "{\n"
+        + "  \"term\" : { \"permissions\" : \"" + IdentityConstants.ANY + "\" }\n" + "}";
+    return permissionQuery;
+  }
+}

--- a/documents-storage-jcr/src/test/resources/document-search-reserved-character-result.json
+++ b/documents-storage-jcr/src/test/resources/document-search-reserved-character-result.json
@@ -1,0 +1,38 @@
+{
+  "took": 28,
+  "timed_out": false,
+  "_shards": {
+    "total": 5,
+    "successful": 5,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 1,
+      "relation": "eq"
+    },
+    "max_score": 1.0,
+    "hits": [
+      {
+        "_index": "file_v3",
+        "_type": "_doc",
+        "_id": "c4a221847f0001013218c5b049ffd95c",
+        "_score": 1.0,
+        "_source": {
+          "path": "/Groups/spaces/test/Documents/term-with-reserved-character.png",
+          "workspace": "collaboration",
+          "name": "term-with-reserved-character.png"
+        },
+        "highlight": {
+          "title": [
+            "<span class='searchMatchExcerpt'>term-with-reserved-character</span>.png"
+          ]
+        },
+        "sort": [
+          "term-with-reserved-character.png"
+        ]
+      }
+    ]
+  }
+}

--- a/documents-storage-jcr/src/test/resources/document-search-result.json
+++ b/documents-storage-jcr/src/test/resources/document-search-result.json
@@ -1,0 +1,39 @@
+{
+  "took": 28,
+  "timed_out": false,
+  "_shards": {
+    "total": 5,
+    "successful": 5,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 1,
+      "relation": "eq"
+    },
+    "max_score": 1.0,
+    "hits": [
+      {
+        "_index": "file_v3",
+        "_type": "_doc",
+        "_id": "c4a221847f0001013218c5b049ffd95f",
+        "_score": 1.0,
+        "_source": {
+          "path": "/Groups/spaces/test/Documents/test.png",
+          "workspace": "collaboration",
+          "name": "test.png"
+        },
+        "highlight": {
+          "title": [
+            "<span class='searchMatchExcerpt'>test</span>.png"
+          ]
+        },
+        "sort": [
+          "test.png"
+        ]
+      }
+    ]
+  }
+}
+


### PR DESCRIPTION
Before this change, when we were searching for a document with a name containing the "-" character, no results were displayed. The problem was that when we escaped the reserved characters in the search term, the "*" character in the search query was not escaped.

This change will verify if the search term contains any escaped reserved characters and then escape the "*" character in the search query.