### PR TITLE
fix : Remove the symlink when designating a document's collaborator - EXO-65859

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/model/NodePermission.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/model/NodePermission.java
@@ -38,4 +38,6 @@ public class NodePermission {
 
   private Map<Long,String> toNotify;
 
+  private Map<Long,String> toUnShare;
+
 }

--- a/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
@@ -215,6 +215,8 @@ public interface DocumentFileService {
 
   void notifyMember(String documentId, long destId) throws IllegalAccessException;
 
+  void unShareDocument(String documentId, long destId) throws IllegalAccessException;
+
   AbstractNode createFolder(long ownerId,String folderId, String folderPath, String name, long authenticatedUserId) throws IllegalAccessException, ObjectAlreadyExistsException, ObjectNotFoundException;
 
   String getNewName(long ownerId, String folderId, String folderPath, String name) throws IllegalAccessException, ObjectAlreadyExistsException, ObjectNotFoundException;

--- a/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
@@ -215,7 +215,7 @@ public interface DocumentFileService {
 
   void notifyMember(String documentId, long destId) throws IllegalAccessException;
 
-  void unShareDocument(String documentId, long destId) throws IllegalAccessException;
+  void unShareDocument(String documentId, long destId) throws IllegalStateException, RepositoryException;
 
   AbstractNode createFolder(long ownerId,String folderId, String folderPath, String name, long authenticatedUserId) throws IllegalAccessException, ObjectAlreadyExistsException, ObjectNotFoundException;
 

--- a/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
@@ -174,6 +174,8 @@ public interface DocumentFileStorage {
    */
   void shareDocument(String documentId, long destId, boolean broadcast) throws IllegalAccessException;
 
+  void unShareDocument(String documentId, long destId) throws IllegalAccessException;
+
   void notifyMember(String documentId, long destId) throws IllegalAccessException;
 
   boolean canAccess(String documentID, Identity aclIdentity) throws RepositoryException;

--- a/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
@@ -174,7 +174,7 @@ public interface DocumentFileStorage {
    */
   void shareDocument(String documentId, long destId, boolean broadcast) throws IllegalAccessException;
 
-  void unShareDocument(String documentId, long destId) throws IllegalAccessException;
+  void unShareDocument(String documentId, long destId) throws RepositoryException;
 
   void notifyMember(String documentId, long destId) throws IllegalAccessException;
 

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -400,7 +400,7 @@ public class EntityBuilder {
       if (nodePermissionEntity.getVisibilityChoice().equals(Visibility.SPECIFIC_COLLABORATOR.name())) {
         permissions.add(new PermissionEntry(identity,"edit",PermissionRole.MANAGERS_REDACTORS.name()));
       }
-      return new NodePermission(nodePermissionEntity.isCanAccess(),nodePermissionEntity.isCanEdit(),nodePermissionEntity.isCanDelete(),permissions,toShare, toNotify);
+      return new NodePermission(nodePermissionEntity.isCanAccess(),nodePermissionEntity.isCanEdit(),nodePermissionEntity.isCanDelete(),permissions,toShare, toNotify, null);
     }
     return null;
   }

--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -331,7 +331,7 @@ public class DocumentFileServiceImpl implements DocumentFileService {
   }
 
   @Override
-  public void unShareDocument(String documentId, long destId) throws IllegalAccessException {
+  public void unShareDocument(String documentId, long destId) throws RepositoryException {
     documentFileStorage.unShareDocument(documentId, destId);
   }
 

--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -319,7 +319,7 @@ public class DocumentFileServiceImpl implements DocumentFileService {
         try {
           unShareDocument(documentId, destId);
         } catch (Exception e) {
-          throw new IllegalStateException("Error updating unSharing of document'" + documentId + " to identity " + destId, e);
+          throw new IllegalStateException("Error when unsharing the document {} with identity {}", documentId, destId, e);
         }
       });
     }

--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -314,12 +314,25 @@ public class DocumentFileServiceImpl implements DocumentFileService {
         throw new IllegalStateException("Error updating sharing of document'" + documentId + " to identity " + destId, e);
       }
     });
+    if (nodePermissionEntity.getToUnShare() != null) {
+      nodePermissionEntity.getToUnShare().keySet().forEach(destId -> {
+        try {
+          unShareDocument(documentId, destId);
+        } catch (Exception e) {
+          throw new IllegalStateException("Error updating unSharing of document'" + documentId + " to identity " + destId, e);
+        }
+      });
+    }
   }
 
   @Override
   public void shareDocument(String documentId, long destId, boolean notifyMember) throws IllegalAccessException {
-
     documentFileStorage.shareDocument(documentId, destId, notifyMember );
+  }
+
+  @Override
+  public void unShareDocument(String documentId, long destId) throws IllegalAccessException {
+    documentFileStorage.unShareDocument(documentId, destId);
   }
 
   @Override

--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -319,7 +319,7 @@ public class DocumentFileServiceImpl implements DocumentFileService {
         try {
           unShareDocument(documentId, destId);
         } catch (Exception e) {
-          throw new IllegalStateException("Error updating unSharing of document'" + documentId + " to identity " + destId, e);
+          throw new IllegalStateException("Error when unsharing the document " + documentId + "with identity " + destId, e);
         }
       });
     }

--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -319,7 +319,7 @@ public class DocumentFileServiceImpl implements DocumentFileService {
         try {
           unShareDocument(documentId, destId);
         } catch (Exception e) {
-          throw new IllegalStateException("Error when unsharing the document {} with identity {}", documentId, destId, e);
+          throw new IllegalStateException("Error updating unSharing of document'" + documentId + " to identity " + destId, e);
         }
       });
     }

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
@@ -522,7 +522,7 @@ public class DocumentFileRestTest {
     permissionEntries.add(permissionEntry4);
     permissionEntries.add(permissionEntry5);
     permissionEntries.add(permissionEntry6);
-    NodePermission nodePermission = new NodePermission(true, true, true, permissionEntries, null, null);
+    NodePermission nodePermission = new NodePermission(true, true, true, permissionEntries, null, null, null);
     folder1.setAcl(nodePermission);
 
     FolderNodeEntity folderEntity = new FolderNodeEntity();

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1189,11 +1189,16 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       Map<Long,String> toUnShare = new HashMap<>();
       ((ExtendedNode) node).getACL().getPermissionEntries().forEach(accessControlEntry -> {
         if (!permissions.containsKey(accessControlEntry.getIdentity())){
-          if (!accessControlEntry.getIdentity().startsWith("*:")){
-            toUnShare.put(Long.valueOf(identityManager.getOrCreateUserIdentity(accessControlEntry.getIdentity()).getId()), accessControlEntry.getPermission());
+          if (!accessControlEntry.getIdentity().startsWith("*:") && !accessControlEntry.getIdentity().startsWith("redactor:/") && !accessControlEntry.getIdentity().startsWith("manager:/")){
+            org.exoplatform.social.core.identity.model.Identity userIdentity = identityManager.getOrCreateUserIdentity(accessControlEntry.getIdentity());
+            if (userIdentity != null) {
+              toUnShare.put(Long.valueOf(userIdentity.getId()), accessControlEntry.getPermission());
+            }
           }else if (accessControlEntry.getIdentity().startsWith("*:/spaces")) {
            Space space = spaceService.getSpaceByGroupId(accessControlEntry.getIdentity().substring(2)) ;
-            toUnShare.put(Long.valueOf(identityManager.getOrCreateSpaceIdentity(space.getPrettyName()).getId()), accessControlEntry.getPermission());
+           if (space != null) {
+             toUnShare.put(Long.valueOf(identityManager.getOrCreateSpaceIdentity(space.getPrettyName()).getId()), accessControlEntry.getPermission());
+           }
           }
         }
       });
@@ -1874,7 +1879,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     return null;
   }
   @Override
-  public void unShareDocument(String documentId, long destId) throws IllegalAccessException {
+  public void unShareDocument(String documentId, long destId) {
     Node rootNode = null;
     Node shared = null;
     SessionProvider sessionProvider = null;

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1908,7 +1908,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         systemSession.save();
       }
     } catch (Exception e) {
-      throw new IllegalStateException("Error updating unSharing of document'" + documentId + " to identity " + destId, e);
+      throw new IllegalStateException("Error when unsharing the document " + documentId + "with identity " + destId, e);
     }finally {
       if (sessionProvider != null) {
         sessionProvider.close();

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1186,6 +1186,18 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       node.setProperty(NodeTypeConstants.EXO_DATE_MODIFIED, now);
       node.setProperty(NodeTypeConstants.EXO_LAST_MODIFIED_DATE, now);
       node.save();
+      Map<Long,String> toUnShare = new HashMap<>();
+      ((ExtendedNode) node).getACL().getPermissionEntries().forEach(accessControlEntry -> {
+        if (!permissions.containsKey(accessControlEntry.getIdentity())){
+          if (!accessControlEntry.getIdentity().startsWith("*:")){
+            toUnShare.put(Long.valueOf(identityManager.getOrCreateUserIdentity(accessControlEntry.getIdentity()).getId()), accessControlEntry.getPermission());
+          }else if (accessControlEntry.getIdentity().startsWith("*:/spaces")) {
+           Space space = spaceService.getSpaceByGroupId(accessControlEntry.getIdentity().substring(2)) ;
+            toUnShare.put(Long.valueOf(identityManager.getOrCreateSpaceIdentity(space.getPrettyName()).getId()), accessControlEntry.getPermission());
+          }
+        }
+      });
+      nodePermissionEntity.setToUnShare(toUnShare);
       ((ExtendedNode) node).setPermissions(permissions);
       session.save();
     } catch (Exception e) {
@@ -1860,5 +1872,42 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       }
     }
     return null;
+  }
+  @Override
+  public void unShareDocument(String documentId, long destId) throws IllegalAccessException {
+    Node rootNode = null;
+    Node shared = null;
+    SessionProvider sessionProvider = null;
+    try {
+      sessionProvider = SessionProvider.createSystemProvider();
+      ManageableRepository repository = repositoryService.getCurrentRepository();
+      Session systemSession = sessionProvider.getSession(repository.getConfiguration().getDefaultWorkspaceName(), repository);
+      Node currentNode = getNodeByIdentifier(systemSession, documentId);
+      org.exoplatform.social.core.identity.model.Identity destIdentity = identityManager.getIdentity(String.valueOf(destId));
+      rootNode = getIdentityRootNode(spaceService, nodeHierarchyCreator, destIdentity, systemSession);
+      if(!destIdentity.getProviderId().equals(SPACE_PROVIDER_ID)){
+        rootNode = rootNode.getNode("Documents");
+      }
+      if(!rootNode.hasNode(SHARED_FOLDER_NAME)){
+        return;
+      }else{
+        shared = rootNode.getNode(SHARED_FOLDER_NAME);
+      }
+      if(currentNode.isNodeType(NodeTypeConstants.EXO_SYMLINK)){
+        String sourceNodeId = currentNode.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString();
+        currentNode = getNodeByIdentifier(systemSession, sourceNodeId);
+      }
+      if (shared.hasNode(currentNode.getName()) && shared.getNode(currentNode.getName()).isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
+        Node link = shared.getNode(currentNode.getName());
+        link.remove();
+        systemSession.save();
+      }
+    } catch (Exception e) {
+      throw new IllegalStateException("Error updating unSharing of document'" + documentId + " to identity " + destId, e);
+    }finally {
+      if (sessionProvider != null) {
+        sessionProvider.close();
+      }
+    }
   }
 }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -512,7 +512,7 @@ public class JCRDocumentsUtil {
       }
 
     }
-    documentNode.setAcl(new NodePermission(true, canEdit, canDelete, permissions,null, null));
+    documentNode.setAcl(new NodePermission(true, canEdit, canDelete, permissions,null, null,null));
   }
 
   private static String getPermissionRole (String membershipType){

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -1305,15 +1305,15 @@ public class JCRDocumentFileStorageTest {
     lenient().when(node.canAddMixin(NodeTypeConstants.EXO_LAST_MODIFIED_DATE)).thenReturn(true);
     lenient().when(node.canAddMixin(NodeTypeConstants.EXO_PRIVILEGEABLE)).thenReturn(true);
     lenient().when(node.hasNode(NodeTypeConstants.JCR_CONTENT)).thenReturn(true);
-    lenient().when(node.getACL()).thenReturn(new AccessControlList());
-    NodePermission nodePermission = mock(NodePermission.class);
+    NodePermission nodePermission = new NodePermission();
     // permissionsList including group permission
     List<PermissionEntry> permissionsList = new ArrayList<>();
     permissionsList.add(new PermissionEntry(identity, "read", null));
     permissionsList.add(new PermissionEntry(identity1, "edit", null));
     // permissionsList including space manager and redactor permission
     permissionsList.add(new PermissionEntry(spaceIdentity, "edit", PermissionRole.MANAGERS_REDACTORS.name()));
-    when(nodePermission.getPermissions()).thenReturn(permissionsList);
+    nodePermission.setPermissions(permissionsList);
+    when(node.getACL()).thenReturn(new AccessControlList("root", new ArrayList<>()));
     //When
     jcrDocumentFileStorage.updatePermissions("123",  nodePermission, aclIdentity);
     //Then
@@ -1323,6 +1323,25 @@ public class JCRDocumentFileStorageTest {
     //
     verify(node).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("redactor:/spaces/spaceTest") && Arrays.equals(map.get("redactor:/spaces/spaceTest"),PermissionType.ALL)));
     verify(node).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("manager:/spaces/spaceTest") && Arrays.equals(map.get("redactor:/spaces/spaceTest"),PermissionType.ALL)));
+
+    AccessControlList existingAccessList = new AccessControlList("root", new ArrayList<>());
+    existingAccessList.addPermissions("removedUserCollaborator", new String[]{"read"});
+    String spaceGroupId = "/spaces/removedSpaceCollaborator";
+    existingAccessList.addPermissions("*:" + spaceGroupId, new String[]{"read"});
+    when(node.getACL()).thenReturn(existingAccessList);
+    when(spaceService.getSpaceByGroupId(spaceGroupId)).thenReturn(space);
+    when(space.getPrettyName()).thenReturn("removedSpaceCollaborator");
+    when(identityManager.getOrCreateSpaceIdentity(space.getPrettyName())).thenReturn(spaceIdentity);
+    when(spaceIdentity.getId()).thenReturn("3");
+    Identity userIdentity = mock(Identity.class);
+    when(identityManager.getOrCreateUserIdentity("removedUserCollaborator")).thenReturn(userIdentity);
+    when(userIdentity.getId()).thenReturn("4");
+    //when
+    jcrDocumentFileStorage.updatePermissions("123",  nodePermission, aclIdentity);
+    //
+    assertEquals(2, nodePermission.getToUnShare().size());
+    assertTrue(nodePermission.getToUnShare().containsKey(3L));
+    assertTrue(nodePermission.getToUnShare().containsKey(4L));
   }
   
   private Session getMockedSession(org.exoplatform.services.security.Identity identity) throws RepositoryException {
@@ -1428,5 +1447,49 @@ public class JCRDocumentFileStorageTest {
     //
     assertFalse(jcrDocumentFileStorage.isDocumentSharedWithSamePermissions(currentNode, linkNode, identity));
 
+  }
+
+  @Test
+  public void unShareDocumetTest() throws RepositoryException{
+    Session systemSession = mock(Session.class);
+    Identity identity = mock(Identity.class);
+    Node rootNode = mock(Node.class);
+    Node sharedNode = mock(Node.class);
+    Node currentNode = Mockito.mock(ExtendedNode.class);
+    ExtendedNode linkNode = mock(ExtendedNode.class);
+    when(currentNode.isNodeType(NodeTypeConstants.EXO_SYMLINK)).thenReturn(false);
+    when(linkNode.isNodeType(NodeTypeConstants.EXO_SYMLINK)).thenReturn(true);
+    SessionProvider sessionProvider = mock(SessionProvider.class);
+    when(SessionProvider.createSystemProvider()).thenReturn(sessionProvider);
+    ManageableRepository manageableRepository = mock(ManageableRepository.class);
+    RepositoryEntry repositoryEntry = mock(RepositoryEntry.class);
+    when(repositoryService.getCurrentRepository()).thenReturn(manageableRepository);
+    when(manageableRepository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
+    when(sessionProvider.getSession(manageableRepository.getConfiguration().getDefaultWorkspaceName(),
+            manageableRepository)).thenReturn(systemSession);
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getNodeByIdentifier(systemSession, "1")).thenReturn(currentNode);
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getIdentityRootNode(spaceService, nodeHierarchyCreator,identity, systemSession)).thenReturn(rootNode);
+    when(identity.getProviderId()).thenReturn("USER");
+    when(rootNode.getNode("Documents")).thenReturn(rootNode);
+    when(identityManager.getIdentity("1")).thenReturn(null);
+
+    assertThrows(IllegalStateException.class, () -> jcrDocumentFileStorage.unShareDocument("1", 1L));
+
+    when(identityManager.getIdentity("1")).thenReturn(identity);
+    when(rootNode.hasNode("Shared")).thenReturn(false);
+
+    verify(linkNode, times(0)).remove();
+    verify(sessionProvider, times(1)).close();
+
+    when(rootNode.hasNode("Shared")).thenReturn(true);
+    when(rootNode.getNode("Shared")).thenReturn(sharedNode);
+    when(sharedNode.hasNode(currentNode.getName())).thenReturn(true);
+    when(sharedNode.getNode(currentNode.getName())).thenReturn(linkNode);
+
+    jcrDocumentFileStorage.unShareDocument("1", 1L);
+
+    verify(linkNode, times(1)).remove();
+    verify(sessionProvider, atLeast(1)).close();
   }
 }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -1296,11 +1296,16 @@ public class JCRDocumentFileStorageTest {
     ExtendedNode node = mock(ExtendedNode.class);
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getNodeByIdentifier(session, "123")).thenReturn(node);
     lenient().when(spaceService.getSpaceByPrettyName(spaceIdentity.getRemoteId())).thenReturn(space);
+    lenient().when(spaceService.getSpaceByGroupId(anyString())).thenReturn(space);
+    lenient().when(identityManager.getOrCreateUserIdentity(anyString())).thenReturn(identity1);
+    lenient().when(identity1.getId()).thenReturn("1");
     lenient().when(space.getGroupId()).thenReturn("/spaces/spaceTest");
+    lenient().when(space.getId()).thenReturn("2");
     lenient().when(node.canAddMixin(NodeTypeConstants.EXO_DATE_MODIFIED)).thenReturn(true);
     lenient().when(node.canAddMixin(NodeTypeConstants.EXO_LAST_MODIFIED_DATE)).thenReturn(true);
     lenient().when(node.canAddMixin(NodeTypeConstants.EXO_PRIVILEGEABLE)).thenReturn(true);
     lenient().when(node.hasNode(NodeTypeConstants.JCR_CONTENT)).thenReturn(true);
+    lenient().when(node.getACL()).thenReturn(new AccessControlList());
     NodePermission nodePermission = mock(NodePermission.class);
     // permissionsList including group permission
     List<PermissionEntry> permissionsList = new ArrayList<>();


### PR DESCRIPTION
Prior to this change ,When a document was re-shared with a user (after being removed from the document collaborators list and reassigned), they did not receive a notification. This was because the symlink  already exists with the same permissions, but it was hidden from the collaborators by removing the permissions from the target node.
This change is going to remove the symlink from the shared folder if a user or a space is removed from the document collaborators list.