### PR TITLE
fix: Grant all permissions to space hosts and editors when the document visibility is set to Only designated collaborator -EXO-65224

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -361,6 +361,9 @@ public class EntityBuilder {
           permissions.add(new PermissionEntry(identity,"edit",PermissionRole.MANAGERS_REDACTORS.name()));
         }
       }
+      if (nodePermissionEntity.getVisibilityChoice().equals(Visibility.SPECIFIC_COLLABORATOR.name())) {
+        permissions.add(new PermissionEntry(identity,"edit",PermissionRole.MANAGERS_REDACTORS.name()));
+      }
       return new NodePermission(nodePermissionEntity.isCanAccess(),nodePermissionEntity.isCanEdit(),nodePermissionEntity.isCanDelete(),permissions,toShare, toNotify);
     }
     return null;

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/util/EntityBuilderTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/util/EntityBuilderTest.java
@@ -1,5 +1,17 @@
 package org.exoplatform.documents.rest.util;
 
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.exoplatform.documents.model.PermissionRole;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
 import org.exoplatform.documents.model.NodePermission;
 import org.exoplatform.documents.rest.model.*;
 import org.exoplatform.documents.service.DocumentFileService;
@@ -7,17 +19,9 @@ import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
+
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.List;
-
-import static org.junit.Assert.*;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
 public class EntityBuilderTest {
@@ -65,6 +69,14 @@ public class EntityBuilderTest {
         nodePermissionEntity.setCollaborators(List.of(permissionEntryEntity));
         NodePermission nodePermission2 = EntityBuilder.toNodePermission(abstractNodeEntity,documentFileService, spaceService, identityManager);
         assertNotNull(nodePermission2);
+        //
+        nodePermissionEntity.setVisibilityChoice(Visibility.SPECIFIC_COLLABORATOR.name());
+        nodePermissionEntity.setAllMembersCanEdit(false);
+        NodePermission specificCollabotratorsNodePermission = EntityBuilder.toNodePermission(abstractNodeEntity,documentFileService, spaceService, identityManager);
+        assertNotNull(specificCollabotratorsNodePermission);
+        assertEquals(PermissionRole.MANAGERS_REDACTORS.name(), specificCollabotratorsNodePermission.getPermissions().get(0).getRole());
+        assertEquals(identity.getRemoteId(), specificCollabotratorsNodePermission.getPermissions().get(0).getIdentity().getRemoteId());
+        assertEquals("edit", specificCollabotratorsNodePermission.getPermissions().get(0).getPermission());
 
         IdentityEntity useridentityEntity = new IdentityEntity();
         useridentityEntity.setId("1");

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -1087,11 +1087,15 @@ public class JCRDocumentFileStorageTest {
     org.exoplatform.services.security.Identity aclIdentity = mock(org.exoplatform.services.security.Identity.class);
     org.exoplatform.social.core.identity.model.Identity identity = mock(org.exoplatform.social.core.identity.model.Identity.class);
     org.exoplatform.social.core.identity.model.Identity identity1 = mock(org.exoplatform.social.core.identity.model.Identity.class);
+    org.exoplatform.social.core.identity.model.Identity spaceIdentity = mock(org.exoplatform.social.core.identity.model.Identity.class);
+    Space space = mock(Space.class);
     when(identity.getProviderId()).thenReturn("group");
     when(identity.getRemoteId()).thenReturn("/platform/users");
     when(identity1.getProviderId()).thenReturn("user");
     when(identity1.getRemoteId()).thenReturn("John");
     when(aclIdentity.getUserId()).thenReturn("user");
+    when(spaceIdentity.getProviderId()).thenReturn("space");
+    when(spaceIdentity.getRemoteId()).thenReturn("spaceTest");
     ManageableRepository manageableRepository = mock(ManageableRepository.class);
     when(repositoryService.getCurrentRepository()).thenReturn(manageableRepository);
     Session session = mock(Session.class);
@@ -1101,6 +1105,8 @@ public class JCRDocumentFileStorageTest {
     when(sessionProvider.getSession("collaboration", manageableRepository)).thenReturn(session);
     ExtendedNode node = mock(ExtendedNode.class);
     when(JCRDocumentsUtil.getNodeByIdentifier(session, "123")).thenReturn(node);
+    when(spaceService.getSpaceByPrettyName(spaceIdentity.getRemoteId())).thenReturn(space);
+    when(space.getGroupId()).thenReturn("/spaces/spaceTest");
     when(node.canAddMixin(NodeTypeConstants.EXO_DATE_MODIFIED)).thenReturn(true);
     when(node.canAddMixin(NodeTypeConstants.EXO_LAST_MODIFIED_DATE)).thenReturn(true);
     when(node.canAddMixin(NodeTypeConstants.EXO_PRIVILEGEABLE)).thenReturn(true);
@@ -1110,6 +1116,8 @@ public class JCRDocumentFileStorageTest {
     List<PermissionEntry> permissionsList = new ArrayList<>();
     permissionsList.add(new PermissionEntry(identity, "read", null));
     permissionsList.add(new PermissionEntry(identity1, "edit", null));
+    // permissionsList including space manager and redactor permission
+    permissionsList.add(new PermissionEntry(spaceIdentity, "edit", PermissionRole.MANAGERS_REDACTORS.name()));
     when(nodePermission.getPermissions()).thenReturn(permissionsList);
     //When
     jcrDocumentFileStorage.updatePermissions("123",  nodePermission, aclIdentity);
@@ -1117,6 +1125,9 @@ public class JCRDocumentFileStorageTest {
     verify(node).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("*:/platform/administrators") && Arrays.equals(map.get("*:/platform/administrators"),PermissionType.ALL)));
     verify(node).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("*:/platform/users") && Arrays.equals(map.get("*:/platform/users"),new String[]{"read"})));
     verify(node).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("John") && Arrays.equals(map.get("John"),PermissionType.ALL)));
+    //
+    verify(node).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("redactor:/spaces/spaceTest") && Arrays.equals(map.get("redactor:/spaces/spaceTest"),PermissionType.ALL)));
+    verify(node).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("manager:/spaces/spaceTest") && Arrays.equals(map.get("redactor:/spaces/spaceTest"),PermissionType.ALL)));
   }
 
   @Test


### PR DESCRIPTION
Before this change, when the document visibility was set to "Only designated collaborator," the document became inaccessible to the space hosts and redactors. This change is going to grant all permissions to space hosts and editors when the document visibility is set to Only designated collaborator .