### PR TITLE
fix: fix copy public link when no password is defined - EXO-64645

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/service/PublicDocumentAccessServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/PublicDocumentAccessServiceImpl.java
@@ -130,7 +130,7 @@ public class PublicDocumentAccessServiceImpl implements PublicDocumentAccessServ
   @Override
   public PublicDocumentAccess getPublicDocumentAccess(String documentId) {
     PublicDocumentAccess publicDocumentAccess = publicDocumentAccessStorage.getPublicDocumentAccessByNodeId(documentId);
-    if (publicDocumentAccess != null) {
+    if (publicDocumentAccess != null && publicDocumentAccess.getEncodedPassword() != null) {
       publicDocumentAccess.setDecodedPassword(codec.decode(publicDocumentAccess.getEncodedPassword()));
     }
     return publicDocumentAccess;


### PR DESCRIPTION
fix copy public link when no password is defined