### PR TITLE
fix: When a version is created by system, the version history drawer is empty - EXO-65435

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -58,7 +58,7 @@ import org.exoplatform.social.core.space.spi.SpaceService;
 
 public class JCRDocumentsUtil {
   private static final Log                              LOG                           =
-                                                            ExoLogger.getLogger(JCRDocumentsUtil.class);
+      ExoLogger.getLogger(JCRDocumentsUtil.class);
 
   private static final String                           DEFAULT_GROUPS_HOME_PATH      = "/Groups";                             // NOSONAR
 
@@ -243,10 +243,10 @@ public class JCRDocumentsUtil {
   }
 
   public static FolderNode toFolderNode(IdentityManager identityManager,
-                                 Identity aclIdentity,
-                                 Node node,
-                                 String sourceID,
-                                 SpaceService spaceService) {
+                                        Identity aclIdentity,
+                                        Node node,
+                                        String sourceID,
+                                        SpaceService spaceService) {
     try {
       if (node == null) {
         return null;
@@ -305,7 +305,7 @@ public class JCRDocumentsUtil {
     toFileNode(identityManager, aclIdentity, node, fileNode , spaceService);
     return fileNode;
   }
-  
+
   public static void toFileNode(IdentityManager identityManager,
                                 Identity aclIdentity,
                                 Node node,
@@ -331,7 +331,7 @@ public class JCRDocumentsUtil {
       }
     }
   }
-  
+
   private static void retrieveViewsProperty(Node node, FileNode fileNode) throws RepositoryException {
     long views = 0L;
     if (node.isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
@@ -342,7 +342,7 @@ public class JCRDocumentsUtil {
     }
     fileNode.setViews(views);
   }
-  
+
   private static void retrieveSymlinkSize(Node node, FileNode fileNode) throws RepositoryException {
     Node source = getNodeByIdentifier(node.getSession(), fileNode.getSourceID());
     if (source != null && source.getNode(NodeTypeConstants.JCR_CONTENT) != null) {
@@ -436,8 +436,8 @@ public class JCRDocumentsUtil {
         }
       }
       long modifiedDate = nodeToModify.getProperty(NodeTypeConstants.EXO_DATE_MODIFIED)
-              .getDate()
-              .getTimeInMillis();
+                                      .getDate()
+                                      .getTimeInMillis();
       documentNode.setModifiedDate(modifiedDate);
       String modifier = nodeToModify.getProperty(NodeTypeConstants.EXO_LAST_MODIFIER).getString();
       documentNode.setModifierId(getUserIdentityId(identityManager, modifier));
@@ -596,10 +596,10 @@ public class JCRDocumentsUtil {
       SessionProvider systemSession = SessionProvider.createSystemProvider();
       Node identityNode = nodeHierarchyCreator.getUserNode(systemSession, ownerIdentity.getRemoteId());
       String privatePathNode = identityNode.getPath()+"/"+USER_PRIVATE_ROOT_NODE;
-        if (session.itemExists(privatePathNode)) {
-          identityRootNode = (Node) session.getItem(privatePathNode);
-        }
-     }
+      if (session.itemExists(privatePathNode)) {
+        identityRootNode = (Node) session.getItem(privatePathNode);
+      }
+    }
     return identityRootNode;
   }
 
@@ -687,9 +687,9 @@ public class JCRDocumentsUtil {
   public static String getMimeType(Node node) {
     try {
       if (node.getPrimaryNodeType().getName().equals(NodeTypeConstants.NT_FILE) && node.hasNode(NodeTypeConstants.JCR_CONTENT)) {
-          return node.getNode(NodeTypeConstants.JCR_CONTENT)
-                  .getProperty(NodeTypeConstants.JCR_MIME_TYPE)
-                  .getString();
+        return node.getNode(NodeTypeConstants.JCR_CONTENT)
+                   .getProperty(NodeTypeConstants.JCR_MIME_TYPE)
+                   .getString();
       }
     } catch (RepositoryException e) {
       LOG.error(e.getMessage(), e);
@@ -728,7 +728,9 @@ public class JCRDocumentsUtil {
       versionFileNode.setTitle(node.getName());
     }
     String userName = frozen.getProperty(NodeTypeConstants.EXO_LAST_MODIFIER).getValue().getString();
-    Profile profile = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, userName).getProfile();
+    org.exoplatform.social.core.identity.model.Identity
+        identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, userName);
+    Profile profile = identity != null ? identity.getProfile() : null;
     String[] summary = node.getVersionHistory().getVersionLabels(version);
     if (summary.length > 0) {
       versionFileNode.setSummary(summary[0]);
@@ -737,7 +739,7 @@ public class JCRDocumentsUtil {
     versionFileNode.setFrozenId(frozen.getUUID());
     versionFileNode.setOriginId(node.getUUID());
     versionFileNode.setAuthor(userName);
-    versionFileNode.setAuthorFullName(profile.getFullName());
+    versionFileNode.setAuthorFullName(profile != null ? profile.getFullName() : userName);
     versionFileNode.setCreatedDate(version.getCreated().getTime());
     versionFileNode.setVersionNumber(Integer.parseInt(version.getName()));
     if (version.getName().equals(currentVersionName)) {
@@ -775,9 +777,9 @@ public class JCRDocumentsUtil {
     return true;
   }
   /*
-  * Build a group to identity model to display it on the manage access drawer collaborators .
-  * Like the built model by the identity suggester for group suggester .
-  */
+   * Build a group to identity model to display it on the manage access drawer collaborators .
+   * Like the built model by the identity suggester for group suggester .
+   */
   public static org.exoplatform.social.core.identity.model.Identity groupToIdentity(String groupId){
 
     OrganizationService organizationService = CommonsUtils.getService(OrganizationService.class);
@@ -795,7 +797,7 @@ public class JCRDocumentsUtil {
       return null ;
     }
   }
-  
+
   public static DownloadItem toDownloadItem(Node node) throws Exception {
     ByteArrayOutputStream byteArrayOutputStream = null;
     String mimeType = null;
@@ -824,10 +826,10 @@ public class JCRDocumentsUtil {
   }
 
   public static void createFile(Node node,
-                                 String symlinkPath,
-                                 String sourcePath,
-                                 String tempFolderPath,
-                                 String parentPath) throws RepositoryException, IOException {
+                                String symlinkPath,
+                                String sourcePath,
+                                String tempFolderPath,
+                                String parentPath) throws RepositoryException, IOException {
     if (node == null) {
       return;
     }
@@ -905,7 +907,7 @@ public class JCRDocumentsUtil {
   private static String getFolderName(File file, String folderName) {
     return StringUtils.isNotEmpty(folderName) ? folderName + "/" + file.getName() : file.getName();
   }
-  
+
   private static void zipFolder(File folder, String folderName, ZipOutputStream zipOutputStream) throws Exception {
     File[] files = folder.listFiles();
     if (files == null) {

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -29,12 +29,16 @@ import java.util.List;
 import javax.jcr.*;
 import javax.jcr.nodetype.NodeType;
 import javax.jcr.version.Version;
+import javax.jcr.version.VersionHistory;
+
 
 import org.exoplatform.services.jcr.access.PermissionType;
+import org.exoplatform.documents.model.FileVersion;
 import org.exoplatform.services.jcr.impl.core.SessionImpl;
 import org.exoplatform.services.organization.Group;
 import org.exoplatform.services.organization.GroupHandler;
 import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -395,6 +399,47 @@ public class JCRDocumentsUtilTest {
     //folder name with '.' character followed by a special character
     String folderNameWithPointfollowedBySpChar = "folder&Name.followedBy#character";
     assertEquals("folder_Name_followedBy_character", JCRDocumentsUtil.cleanName(folderNameWithPointfollowedBySpChar, NodeTypeConstants.NT_FOLDER));
+  }
+
+  @Test
+  public void testToFileVersionWithSystemAuthor() throws  RepositoryException {
+    Version version = mock(Version.class);
+    when(version.getName()).thenReturn("1");
+    when(version.getCreated()).thenReturn(Calendar.getInstance());
+
+    Version baseVersion = mock(Version.class);
+    when(baseVersion.getName()).thenReturn("baseVersionName");
+
+    Node frozenNode = mock(Node.class);
+    when(version.getNode(NodeTypeConstants.JCR_FROZEN_NODE)).thenReturn(frozenNode);
+
+    Value value = mock(Value.class);
+    when(value.getString()).thenReturn("__system");
+
+    Property property= mock(Property.class);
+    when(property.getValue()).thenReturn(value);
+    when(frozenNode.getProperty(NodeTypeConstants.EXO_LAST_MODIFIER)).thenReturn(property);
+
+
+    Node node = mock(Node.class);
+    when(node.hasProperty(NodeTypeConstants.EXO_TITLE)).thenReturn(false);
+    when(node.getName()).thenReturn("nodeName");
+    when(node.getBaseVersion()).thenReturn(baseVersion);
+
+    VersionHistory versionHistory = mock(VersionHistory.class);
+    String[] versionLabels = {"versionLabel"};
+    when(versionHistory.getVersionLabels(version)).thenReturn(versionLabels);
+    when(node.getVersionHistory()).thenReturn(versionHistory);
+
+    IdentityManager identityManager = mock(IdentityManager.class);
+    when(identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "__system")).thenReturn(null);
+
+    FileVersion fileVersion = JCRDocumentsUtil.toFileVersion(version,node,identityManager);
+
+
+    assertEquals("__system",fileVersion.getAuthor());
+    assertEquals("__system",fileVersion.getAuthorFullName());
+
   }
 
 }


### PR DESCRIPTION
Before this fix, when a version is created by system session (by a job for example), the version history drawer is empty due to error in RestService : when computing user profile, the identity for system is not found, and so getting the profile create a null pointer exception This fix adress this special case to not have the NPE