### PR TITLE
fix: When a version is created by system, the version history drawer is empty - EXO-65435

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -698,7 +698,9 @@ public class JCRDocumentsUtil {
       versionFileNode.setTitle(node.getName());
     }
     String userName = frozen.getProperty(NodeTypeConstants.EXO_LAST_MODIFIER).getValue().getString();
-    Profile profile = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, userName).getProfile();
+    org.exoplatform.social.core.identity.model.Identity
+        identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, userName);
+    Profile profile = identity != null ? identity.getProfile() : null;
     String[] summary = node.getVersionHistory().getVersionLabels(version);
     if (summary.length > 0) {
       versionFileNode.setSummary(summary[0]);
@@ -707,7 +709,7 @@ public class JCRDocumentsUtil {
     versionFileNode.setFrozenId(frozen.getUUID());
     versionFileNode.setOriginId(node.getUUID());
     versionFileNode.setAuthor(userName);
-    versionFileNode.setAuthorFullName(profile.getFullName());
+    versionFileNode.setAuthorFullName(profile != null ? profile.getFullName() : userName);
     versionFileNode.setCreatedDate(version.getCreated().getTime());
     versionFileNode.setVersionNumber(Integer.parseInt(version.getName()));
     if (version.getName().equals(currentVersionName)) {


### PR DESCRIPTION
Before this fix, when a version is created by system session (by a job for example), the version history drawer is empty due to error in RestService : when computing user profile, the identity for system is not found, and so getting the profile create a null pointer exception This fix adress this special case to not have the NPE

(cherry picked from commit 5d394da05943bd78844620d26e51c385a915704f)