### PR TITLE
fix: Notify only corresponding collaborators after making changes on their permission on the document managed access drawer - EXO-65096

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1161,7 +1161,12 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       }
       Node linkNode = null;
       if (shared.hasNode(currentNode.getName())) {
+        // link node already exist
         linkNode = shared.getNode(currentNode.getName());
+        // check if the document is already shared with the same permissions
+        if (isDocumentSharedWithSamePermissions(currentNode, linkNode, destIdentity)) {
+          return;
+        }
       } else {
         linkNode = shared.addNode(currentNode.getName(), NodeTypeConstants.EXO_SYMLINK);
       }
@@ -1213,7 +1218,18 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       }
     }
   }
+  public boolean isDocumentSharedWithSamePermissions(Node currentNode, Node linkNode, org.exoplatform.social.core.identity.model.Identity destinationIdentity ) throws RepositoryException {
+    String destinationRemoteId;
+    if (destinationIdentity.getProviderId().equals(SPACE_PROVIDER_ID)) {
+      destinationRemoteId = "*:" + spaceService.getSpaceByPrettyName(destinationIdentity.getRemoteId()).getGroupId();
+    } else destinationRemoteId = destinationIdentity.getRemoteId();
+    List<AccessControlEntry> currentNodeAcc = ((ExtendedNode) currentNode).getACL().getPermissionEntries()
+            .stream().filter(accessControlEntry -> accessControlEntry.getIdentity().equals(destinationRemoteId)).toList();
 
+    List<AccessControlEntry> linkNodeAcc = ((ExtendedNode) linkNode).getACL().getPermissionEntries()
+            .stream().filter(accessControlEntry -> accessControlEntry.getIdentity().equals(destinationRemoteId)).toList();
+    return currentNodeAcc.equals(linkNodeAcc);
+  }
   public void notifyMember(String documentId, long destId) {
     SessionProvider sessionProvider = null;
     try {

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -4,10 +4,6 @@ package org.exoplatform.documents.storage.jcr;
 
 import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.getIdentityRootNode;
 import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.getNodeByIdentifier;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 import java.util.*;
 
@@ -65,6 +61,7 @@ import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -72,6 +69,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.util.Calendar;
 import java.util.List;
 
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -191,6 +189,17 @@ public class JCRDocumentFileStorageTest {
     //assert that the linkNode set edit permission
     verify(linkNode).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("username") && Arrays.equals(map.get("username"),new String[]{"edit"})));
 
+    when(rootNode.hasNode("Shared")).thenReturn(true);
+    when(rootNode.getNode("Shared")).thenReturn(sharedNode);
+    when(sharedNode.hasNode(currentNode.getName())).thenReturn(true);
+    when(sharedNode.getNode(currentNode.getName())).thenReturn(linkNode);
+    when(linkNode.getACL()).thenReturn(acl);
+
+    jcrDocumentFileStorage.shareDocument("1", 1L);
+    // Assert that the shared document event was not broadcast
+    PowerMockito.verifyStatic(Utils.class, Mockito.atLeast(0));
+    Utils.broadcast(listenerService, "share_document_event", identity, linkNode);
+    verify(sessionProvider, times(3)).close();
   }
 
   @Test
@@ -1108,6 +1117,41 @@ public class JCRDocumentFileStorageTest {
     verify(node).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("*:/platform/administrators") && Arrays.equals(map.get("*:/platform/administrators"),PermissionType.ALL)));
     verify(node).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("*:/platform/users") && Arrays.equals(map.get("*:/platform/users"),new String[]{"read"})));
     verify(node).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("John") && Arrays.equals(map.get("John"),PermissionType.ALL)));
+  }
+
+  @Test
+  public void isDocumentSharedWithSamePermissionsTest() throws RepositoryException {
+    ExtendedNode currentNode = mock(ExtendedNode.class);
+    ExtendedNode linkNode = mock(ExtendedNode.class);
+    Identity identity = mock(Identity.class);
+    when(identity.getProviderId()).thenReturn("USER");
+    AccessControlEntry accessControlEntry = new AccessControlEntry("john", "edit");
+    AccessControlList acl = new AccessControlList("john", Arrays.asList(accessControlEntry));
+    when(currentNode.getACL()).thenReturn(acl);
+    when(linkNode.getACL()).thenReturn(acl);
+    when(identity.getRemoteId()).thenReturn("john");
+    //
+    assertTrue(jcrDocumentFileStorage.isDocumentSharedWithSamePermissions(currentNode, linkNode, identity));
+
+    when(identity.getProviderId()).thenReturn("space");
+    when(identity.getRemoteId()).thenReturn("spaceTest");
+    Space spaceTest = mock(Space.class);
+    when(spaceService.getSpaceByPrettyName(identity.getRemoteId())).thenReturn(spaceTest);
+    when(spaceTest.getGroupId()).thenReturn("/space/Test");
+    AccessControlEntry accessControlEntry1 = new AccessControlEntry("*:/space/Test", "edit");
+    AccessControlList acl1 = new AccessControlList("*:/space/Test", Arrays.asList(accessControlEntry1));
+    when(currentNode.getACL()).thenReturn(acl1);
+    when(linkNode.getACL()).thenReturn(acl1);
+    //
+    assertTrue(jcrDocumentFileStorage.isDocumentSharedWithSamePermissions(currentNode, linkNode, identity));
+
+    AccessControlEntry accessControlEntry2 = new AccessControlEntry("*:/space/Test", "read");
+    AccessControlList acl2 = new AccessControlList("*:/space/Test", Arrays.asList(accessControlEntry2));
+    when(currentNode.getACL()).thenReturn(acl1);
+    when(linkNode.getACL()).thenReturn(acl2);
+    //
+    assertFalse(jcrDocumentFileStorage.isDocumentSharedWithSamePermissions(currentNode, linkNode, identity));
+
   }
 
 }


### PR DESCRIPTION
Prior to this change, after adding a collaborator or updating the permissions of an existing collaborator in the document's managed access drawer, all collaborators were notified that they were assigned as collaborators on the corresponding document. This issue was due to the updating of the permissions list of the linked node, even when we didn't have any changes, and broadcasting the shared document event to notify the destination identity.

With this change, before creating or updating the linked node's permission list, we will verify whether the linked node has already been created with the same permission list.