### PR TITLE
fix : Remove the symlink when designating a document's collaborator EXO-65859

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/model/NodePermission.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/model/NodePermission.java
@@ -38,4 +38,6 @@ public class NodePermission {
 
   private Map<Long,String> toNotify;
 
+  private Map<Long,String> toUnShare;
+
 }

--- a/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
@@ -215,6 +215,8 @@ public interface DocumentFileService {
 
   void notifyMember(String documentId, long destId) throws IllegalAccessException;
 
+  void unShareDocument(String documentId, long destId) throws IllegalStateException, RepositoryException;
+
   AbstractNode createFolder(long ownerId,String folderId, String folderPath, String name, long authenticatedUserId) throws IllegalAccessException, ObjectAlreadyExistsException, ObjectNotFoundException;
 
   String getNewName(long ownerId, String folderId, String folderPath, String name) throws IllegalAccessException, ObjectAlreadyExistsException, ObjectNotFoundException;

--- a/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
@@ -174,6 +174,8 @@ public interface DocumentFileStorage {
    */
   void shareDocument(String documentId, long destId, boolean broadcast) throws IllegalAccessException;
 
+  void unShareDocument(String documentId, long destId) throws RepositoryException;
+
   void notifyMember(String documentId, long destId) throws IllegalAccessException;
 
   boolean canAccess(String documentID, Identity aclIdentity) throws RepositoryException;

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -400,7 +400,7 @@ public class EntityBuilder {
       if (nodePermissionEntity.getVisibilityChoice().equals(Visibility.SPECIFIC_COLLABORATOR.name())) {
         permissions.add(new PermissionEntry(identity,"edit",PermissionRole.MANAGERS_REDACTORS.name()));
       }
-      return new NodePermission(nodePermissionEntity.isCanAccess(),nodePermissionEntity.isCanEdit(),nodePermissionEntity.isCanDelete(),permissions,toShare, toNotify);
+      return new NodePermission(nodePermissionEntity.isCanAccess(),nodePermissionEntity.isCanEdit(),nodePermissionEntity.isCanDelete(),permissions,toShare, toNotify, null);
     }
     return null;
   }

--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -314,12 +314,25 @@ public class DocumentFileServiceImpl implements DocumentFileService {
         throw new IllegalStateException("Error updating sharing of document'" + documentId + " to identity " + destId, e);
       }
     });
+    if (nodePermissionEntity.getToUnShare() != null) {
+      nodePermissionEntity.getToUnShare().keySet().forEach(destId -> {
+        try {
+          unShareDocument(documentId, destId);
+        } catch (Exception e) {
+          throw new IllegalStateException("Error when unsharing the document " + documentId + "with identity " + destId, e);
+        }
+      });
+    }
   }
 
   @Override
   public void shareDocument(String documentId, long destId, boolean notifyMember) throws IllegalAccessException {
-
     documentFileStorage.shareDocument(documentId, destId, notifyMember );
+  }
+
+  @Override
+  public void unShareDocument(String documentId, long destId) throws RepositoryException {
+    documentFileStorage.unShareDocument(documentId, destId);
   }
 
   @Override

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
@@ -522,7 +522,7 @@ public class DocumentFileRestTest {
     permissionEntries.add(permissionEntry4);
     permissionEntries.add(permissionEntry5);
     permissionEntries.add(permissionEntry6);
-    NodePermission nodePermission = new NodePermission(true, true, true, permissionEntries, null, null);
+    NodePermission nodePermission = new NodePermission(true, true, true, permissionEntries, null, null, null);
     folder1.setAcl(nodePermission);
 
     FolderNodeEntity folderEntity = new FolderNodeEntity();

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1186,6 +1186,23 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       node.setProperty(NodeTypeConstants.EXO_DATE_MODIFIED, now);
       node.setProperty(NodeTypeConstants.EXO_LAST_MODIFIED_DATE, now);
       node.save();
+      Map<Long,String> toUnShare = new HashMap<>();
+      ((ExtendedNode) node).getACL().getPermissionEntries().forEach(accessControlEntry -> {
+        if (!permissions.containsKey(accessControlEntry.getIdentity())){
+          if (!accessControlEntry.getIdentity().startsWith("*:") && !accessControlEntry.getIdentity().startsWith("redactor:/") && !accessControlEntry.getIdentity().startsWith("manager:/")){
+            org.exoplatform.social.core.identity.model.Identity userIdentity = identityManager.getOrCreateUserIdentity(accessControlEntry.getIdentity());
+            if (userIdentity != null) {
+              toUnShare.put(Long.valueOf(userIdentity.getId()), accessControlEntry.getPermission());
+            }
+          }else if (accessControlEntry.getIdentity().startsWith("*:/spaces")) {
+           Space space = spaceService.getSpaceByGroupId(accessControlEntry.getIdentity().substring(2)) ;
+           if (space != null) {
+             toUnShare.put(Long.valueOf(identityManager.getOrCreateSpaceIdentity(space.getPrettyName()).getId()), accessControlEntry.getPermission());
+           }
+          }
+        }
+      });
+      nodePermissionEntity.setToUnShare(toUnShare);
       ((ExtendedNode) node).setPermissions(permissions);
       session.save();
     } catch (Exception e) {
@@ -1860,5 +1877,42 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       }
     }
     return null;
+  }
+  @Override
+  public void unShareDocument(String documentId, long destId) {
+    Node rootNode = null;
+    Node shared = null;
+    SessionProvider sessionProvider = null;
+    try {
+      sessionProvider = SessionProvider.createSystemProvider();
+      ManageableRepository repository = repositoryService.getCurrentRepository();
+      Session systemSession = sessionProvider.getSession(repository.getConfiguration().getDefaultWorkspaceName(), repository);
+      Node currentNode = getNodeByIdentifier(systemSession, documentId);
+      org.exoplatform.social.core.identity.model.Identity destIdentity = identityManager.getIdentity(String.valueOf(destId));
+      rootNode = getIdentityRootNode(spaceService, nodeHierarchyCreator, destIdentity, systemSession);
+      if(!destIdentity.getProviderId().equals(SPACE_PROVIDER_ID)){
+        rootNode = rootNode.getNode("Documents");
+      }
+      if(!rootNode.hasNode(SHARED_FOLDER_NAME)){
+        return;
+      }else{
+        shared = rootNode.getNode(SHARED_FOLDER_NAME);
+      }
+      if(currentNode.isNodeType(NodeTypeConstants.EXO_SYMLINK)){
+        String sourceNodeId = currentNode.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString();
+        currentNode = getNodeByIdentifier(systemSession, sourceNodeId);
+      }
+      if (shared.hasNode(currentNode.getName()) && shared.getNode(currentNode.getName()).isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
+        Node link = shared.getNode(currentNode.getName());
+        link.remove();
+        systemSession.save();
+      }
+    } catch (Exception e) {
+      throw new IllegalStateException("Error when unsharing the document " + documentId + "with identity " + destId, e);
+    }finally {
+      if (sessionProvider != null) {
+        sessionProvider.close();
+      }
+    }
   }
 }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -512,7 +512,7 @@ public class JCRDocumentsUtil {
       }
 
     }
-    documentNode.setAcl(new NodePermission(true, canEdit, canDelete, permissions,null, null));
+    documentNode.setAcl(new NodePermission(true, canEdit, canDelete, permissions,null, null,null));
   }
 
   private static String getPermissionRole (String membershipType){


### PR DESCRIPTION

Prior to this change ,When a document was re-shared with a user (after being removed from the document collaborators list and reassigned), they did not receive a notification. This was because the symlink already exists with the same permissions, but it was hidden from the collaborators by removing the permissions from the target node. This change is going to remove the symlink from the shared folder if a user or a space is removed from the document collaborators list.