### PR TITLE
fix : Upload or create documents within the shortcut of a folder created in exo 6.3 after upgrading to exo 6.4/6.5 - EXO-65280

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1337,6 +1337,11 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         String sourceNodeId = currentNode.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString();
         currentNode = getNodeByIdentifier(session, sourceNodeId);
       }
+      // add referencable mixin to the node if isn't referencable
+      if (!currentNode.isNodeType(NodeTypeConstants.MIX_REFERENCEABLE ) && currentNode.canAddMixin(NodeTypeConstants.MIX_REFERENCEABLE)) {
+        currentNode.addMixin(NodeTypeConstants.MIX_REFERENCEABLE);
+        currentNode.save();
+      }
       Node linkNode;
       if (currentNode != null && rootNode.hasNode(currentNode.getName())) {
         linkNode = handleShortcutDocConflict(rootNode, currentNode, conflictAction);


### PR DESCRIPTION
Before this change, when we were creating a folder in the document app of a space in Exo 6.3.4, after upgrading to Exo 6.4/6.5 and creating a shortcut of this folder, we were unable to upload or create a document inside it. A repository exception was thrown with the message "folderName isn't referencable " during the process to get the target node.

This fix will now check if the node is referencable and add the referencable mixin before creating a shortcut for it.

(cherry picked from commit 8c7ba6320329ac0ba7ef039c35f27cdc51b821f6)