### PR TITLE
fix: Notify only corresponding collaborators after making changes on their permission on the document managed access drawer - EXO-65096

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -306,29 +306,20 @@ public class DocumentFileServiceImpl implements DocumentFileService {
   public void updatePermissions(String documentId,  NodePermission nodePermissionEntity, long authenticatedUserId) throws IllegalAccessException {
 
     documentFileStorage.updatePermissions(documentId, nodePermissionEntity, getAclUserIdentity(authenticatedUserId));
-    boolean broadcastShareDocumentEvent = nodePermissionEntity.getToNotify() == null || nodePermissionEntity.getToNotify().isEmpty();
     nodePermissionEntity.getToShare().keySet().forEach(destId-> {
       try {
-        shareDocument(documentId, destId, broadcastShareDocumentEvent);
+        boolean notifyMember = nodePermissionEntity.getToNotify() != null && nodePermissionEntity.getToNotify().containsKey(destId);
+        shareDocument(documentId, destId, notifyMember);
       } catch (IllegalAccessException e) {
         throw new IllegalStateException("Error updating sharing of document'" + documentId + " to identity " + destId, e);
       }
     });
-    if (nodePermissionEntity.getToNotify() != null) {
-      nodePermissionEntity.getToNotify().keySet().forEach(destId -> {
-        try {
-          notifyMember(documentId, destId);
-        } catch (IllegalAccessException e) {
-          throw new IllegalStateException("Error updating sharing of document'" + documentId + " to identity " + destId, e);
-        }
-      });
-    }
   }
 
   @Override
-  public void shareDocument(String documentId, long destId, boolean broadcast) throws IllegalAccessException {
+  public void shareDocument(String documentId, long destId, boolean notifyMember) throws IllegalAccessException {
 
-    documentFileStorage.shareDocument(documentId, destId, broadcast );
+    documentFileStorage.shareDocument(documentId, destId, notifyMember );
   }
 
   @Override

--- a/documents-services/src/test/java/org/exoplatform/documents/service/DocumentFileServiceTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/service/DocumentFileServiceTest.java
@@ -448,6 +448,14 @@ public class DocumentFileServiceTest {
     documentFileService.updatePermissions("123", nodePermission, 1L);
     verify(documentFileStorage, times(1)).updatePermissions("123", nodePermission, identity);
     verify(documentFileStorage, times(1)).shareDocument("123", 1L, false);
+    //
+    Map<Long, String> toNotify = new HashMap<>();
+    toNotify.put(1L, "read");
+    nodePermission.setToNotify(toNotify);
+    documentFileService.updatePermissions("123", nodePermission, 1L);
+    verify(documentFileStorage, atLeast(1)).updatePermissions("123", nodePermission, identity);
+    verify(documentFileStorage, atLeast(1)).shareDocument("123", 1L, true);
+
   }
 
   @Test

--- a/documents-services/src/test/java/org/exoplatform/documents/service/DocumentFileServiceTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/service/DocumentFileServiceTest.java
@@ -447,7 +447,7 @@ public class DocumentFileServiceTest {
     when(identityManager.getIdentity("1")).thenReturn(socialIdentity);
     documentFileService.updatePermissions("123", nodePermission, 1L);
     verify(documentFileStorage, times(1)).updatePermissions("123", nodePermission, identity);
-    verify(documentFileStorage, times(1)).shareDocument("123", 1L, true);
+    verify(documentFileStorage, times(1)).shareDocument("123", 1L, false);
   }
 
   @Test

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1198,7 +1198,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     }
   }
 
-  public void shareDocument(String documentId, long destId, boolean broadcast) {
+  public void shareDocument(String documentId, long destId, boolean notifyMember) {
     Node rootNode = null;
     Node shared = null;
     SessionProvider sessionProvider = null;
@@ -1272,7 +1272,9 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       }
       ((ExtendedNode) linkNode).setPermissions(permissions);
       systemSession.save();
-      if (broadcast) {
+      if (notifyMember) {
+        notifyMember(documentId, destId);
+      } else {
         Utils.broadcast(listenerService, "share_document_event", destIdentity, linkNode);
       }
     } catch (Exception e) {

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -190,17 +190,29 @@ public class JCRDocumentFileStorageTest {
     //assert that the linkNode set edit permission
     verify(linkNode).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("username") && Arrays.equals(map.get("username"),new String[]{"edit"})));
 
+    // case of space member
+    boolean notifyMember = true ;
+    jcrDocumentFileStorage.shareDocument("1", 1L, notifyMember);
+    //assert that the event broadcast with the target node as parameter
+    UTILS.verify(() -> Utils.broadcast(listenerService, "share_document_event", identity, currentNode) ,atLeast(1));
+
     when(rootNode.hasNode("Shared")).thenReturn(true);
     when(rootNode.getNode("Shared")).thenReturn(sharedNode);
     when(sharedNode.hasNode(currentNode.getName())).thenReturn(true);
     when(sharedNode.getNode(currentNode.getName())).thenReturn(linkNode);
     when(linkNode.getACL()).thenReturn(acl);
-
+    // no member
     jcrDocumentFileStorage.shareDocument("1", 1L, false);
+
     // Assert that the shared document event was not broadcast
     UTILS.verify(() -> Utils.broadcast(listenerService, "share_document_event", identity, linkNode), atLeast(0));
-    verify(sessionProvider, times(3)).close();
+    verify(sessionProvider, atLeast(1)).close();
 
+    // space member
+    jcrDocumentFileStorage.shareDocument("1", 1L, notifyMember);
+    // Assert that the shared document event was not broadcast for member
+    UTILS.verify(() -> Utils.broadcast(listenerService, "share_document_event", identity, currentNode), atLeast(0));
+    verify(sessionProvider, atLeast(1)).close();
   }
 
   @Test

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -172,7 +172,7 @@ public class JCRDocumentFileStorageTest {
     AccessControlList acl1 = new AccessControlList("username", Arrays.asList(accessControlEntry));
     when(((ExtendedNode) currentNode).getACL()).thenReturn(acl1);
     when(linkNode.canAddMixin(NodeTypeConstants.EXO_PRIVILEGEABLE)).thenReturn(true);
-    jcrDocumentFileStorage.shareDocument("1", 1L, true);
+    jcrDocumentFileStorage.shareDocument("1", 1L, false);
 
     UTILS.verify(() -> times(1));
     Utils.broadcast(listenerService, "share_document_event", identity, linkNode);
@@ -185,7 +185,7 @@ public class JCRDocumentFileStorageTest {
     AccessControlEntry accessControlEntry1 = new AccessControlEntry("username", "edit");
     AccessControlList acl = new AccessControlList("username", Arrays.asList(accessControlEntry1));
     when(((ExtendedNode) currentNode).getACL()).thenReturn(acl);
-    jcrDocumentFileStorage.shareDocument("1", 1L, true);
+    jcrDocumentFileStorage.shareDocument("1", 1L, false);
 
     //assert that the linkNode set edit permission
     verify(linkNode).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("username") && Arrays.equals(map.get("username"),new String[]{"edit"})));
@@ -196,7 +196,7 @@ public class JCRDocumentFileStorageTest {
     when(sharedNode.getNode(currentNode.getName())).thenReturn(linkNode);
     when(linkNode.getACL()).thenReturn(acl);
 
-    jcrDocumentFileStorage.shareDocument("1", 1L, true);
+    jcrDocumentFileStorage.shareDocument("1", 1L, false);
     // Assert that the shared document event was not broadcast
     UTILS.verify(() -> Utils.broadcast(listenerService, "share_document_event", identity, linkNode), atLeast(0));
     verify(sessionProvider, times(3)).close();


### PR DESCRIPTION
After implementing this previous pull request https://github.com/exoplatform/documents/pull/1069 to notify only the corresponding collaborators after making changes to their permissions, space members are still receiving notifications.

With this new change, we will first verify whether the linked node has already been created with the same permission list before notifying the member.