### PR TITLE
fix: display all type of folders - EXO-65353

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -71,7 +71,15 @@ import org.exoplatform.social.metadata.tag.model.TagObject;
 
 public class JCRDocumentFileStorage implements DocumentFileStorage {
 
-  private static final String                  COLLABORATION              = "collaboration";
+  private static final String                       COLLABORATION        = "collaboration";
+
+  private static final List<String>                 FOLDER_NODE_TYPES    = List.of(NodeTypeConstants.NT_UNSTRUCTURED,
+                                                                                   NodeTypeConstants.NT_FOLDER,
+                                                                                   NodeTypeConstants.EXO_SYMLINK,
+                                                                                   NodeTypeConstants.CSS_FOLDER,
+                                                                                   NodeTypeConstants.JS_FOLDER,
+                                                                                   NodeTypeConstants.LINK_FOLDER,
+                                                                                   NodeTypeConstants.WEB_FOLDER);
 
   private final SpaceService                   spaceService;
 
@@ -313,7 +321,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
           String sortField = getSortField(filter, true);
           String sortDirection = getSortDirection(filter);
           // Load folders + symlink of folders
-          String statementOfFolders = getFolderDocumentsQuery(parent.getPath(), sortField, sortDirection, List.of(NodeTypeConstants.NT_UNSTRUCTURED, NodeTypeConstants.NT_FOLDER, NodeTypeConstants.EXO_SYMLINK), includeHiddenFiles);
+          String statementOfFolders = getFolderDocumentsQuery(parent.getPath(), sortField, sortDirection, FOLDER_NODE_TYPES, includeHiddenFiles);
           Query jcrQuery = session.getWorkspace().getQueryManager().createQuery(statementOfFolders, Query.SQL);
           ((QueryImpl)jcrQuery).setOffset(offset);
           ((QueryImpl)jcrQuery).setLimit(limit);

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/NodeTypeConstants.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/NodeTypeConstants.java
@@ -32,7 +32,15 @@ public class NodeTypeConstants {
 
   public static final String NT_UNSTRUCTURED        = "nt:unstructured";
 
-  public static final String NT_RESOURCE            = "nt:resource";
+  public static final String CSS_FOLDER                = "exo:cssFolder";
+
+  public static final String JS_FOLDER                 = "exo:jsFolder";
+
+  public static final String LINK_FOLDER               = "exo:linkFolder";
+
+  public static final String WEB_FOLDER                = "exo:webFolder";
+
+  public static final String NT_RESOURCE               = "nt:resource";
 
   public static final String NT_VERSIONED_CHILD     = "nt:versionedChild";
 


### PR DESCRIPTION
Documents app was displaying just folders of type nt:unstructred and nt:folder 
This change includes other folder types like link folder, css folder etc ...

(cherry picked from commit ba7ae27b2dd55966e06797a8fe08d37cf738a072)