### PR TITLE
fix : Do not notify space members when the space is assigned as a document collaborator - EXO-65094

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/listener/ShareDocumentNotificationListener.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/listener/ShareDocumentNotificationListener.java
@@ -50,6 +50,10 @@ public class ShareDocumentNotificationListener extends Listener<Identity, Node> 
   public void onEvent(Event<Identity, Node> event) throws Exception {
     Node targetNode = event.getData();
     Identity targetIdentity = event.getSource();
+    if (targetIdentity.getProviderId().equals(SpaceIdentityProvider.NAME)) {
+      // Do not notify space members
+      return;
+    }
     String currentUser = ConversationState.getCurrent().getIdentity().getUserId();
     NotificationContext ctx = NotificationContextImpl.cloneInstance();
     String documentLink = null;
@@ -57,11 +61,6 @@ public class ShareDocumentNotificationListener extends Listener<Identity, Node> 
       documentLink = NotificationUtils.getSharedDocumentLink(targetNode, null, null);
     } else {
       documentLink = NotificationUtils.getDocumentLink(targetNode, spaceService, identityManager);
-    }
-    if (targetIdentity.getProviderId().equals(SpaceIdentityProvider.NAME)) {
-      documentLink = NotificationUtils.getSharedDocumentLink(targetNode,
-                                                             spaceService,
-                                                             targetIdentity.getRemoteId());
     }
     ctx.append(NotificationConstants.FROM_USER, currentUser);
     ctx.append(NotificationConstants.DOCUMENT_URL, documentLink);

--- a/documents-services/src/test/java/org/exoplatform/documents/listener/ShareDocumentNotificationListenerTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/listener/ShareDocumentNotificationListenerTest.java
@@ -148,9 +148,10 @@ public class ShareDocumentNotificationListenerTest {
     NOTIFICATION_UTILS.when(() -> NotificationUtils.getDocumentTitle(any(Node.class))).thenReturn("document");
     shareDocumentNotificationListener.onEvent(event);
     verify(notificationExecutor, times(1)).execute(notificationContext);
-    when(targetIdentity.getRemoteId()).thenReturn("space_name");
+    // Space case
     when(targetIdentity.getProviderId()).thenReturn(SpaceIdentityProvider.NAME);
     shareDocumentNotificationListener.onEvent(event);
-    verify(notificationExecutor, times(2)).execute(notificationContext);
+    //
+    verify(notificationExecutor, times(1)).execute(notificationContext);
   }
 }


### PR DESCRIPTION
This change will prevent the notification of space members when the space is assigned as a document collaborator.