### PR TITLE
fix: Fix DocumentSize Widget installation Listener - Meeds-io/MIPs#50

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/listener/DocumentsSpaceApplicationListener.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/listener/DocumentsSpaceApplicationListener.java
@@ -82,7 +82,21 @@ public class DocumentsSpaceApplicationListener implements SpaceLifeCycleListener
 
   @Override
   public void spaceCreated(SpaceLifeCycleEvent event) {
-    // Not needed
+    Space space = event.getSpace();
+    SpaceTemplate spaceTemplate = getSpaceTemplateService().getSpaceTemplateByName(space.getTemplate());
+    if (spaceTemplate != null && spaceTemplate.getSpaceApplicationList() != null) {
+      boolean documentAppInstalled = spaceTemplate.getSpaceApplicationList()
+                                                .stream()
+                                                .anyMatch(app -> StringUtils.equals(app.getPortletName(),
+                                                                                    DOCUMENTS_DOCUMENTS_PORTLET_ID));
+      if (documentAppInstalled) {
+        try {
+          installDocumentsSizeGadget(space, event.getType());
+        } catch (Exception e) {
+          LOG.warn("Error installing AgendaTimeline widget in space {}", space.getDisplayName(), e);
+        }
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
The MIP#50 had change the way the space listeners are triggered to not trigger events embedded inside other events, which means, when a space is created, only space creation is triggered instead of triggering a lot of events due to space initialization. This will help to manage well the events triggered by Space API. This change makes the necessary adapations to add DocumentSize Widget when the used space Template to create the space contains Documents application.