### PR TITLE
fix : Do not notify space members when the space is assigned as a document collaborator - EXO-65094

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/listener/ShareDocumentNotificationListener.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/listener/ShareDocumentNotificationListener.java
@@ -50,6 +50,10 @@ public class ShareDocumentNotificationListener extends Listener<Identity, Node> 
   public void onEvent(Event<Identity, Node> event) throws Exception {
     Node targetNode = event.getData();
     Identity targetIdentity = event.getSource();
+    if (targetIdentity.getProviderId().equals(SpaceIdentityProvider.NAME)) {
+      // Do not notify space members
+      return;
+    }
     String currentUser = ConversationState.getCurrent().getIdentity().getUserId();
     NotificationContext ctx = NotificationContextImpl.cloneInstance();
     String documentLink = null;
@@ -57,11 +61,6 @@ public class ShareDocumentNotificationListener extends Listener<Identity, Node> 
       documentLink = NotificationUtils.getSharedDocumentLink(targetNode, null, null);
     } else {
       documentLink = NotificationUtils.getDocumentLink(targetNode, spaceService, identityManager);
-    }
-    if (targetIdentity.getProviderId().equals(SpaceIdentityProvider.NAME)) {
-      documentLink = NotificationUtils.getSharedDocumentLink(targetNode,
-                                                             spaceService,
-                                                             targetIdentity.getRemoteId());
     }
     ctx.append(NotificationConstants.FROM_USER, currentUser);
     ctx.append(NotificationConstants.DOCUMENT_URL, documentLink);

--- a/documents-services/src/test/java/org/exoplatform/documents/listener/ShareDocumentNotificationListenerTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/listener/ShareDocumentNotificationListenerTest.java
@@ -122,10 +122,11 @@ public class ShareDocumentNotificationListenerTest {
     shareDocumentNotificationListener.onEvent(event);
     verifyStatic(PluginKey.class, times(1));
     PluginKey.key(AddDocumentCollaboratorPlugin.ID);
-    when(targetIdentity.getRemoteId()).thenReturn("space_name");
+    // Space case
     when(targetIdentity.getProviderId()).thenReturn(SpaceIdentityProvider.NAME);
     shareDocumentNotificationListener.onEvent(event);
-    verifyStatic(PluginKey.class, times(2));
+    //
+    verifyStatic(PluginKey.class, times(1));
     PluginKey.key(AddDocumentCollaboratorPlugin.ID);
   }
 }


### PR DESCRIPTION
This change will prevent the notification of space members when the space is assigned as a document collaborator.