### PR TITLE
fix : Fix the infinite loop that occurs when creating a shortcut of a folder within the same folder -EXO-65086

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -419,7 +419,6 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         folderId = ((NodeImpl) node).getIdentifier();
       } else {
         node = getNodeByIdentifier(session, folderId);
-        node = checkSymlinkHistory(node, session, ownerId);
       }
       if (StringUtils.isNotBlank(folderPath)) {
         node = getNodeByPath(node, folderPath, sessionProvider);
@@ -458,10 +457,16 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
               }
               break;
             } else{
-              node = node.getParent();
+              Node parentNode = node.getParent();
+              node = parentNode;
               node = checkSymlinkHistory(node, session, ownerId);
               if (node != null) {
                 nodeName= node.hasProperty(NodeTypeConstants.EXO_TITLE) ? node.getProperty(NodeTypeConstants.EXO_TITLE).getString() : node.getName();
+                String identifier = ((NodeImpl)node).getIdentifier();
+                // If the symlink exists on the breadcrumb list, then the required node is the non-symlink node
+                if (parents.stream().anyMatch(breadCrumbItem -> breadCrumbItem.isSymlink() && breadCrumbItem.getId().equals(identifier))){
+                  node = parentNode;
+                }
                 parents.add(new BreadCrumbItem(((NodeImpl) node).getIdentifier(),
                                                nodeName,
                                                node.getPath(),


### PR DESCRIPTION

Before this change, when we created a shortcut of a folder within the same folder, an infinite loop was thrown. This issue occurred due to the symlink check, which returned the symlink of the node itself. This change is going to resolve this problem by disallowing the addition of the same symlink to the breadcrumb list.