### PR TITLE
fix: Notify only corresponding collaborators after making changes on their permission on the document managed access drawer - EXO-65096

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -263,29 +263,20 @@ public class DocumentFileServiceImpl implements DocumentFileService {
   public void updatePermissions(String documentId,  NodePermission nodePermissionEntity, long authenticatedUserId) throws IllegalAccessException {
 
     documentFileStorage.updatePermissions(documentId, nodePermissionEntity, getAclUserIdentity(authenticatedUserId));
-    boolean broadcastShareDocumentEvent = nodePermissionEntity.getToNotify() == null || nodePermissionEntity.getToNotify().isEmpty();
     nodePermissionEntity.getToShare().keySet().forEach(destId-> {
       try {
-        shareDocument(documentId, destId, broadcastShareDocumentEvent);
+        boolean notifyMember = nodePermissionEntity.getToNotify() != null && nodePermissionEntity.getToNotify().containsKey(destId);
+        shareDocument(documentId, destId, notifyMember);
       } catch (IllegalAccessException e) {
         throw new IllegalStateException("Error updating sharing of document'" + documentId + " to identity " + destId, e);
       }
     });
-    if (nodePermissionEntity.getToNotify() != null) {
-      nodePermissionEntity.getToNotify().keySet().forEach(destId -> {
-        try {
-          notifyMember(documentId, destId);
-        } catch (IllegalAccessException e) {
-          throw new IllegalStateException("Error updating sharing of document'" + documentId + " to identity " + destId, e);
-        }
-      });
-    }
   }
 
   @Override
-  public void shareDocument(String documentId, long destId, boolean broadcast) throws IllegalAccessException {
+  public void shareDocument(String documentId, long destId, boolean notifyMember) throws IllegalAccessException {
 
-    documentFileStorage.shareDocument(documentId, destId, broadcast );
+    documentFileStorage.shareDocument(documentId, destId, notifyMember );
   }
 
   @Override

--- a/documents-services/src/test/java/org/exoplatform/documents/service/DocumentFileServiceTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/service/DocumentFileServiceTest.java
@@ -429,7 +429,15 @@ public class DocumentFileServiceTest {
     when(identityManager.getIdentity("1")).thenReturn(socialIdentity);
     documentFileService.updatePermissions("123", nodePermission, 1L);
     verify(documentFileStorage, times(1)).updatePermissions("123", nodePermission, identity);
-    verify(documentFileStorage, times(1)).shareDocument("123", 1L, true);
+    verify(documentFileStorage, times(1)).shareDocument("123", 1L, false);
+    //
+    Map<Long, String> toNotify = new HashMap<>();
+    toNotify.put(1L, "read");
+    nodePermission.setToNotify(toNotify);
+    documentFileService.updatePermissions("123", nodePermission, 1L);
+    verify(documentFileStorage, atLeast(1)).updatePermissions("123", nodePermission, identity);
+    verify(documentFileStorage, atLeast(1)).shareDocument("123", 1L, true);
+
   }
 
   @Test

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1136,7 +1136,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     }
   }
 
-  public void shareDocument(String documentId, long destId, boolean broadcast) {
+  public void shareDocument(String documentId, long destId, boolean notifyMember) {
     Node rootNode = null;
     Node shared = null;
     SessionProvider sessionProvider = null;
@@ -1210,7 +1210,9 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       }
       ((ExtendedNode) linkNode).setPermissions(permissions);
       systemSession.save();
-      if (broadcast) {
+      if (notifyMember) {
+        notifyMember(documentId, destId);
+      } else {
         Utils.broadcast(listenerService, "share_document_event", destIdentity, linkNode);
       }
     } catch (Exception e) {


### PR DESCRIPTION
After implementing this previous pull request https://github.com/exoplatform/documents/pull/1069 to notify only the corresponding collaborators after making changes to their permissions, space members are still receiving notifications.

With this new change, we will first verify whether the linked node has already been created with the same permission list before notifying the member.