### PR TITLE
fix: display all type of folders - EXO-65353

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -78,7 +78,15 @@ import org.exoplatform.social.metadata.tag.model.TagObject;
 
 public class JCRDocumentFileStorage implements DocumentFileStorage {
 
-  private static final String                  COLLABORATION              = "collaboration";
+  private static final String                       COLLABORATION        = "collaboration";
+
+  private static final List<String>                 FOLDER_NODE_TYPES    = List.of(NodeTypeConstants.NT_UNSTRUCTURED,
+                                                                                   NodeTypeConstants.NT_FOLDER,
+                                                                                   NodeTypeConstants.EXO_SYMLINK,
+                                                                                   NodeTypeConstants.CSS_FOLDER,
+                                                                                   NodeTypeConstants.JS_FOLDER,
+                                                                                   NodeTypeConstants.LINK_FOLDER,
+                                                                                   NodeTypeConstants.WEB_FOLDER);
 
   private final SpaceService                   spaceService;
 
@@ -364,7 +372,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
           String sortField = getSortField(filter, true);
           String sortDirection = getSortDirection(filter);
           // Load folders + symlink of folders
-          String statementOfFolders = getFolderDocumentsQuery(parent.getPath(), sortField, sortDirection, List.of(NodeTypeConstants.NT_UNSTRUCTURED, NodeTypeConstants.NT_FOLDER, NodeTypeConstants.EXO_SYMLINK), includeHiddenFiles);
+          String statementOfFolders = getFolderDocumentsQuery(parent.getPath(), sortField, sortDirection, FOLDER_NODE_TYPES, includeHiddenFiles);
           Query jcrQuery = session.getWorkspace().getQueryManager().createQuery(statementOfFolders, Query.SQL);
           ((QueryImpl)jcrQuery).setOffset(offset);
           ((QueryImpl)jcrQuery).setLimit(limit);

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/NodeTypeConstants.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/NodeTypeConstants.java
@@ -32,6 +32,14 @@ public class NodeTypeConstants {
 
   public static final String NT_UNSTRUCTURED           = "nt:unstructured";
 
+  public static final String CSS_FOLDER                = "exo:cssFolder";
+
+  public static final String JS_FOLDER                 = "exo:jsFolder";
+
+  public static final String LINK_FOLDER               = "exo:linkFolder";
+
+  public static final String WEB_FOLDER                = "exo:webFolder";
+
   public static final String NT_RESOURCE               = "nt:resource";
 
   public static final String NT_VERSIONED_CHILD        = "nt:versionedChild";

--- a/documents-webapp/package-lock.json
+++ b/documents-webapp/package-lock.json
@@ -10,7 +10,6 @@
       "license": "LGPL",
       "devDependencies": {
         "babel-loader": "^8.2.4",
-        "copy-to-clipboard": "^3.3.3",
         "eslint": "^8.12.0",
         "eslint-config-meedsio": "^1.0.5",
         "eslint-plugin-vue": "^8.6.0",
@@ -1140,15 +1139,6 @@
       "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/copy-to-clipboard": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
-      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
-      "dev": true,
-      "dependencies": {
-        "toggle-selection": "^1.0.6"
       }
     },
     "node_modules/cross-spawn": {
@@ -3725,12 +3715,6 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
-    "node_modules/toggle-selection": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
-      "dev": true
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5073,15 +5057,6 @@
       "peer": true,
       "requires": {
         "safe-buffer": "~5.1.1"
-      }
-    },
-    "copy-to-clipboard": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
-      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
-      "dev": true,
-      "requires": {
-        "toggle-selection": "^1.0.6"
       }
     },
     "cross-spawn": {
@@ -6939,12 +6914,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
-    "toggle-selection": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
       "dev": true
     },
     "type-check": {


### PR DESCRIPTION
Documents app was displaying just folders of type nt:unstructred and nt:folder 
This change includes other folder types like link folder, css folder etc ...

(cherry picked from commit ba7ae27b2dd55966e06797a8fe08d37cf738a072)