### PR TITLE
fix: Create a symlink to the user's personal documents when assigning a space member as a document collaborator - EXO-65095

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
@@ -188,7 +188,7 @@ public interface DocumentFileService {
    * @param destId target user or space identity id
    * @throws IllegalAccessException
    */
-  void shareDocument(String documentId, long destId) throws IllegalAccessException;
+  void shareDocument(String documentId, long destId, boolean broadcast) throws IllegalAccessException;
 
   void notifyMember(String documentId, long destId) throws IllegalAccessException;
 

--- a/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
@@ -144,7 +144,7 @@ public interface DocumentFileStorage {
    * @param destId target user or space identity id
    * @throws IllegalAccessException
    */
-  void shareDocument(String documentId, long destId) throws IllegalAccessException;
+  void shareDocument(String documentId, long destId, boolean broadcast) throws IllegalAccessException;
 
   void notifyMember(String documentId, long destId) throws IllegalAccessException;
 

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -343,6 +343,7 @@ public class EntityBuilder {
               //check if the owner is a space and the destination is a member of this space
               if (ownerId.isSpace() && spaceService.isMember(spaceService.getSpaceByPrettyName(ownerId.getRemoteId()), permissionEntryEntity.getIdentity().getRemoteId())) {
                 toNotify.put(Long.valueOf(identityManager.getOrCreateUserIdentity(permissionEntryEntity.getIdentity().getRemoteId()).getId()),permissionEntryEntity.getPermission());
+                toShare.put(Long.valueOf(identityManager.getOrCreateUserIdentity(permissionEntryEntity.getIdentity().getRemoteId()).getId()),permissionEntryEntity.getPermission());
               } else {
                 toShare.put(Long.valueOf(identityManager.getOrCreateUserIdentity(permissionEntryEntity.getIdentity().getRemoteId()).getId()),permissionEntryEntity.getPermission());
               }

--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -263,9 +263,10 @@ public class DocumentFileServiceImpl implements DocumentFileService {
   public void updatePermissions(String documentId,  NodePermission nodePermissionEntity, long authenticatedUserId) throws IllegalAccessException {
 
     documentFileStorage.updatePermissions(documentId, nodePermissionEntity, getAclUserIdentity(authenticatedUserId));
+    boolean broadcastShareDocumentEvent = nodePermissionEntity.getToNotify() == null || nodePermissionEntity.getToNotify().isEmpty();
     nodePermissionEntity.getToShare().keySet().forEach(destId-> {
       try {
-        shareDocument(documentId, destId);
+        shareDocument(documentId, destId, broadcastShareDocumentEvent);
       } catch (IllegalAccessException e) {
         throw new IllegalStateException("Error updating sharing of document'" + documentId + " to identity " + destId, e);
       }
@@ -282,9 +283,9 @@ public class DocumentFileServiceImpl implements DocumentFileService {
   }
 
   @Override
-  public void shareDocument(String documentId, long destId) throws IllegalAccessException {
+  public void shareDocument(String documentId, long destId, boolean broadcast) throws IllegalAccessException {
 
-    documentFileStorage.shareDocument(documentId, destId);
+    documentFileStorage.shareDocument(documentId, destId, broadcast );
   }
 
   @Override

--- a/documents-services/src/test/java/org/exoplatform/documents/service/DocumentFileServiceTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/service/DocumentFileServiceTest.java
@@ -429,7 +429,7 @@ public class DocumentFileServiceTest {
     when(identityManager.getIdentity("1")).thenReturn(socialIdentity);
     documentFileService.updatePermissions("123", nodePermission, 1L);
     verify(documentFileStorage, times(1)).updatePermissions("123", nodePermission, identity);
-    verify(documentFileStorage, times(1)).shareDocument("123", 1L);
+    verify(documentFileStorage, times(1)).shareDocument("123", 1L, true);
   }
 
   @Test

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1136,7 +1136,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     }
   }
 
-  public void shareDocument(String documentId, long destId) {
+  public void shareDocument(String documentId, long destId, boolean broadcast) {
     Node rootNode = null;
     Node shared = null;
     SessionProvider sessionProvider = null;
@@ -1210,7 +1210,9 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       }
       ((ExtendedNode) linkNode).setPermissions(permissions);
       systemSession.save();
-      Utils.broadcast(listenerService, "share_document_event", destIdentity, linkNode);
+      if (broadcast) {
+        Utils.broadcast(listenerService, "share_document_event", destIdentity, linkNode);
+      }
     } catch (Exception e) {
       throw new IllegalStateException("Error updating sharing of document'" + documentId + " to identity " + destId, e);
     }finally {

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -171,7 +171,7 @@ public class JCRDocumentFileStorageTest {
     AccessControlList acl1 = new AccessControlList("username", Arrays.asList(accessControlEntry));
     when(((ExtendedNode) currentNode).getACL()).thenReturn(acl1);
     when(linkNode.canAddMixin(NodeTypeConstants.EXO_PRIVILEGEABLE)).thenReturn(true);
-    jcrDocumentFileStorage.shareDocument("1", 1L);
+    jcrDocumentFileStorage.shareDocument("1", 1L, true);
     PowerMockito.verifyStatic(Utils.class, times(1));
 
     Utils.broadcast(listenerService, "share_document_event", identity, linkNode);
@@ -184,7 +184,7 @@ public class JCRDocumentFileStorageTest {
     AccessControlEntry accessControlEntry1 = new AccessControlEntry("username", "edit");
     AccessControlList acl = new AccessControlList("username", Arrays.asList(accessControlEntry1));
     when(((ExtendedNode) currentNode).getACL()).thenReturn(acl);
-    jcrDocumentFileStorage.shareDocument("1", 1L);
+    jcrDocumentFileStorage.shareDocument("1", 1L, true);
 
     //assert that the linkNode set edit permission
     verify(linkNode).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("username") && Arrays.equals(map.get("username"),new String[]{"edit"})));
@@ -195,7 +195,7 @@ public class JCRDocumentFileStorageTest {
     when(sharedNode.getNode(currentNode.getName())).thenReturn(linkNode);
     when(linkNode.getACL()).thenReturn(acl);
 
-    jcrDocumentFileStorage.shareDocument("1", 1L);
+    jcrDocumentFileStorage.shareDocument("1", 1L, true);
     // Assert that the shared document event was not broadcast
     PowerMockito.verifyStatic(Utils.class, Mockito.atLeast(0));
     Utils.broadcast(listenerService, "share_document_event", identity, linkNode);


### PR DESCRIPTION
Before this change, when assigning a space member as a document collaborator, the user would be redirected by the notification to the original document, and no symlink was created in their personal documents. This change will create a symlink to the user's personal documents when assigning a space member as a document collaborator. Nb : To notify members we use the notifyMembers method which broadcast the share_document_event , for this reason we will update the share document method to do not broadcast the share_document_event when we share the document with a space members