### PR TITLE
fix: Update document permission from the all collaborators drawer - EXO-65052

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsAllUsersVisibilityDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsAllUsersVisibilityDrawer.vue
@@ -79,13 +79,17 @@ export default {
       'visibilityChoice': 'ALL_MEMBERS'
     }},
   }),
+  created() {
+    this.$root.$on('open-all-users-visibility-drawer', file => this.open(file));
+  },
   computed: {
     specificCollaborators(){
       return this.$t('documents.label.visibility.specificCollaborator');
     },
   },
   methods: {
-    open() {
+    open(file) {
+      this.file = file;
       this.$refs.documentAllUsersVisibilityDrawer.open();
     },
     close() {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsVisibilityDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsVisibilityDrawer.vue
@@ -320,7 +320,7 @@ export default {
 
     },
     displayAllListUsers(){
-      this.$refs.documentAllUsersVisibilityDrawer.open();
+      this.$root.$emit('open-all-users-visibility-drawer', this.file);
     },
     saveVisibility(){
       this.loading = true;


### PR DESCRIPTION
Before this change, when we tried to update the permission from the "all collaborators" drawer, an exception was thrown and an error message was displayed. The problem was due to a wrong request body file object that was missing attributes such as path and document id.

With this change, the file object will be initialized when the "all collaborators" drawer is opened.