### PR TITLE
fix: When a version is created by system, the version history drawer is empty - EXO-65435

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -728,7 +728,9 @@ public class JCRDocumentsUtil {
       versionFileNode.setTitle(node.getName());
     }
     String userName = frozen.getProperty(NodeTypeConstants.EXO_LAST_MODIFIER).getValue().getString();
-    Profile profile = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, userName).getProfile();
+    org.exoplatform.social.core.identity.model.Identity
+        identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, userName);
+    Profile profile = identity != null ? identity.getProfile() : null;
     String[] summary = node.getVersionHistory().getVersionLabels(version);
     if (summary.length > 0) {
       versionFileNode.setSummary(summary[0]);
@@ -737,7 +739,7 @@ public class JCRDocumentsUtil {
     versionFileNode.setFrozenId(frozen.getUUID());
     versionFileNode.setOriginId(node.getUUID());
     versionFileNode.setAuthor(userName);
-    versionFileNode.setAuthorFullName(profile.getFullName());
+    versionFileNode.setAuthorFullName(profile != null ? profile.getFullName() : userName);
     versionFileNode.setCreatedDate(version.getCreated().getTime());
     versionFileNode.setVersionNumber(Integer.parseInt(version.getName()));
     if (version.getName().equals(currentVersionName)) {

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -29,12 +29,14 @@ import java.util.List;
 import javax.jcr.*;
 import javax.jcr.nodetype.NodeType;
 import javax.jcr.version.Version;
+import javax.jcr.version.VersionHistory;
 
 import org.exoplatform.services.jcr.access.PermissionType;
 import org.exoplatform.services.jcr.impl.core.SessionImpl;
 import org.exoplatform.services.organization.Group;
 import org.exoplatform.services.organization.GroupHandler;
 import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,6 +47,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.documents.model.AbstractNode;
 import org.exoplatform.documents.model.FileNode;
+import org.exoplatform.documents.model.FileVersion;
 import org.exoplatform.documents.storage.JCRDeleteFileStorage;
 import org.exoplatform.services.jcr.access.AccessControlList;
 import org.exoplatform.services.jcr.core.ExtendedNode;
@@ -395,6 +398,47 @@ public class JCRDocumentsUtilTest {
     //folder name with '.' character followed by a special character
     String folderNameWithPointfollowedBySpChar = "folder&Name.followedBy#character";
     assertEquals("folder_Name_followedBy_character", JCRDocumentsUtil.cleanName(folderNameWithPointfollowedBySpChar, NodeTypeConstants.NT_FOLDER));
+  }
+
+  @Test
+  public void testToFileVersionWithSystemAuthor() throws  RepositoryException {
+    Version version = mock(Version.class);
+    when(version.getName()).thenReturn("1");
+    when(version.getCreated()).thenReturn(Calendar.getInstance());
+
+    Version baseVersion = mock(Version.class);
+    when(baseVersion.getName()).thenReturn("baseVersionName");
+
+    Node frozenNode = mock(Node.class);
+    when(version.getNode(NodeTypeConstants.JCR_FROZEN_NODE)).thenReturn(frozenNode);
+
+    Value value = mock(Value.class);
+    when(value.getString()).thenReturn("__system");
+
+    Property property= mock(Property.class);
+    when(property.getValue()).thenReturn(value);
+    when(frozenNode.getProperty(NodeTypeConstants.EXO_LAST_MODIFIER)).thenReturn(property);
+
+
+    Node node = mock(Node.class);
+    when(node.hasProperty(NodeTypeConstants.EXO_TITLE)).thenReturn(false);
+    when(node.getName()).thenReturn("nodeName");
+    when(node.getBaseVersion()).thenReturn(baseVersion);
+
+    VersionHistory versionHistory = mock(VersionHistory.class);
+    String[] versionLabels = {"versionLabel"};
+    when(versionHistory.getVersionLabels(version)).thenReturn(versionLabels);
+    when(node.getVersionHistory()).thenReturn(versionHistory);
+
+    IdentityManager identityManager = mock(IdentityManager.class);
+    when(identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "__system")).thenReturn(null);
+
+    FileVersion fileVersion = JCRDocumentsUtil.toFileVersion(version,node,identityManager);
+
+
+    assertEquals("__system",fileVersion.getAuthor());
+    assertEquals("__system",fileVersion.getAuthorFullName());
+
   }
 
 }


### PR DESCRIPTION
Before this fix, when a version is created by system session (by a job for example), the version history drawer is empty due to error in RestService : when computing user profile, the identity for system is not found, and so getting the profile create a null pointer exception This fix address this special case to not have the NPE

(cherry picked from commit 5d394da05943bd78844620d26e51c385a915704f)