### PR TITLE
feat: Enable Document app-center for mobile

### DIFF
--- a/documents-webapp/src/main/webapp/WEB-INF/conf/documents/app-center-configuration.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/conf/documents/app-center-configuration.xml
@@ -68,7 +68,7 @@
               <boolean>false</boolean>
             </field>
             <field name="isMobile">
-              <boolean>false</boolean>
+              <boolean>true</boolean>
             </field>
           </object>
         </object-param>


### PR DESCRIPTION
Since `exo.documents.portalConfig.metadata.importmode` is set to `insert` as a default value, is Mobile setting gets overridden every server startup. This PR will set `isMobile` to `true` to enable Drive App for Mobile view. https://github.com/exoplatform/documents/blob/8bee31d7b3d3b113f290a484d5d732c7331e3d6d/documents-webapp/src/main/webapp/WEB-INF/conf/documents/portal-configuration.xml#L52