### PR TITLE
fix: move NaturalComparator of Strings to commons module - EXO-46735 - Meeds-io/meeds#1056

### DIFF
--- a/documents-storage-jcr/pom.xml
+++ b/documents-storage-jcr/pom.xml
@@ -42,6 +42,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-component-common</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>javax.jcr</groupId>
       <artifactId>jcr</artifactId>
     </dependency>

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.api.search.data.SearchResult;
+import org.exoplatform.commons.comparators.NaturalComparator;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.documents.model.*;
@@ -554,7 +555,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
 
       }
     }
-    return folderListNodes.stream().sorted((fullTreeItem1, fullTreeItem2)-> new Utils.NaturalComparator().compare(fullTreeItem1.getName(), fullTreeItem2.getName())).toList();
+    return folderListNodes.stream().sorted((fullTreeItem1, fullTreeItem2)-> new NaturalComparator().compare(fullTreeItem1.getName(), fullTreeItem2.getName())).toList();
   }
   @Override
   public AbstractNode createFolder(long ownerId,

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/Utils.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/Utils.java
@@ -42,34 +42,4 @@ public class Utils {
     }
     return "";
   }
-
-  public static class NaturalComparator implements Comparator<String> {
-    @Override
-    public int compare(String s1, String s2) {
-      /*
-      Split string by matching a position where a non-digit (\\D) precedes and a digit (\\d) follows or vice versa
-      (?<=) matches the position immediately following a non-digit (\\D) or a digit (\\d) character
-      (?=) matches the position immediately preceding a non-digit (\\D) or a digit (\\d) character
-       */
-      String[] arr1 = s1.split("(?<=\\D)(?=\\d)|(?<=\\d)(?=\\D)");
-      String[] arr2 = s2.split("(?<=\\D)(?=\\d)|(?<=\\d)(?=\\D)");
-      int i = 0;
-      while (i < arr1.length && i < arr2.length) {
-        if (Character.isDigit(arr1[i].charAt(0)) && Character.isDigit(arr2[i].charAt(0))) {
-          int num1 = Integer.parseInt(arr1[i]);
-          int num2 = Integer.parseInt(arr2[i]);
-          if (num1 != num2) {
-            return Integer.compare(num1, num2);
-          }
-        } else {
-          int result = arr1[i].compareToIgnoreCase(arr2[i]);
-          if (result != 0) {
-            return result;
-          }
-        }
-        i++;
-      }
-      return s1.compareToIgnoreCase(s2);
-    }
-  }
 }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -333,37 +333,6 @@ public class JCRDocumentsUtilTest {
   }
 
   @Test
-  public void TestNaturalCompare(){
-    List<String> list = new ArrayList<>();
-    list.add("1");
-    list.add("3");
-    list.add("2");
-
-    list.sort(new Utils.NaturalComparator());
-    //assert numeric sort
-    assertEquals("1", list.get(0));
-    assertEquals("3", list.get(2));
-
-    list.add("Afile");
-    list.add("bfile");
-    list.sort(new Utils.NaturalComparator());
-    //assert numeric sort then literal sort
-    assertEquals("1", list.get(0));
-    assertEquals("Afile", list.get(3));
-
-    list.add("file1");
-    list.add("file10");
-    list.add("file2");
-    list.add("file20");
-    list.add("file3");
-    list.add("2 test");
-
-    list.sort(new Utils.NaturalComparator());
-    String[] expectedSortedArray = new String[]{"1", "2", "2 test", "3", "Afile", "bfile", "file1", "file2", "file3" ,"file10", "file20"};
-    assertEquals(expectedSortedArray, list.toArray(new String[list.size()]));
-  }
-
-  @Test
   public void testGroupToIdentity() throws Exception {
     OrganizationService organizationService = mock(OrganizationService.class);
     Group group = mock(Group.class);


### PR DESCRIPTION
This will move the NaturalComparator to the module commons to make it reusable by all other modules of eXo platform & Meeds