### PR TITLE
fix: Grant all permissions to space hosts and editors when the document visibility is set to Only designated collaborator -EXO-65224

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -397,6 +397,9 @@ public class EntityBuilder {
           permissions.add(new PermissionEntry(identity,"edit",PermissionRole.MANAGERS_REDACTORS.name()));
         }
       }
+      if (nodePermissionEntity.getVisibilityChoice().equals(Visibility.SPECIFIC_COLLABORATOR.name())) {
+        permissions.add(new PermissionEntry(identity,"edit",PermissionRole.MANAGERS_REDACTORS.name()));
+      }
       return new NodePermission(nodePermissionEntity.isCanAccess(),nodePermissionEntity.isCanEdit(),nodePermissionEntity.isCanDelete(),permissions,toShare, toNotify);
     }
     return null;

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/util/EntityBuilderTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/util/EntityBuilderTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 
+import org.exoplatform.documents.model.PermissionRole;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -70,6 +71,14 @@ public class EntityBuilderTest {
         nodePermissionEntity.setCollaborators(List.of(permissionEntryEntity));
         NodePermission nodePermission2 = EntityBuilder.toNodePermission(abstractNodeEntity,documentFileService, spaceService, identityManager);
         assertNotNull(nodePermission2);
+        //
+        nodePermissionEntity.setVisibilityChoice(Visibility.SPECIFIC_COLLABORATOR.name());
+        nodePermissionEntity.setAllMembersCanEdit(false);
+        NodePermission specificCollabotratorsNodePermission = EntityBuilder.toNodePermission(abstractNodeEntity,documentFileService, spaceService, identityManager);
+        assertNotNull(specificCollabotratorsNodePermission);
+        assertEquals(PermissionRole.MANAGERS_REDACTORS.name(), specificCollabotratorsNodePermission.getPermissions().get(0).getRole());
+        assertEquals(identity.getRemoteId(), specificCollabotratorsNodePermission.getPermissions().get(0).getIdentity().getRemoteId());
+        assertEquals("edit", specificCollabotratorsNodePermission.getPermissions().get(0).getPermission());
 
         IdentityEntity useridentityEntity = new IdentityEntity();
         useridentityEntity.setId("1");


### PR DESCRIPTION
Before this change, when the document visibility was set to "Only designated collaborator," the document became inaccessible to the space hosts and redactors.
This change is going to grant all permissions to space hosts and editors when the document visibility is set to Only designated collaborator .