### PR TITLE
fix : Redirect the user to the destination folder after creating a document shortcut to a renamed space location - EXO-65390 

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -1128,15 +1128,8 @@ export default {
       
     },
     redirectTodestinationSpace(destFolder, space) {
-      const folderPath = destFolder.path.split('/Groups/spaces/')[1].replace('/Documents', '/documents');
-      let pathName;
-      const isSpaceLocation = eXo.env.portal.spaceName !== '';
-      //from space to space
-      if (isSpaceLocation) {
-        pathName = window.location.pathname.split(eXo.env.portal.selectedNodeUri)[0].replace(`:spaces:${eXo.env.portal.spaceGroup}`,`:spaces:${space.prettyName}`);
-      }
-      //from personal drive to space
-      pathName = `${eXo.env.portal.context}/g/${space.groupId.replaceAll('/', ':')}/`;
+      const folderPath = destFolder.path.split(`Groups${space.groupId}`)[1].replace('/Documents', '/documents');
+      const pathName = `${eXo.env.portal.context}/g/${space.groupId.replaceAll('/', ':')}/${space.prettyName}`;
       window.location.replace(`${pathName}${folderPath}?view=folder`, window.location.pathname);
     }
   },


### PR DESCRIPTION

Before this change, when creating a document shortcut from Space or Personal Drive to another destination renaming space, the document content would be changed, but we wouldn't be redirected to the destination space.This issue due to a wrong build of destination space location URL .

With this change, the user will be redirected to the destination space after creating a document shortcut.