### PR TITLE
fix : Remove the symlink when designating a document's collaborator -EXO-65859

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/model/NodePermission.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/model/NodePermission.java
@@ -38,4 +38,6 @@ public class NodePermission {
 
   private Map<Long,String> toNotify;
 
+  private Map<Long,String> toUnShare;
+
 }

--- a/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
@@ -192,6 +192,8 @@ public interface DocumentFileService {
 
   void notifyMember(String documentId, long destId) throws IllegalAccessException;
 
+  void unShareDocument(String documentId, long destId) throws IllegalStateException, RepositoryException;
+
   AbstractNode createFolder(long ownerId,String folderId, String folderPath, String name, long authenticatedUserId) throws IllegalAccessException, ObjectAlreadyExistsException, ObjectNotFoundException;
 
   String getNewName(long ownerId, String folderId, String folderPath, String name) throws IllegalAccessException, ObjectAlreadyExistsException, ObjectNotFoundException;

--- a/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
@@ -146,6 +146,8 @@ public interface DocumentFileStorage {
    */
   void shareDocument(String documentId, long destId, boolean broadcast) throws IllegalAccessException;
 
+  void unShareDocument(String documentId, long destId) throws RepositoryException;
+
   void notifyMember(String documentId, long destId) throws IllegalAccessException;
 
   boolean canAccess(String documentID, Identity aclIdentity) throws RepositoryException;

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -365,7 +365,7 @@ public class EntityBuilder {
       if (nodePermissionEntity.getVisibilityChoice().equals(Visibility.SPECIFIC_COLLABORATOR.name())) {
         permissions.add(new PermissionEntry(identity,"edit",PermissionRole.MANAGERS_REDACTORS.name()));
       }
-      return new NodePermission(nodePermissionEntity.isCanAccess(),nodePermissionEntity.isCanEdit(),nodePermissionEntity.isCanDelete(),permissions,toShare, toNotify);
+      return new NodePermission(nodePermissionEntity.isCanAccess(),nodePermissionEntity.isCanEdit(),nodePermissionEntity.isCanDelete(),permissions,toShare, toNotify, null);
     }
     return null;
   }

--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -271,12 +271,25 @@ public class DocumentFileServiceImpl implements DocumentFileService {
         throw new IllegalStateException("Error updating sharing of document'" + documentId + " to identity " + destId, e);
       }
     });
+    if (nodePermissionEntity.getToUnShare() != null) {
+      nodePermissionEntity.getToUnShare().keySet().forEach(destId -> {
+        try {
+          unShareDocument(documentId, destId);
+        } catch (Exception e) {
+          throw new IllegalStateException("Error when unsharing the document " + documentId + "with identity " + destId, e);
+        }
+      });
+    }
   }
 
   @Override
   public void shareDocument(String documentId, long destId, boolean notifyMember) throws IllegalAccessException {
-
     documentFileStorage.shareDocument(documentId, destId, notifyMember );
+  }
+
+  @Override
+  public void unShareDocument(String documentId, long destId) throws RepositoryException {
+    documentFileStorage.unShareDocument(documentId, destId);
   }
 
   @Override

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
@@ -463,7 +463,7 @@ public class DocumentFileRestTest {
     permissionEntries.add(permissionEntry4);
     permissionEntries.add(permissionEntry5);
     permissionEntries.add(permissionEntry6);
-    NodePermission nodePermission = new NodePermission(true,true,true,permissionEntries,null, null);
+    NodePermission nodePermission = new NodePermission(true, true, true, permissionEntries, null, null, null);
     folder1.setAcl(nodePermission);
 
 

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -482,7 +482,7 @@ public class JCRDocumentsUtil {
       }
 
     }
-    documentNode.setAcl(new NodePermission(true, canEdit, canDelete, permissions,null, null));
+    documentNode.setAcl(new NodePermission(true, canEdit, canDelete, permissions,null, null,null));
   }
 
   private static String getPermissionRole (String membershipType){

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -1121,19 +1121,24 @@ public class JCRDocumentFileStorageTest {
     ExtendedNode node = mock(ExtendedNode.class);
     when(JCRDocumentsUtil.getNodeByIdentifier(session, "123")).thenReturn(node);
     when(spaceService.getSpaceByPrettyName(spaceIdentity.getRemoteId())).thenReturn(space);
+    when(spaceService.getSpaceByGroupId(anyString())).thenReturn(space);
+    when(identityManager.getOrCreateUserIdentity(anyString())).thenReturn(identity1);
+    when(identity1.getId()).thenReturn("1");
     when(space.getGroupId()).thenReturn("/spaces/spaceTest");
+    when(space.getId()).thenReturn("2");
     when(node.canAddMixin(NodeTypeConstants.EXO_DATE_MODIFIED)).thenReturn(true);
     when(node.canAddMixin(NodeTypeConstants.EXO_LAST_MODIFIED_DATE)).thenReturn(true);
     when(node.canAddMixin(NodeTypeConstants.EXO_PRIVILEGEABLE)).thenReturn(true);
     when(node.hasNode(NodeTypeConstants.JCR_CONTENT)).thenReturn(true);
-    NodePermission nodePermission = mock(NodePermission.class);
+    NodePermission nodePermission = new NodePermission();
     // permissionsList including group permission
     List<PermissionEntry> permissionsList = new ArrayList<>();
     permissionsList.add(new PermissionEntry(identity, "read", null));
     permissionsList.add(new PermissionEntry(identity1, "edit", null));
     // permissionsList including space manager and redactor permission
     permissionsList.add(new PermissionEntry(spaceIdentity, "edit", PermissionRole.MANAGERS_REDACTORS.name()));
-    when(nodePermission.getPermissions()).thenReturn(permissionsList);
+    nodePermission.setPermissions(permissionsList);
+    when(node.getACL()).thenReturn(new AccessControlList("root", new ArrayList<>()));
     //When
     jcrDocumentFileStorage.updatePermissions("123",  nodePermission, aclIdentity);
     //Then
@@ -1143,6 +1148,25 @@ public class JCRDocumentFileStorageTest {
     //
     verify(node).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("redactor:/spaces/spaceTest") && Arrays.equals(map.get("redactor:/spaces/spaceTest"),PermissionType.ALL)));
     verify(node).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("manager:/spaces/spaceTest") && Arrays.equals(map.get("redactor:/spaces/spaceTest"),PermissionType.ALL)));
+
+    AccessControlList existingAccessList = new AccessControlList("root", new ArrayList<>());
+    existingAccessList.addPermissions("removedUserCollaborator", new String[]{"read"});
+    String spaceGroupId = "/spaces/removedSpaceCollaborator";
+    existingAccessList.addPermissions("*:" + spaceGroupId, new String[]{"read"});
+    when(node.getACL()).thenReturn(existingAccessList);
+    when(spaceService.getSpaceByGroupId(spaceGroupId)).thenReturn(space);
+    when(space.getPrettyName()).thenReturn("removedSpaceCollaborator");
+    when(identityManager.getOrCreateSpaceIdentity(space.getPrettyName())).thenReturn(spaceIdentity);
+    when(spaceIdentity.getId()).thenReturn("3");
+    Identity userIdentity = mock(Identity.class);
+    when(identityManager.getOrCreateUserIdentity("removedUserCollaborator")).thenReturn(userIdentity);
+    when(userIdentity.getId()).thenReturn("4");
+    //when
+    jcrDocumentFileStorage.updatePermissions("123",  nodePermission, aclIdentity);
+    //
+    assertEquals(2, nodePermission.getToUnShare().size());
+    assertTrue(nodePermission.getToUnShare().containsKey(3L));
+    assertTrue(nodePermission.getToUnShare().containsKey(4L));
   }
 
   @Test
@@ -1180,4 +1204,47 @@ public class JCRDocumentFileStorageTest {
 
   }
 
+  @Test
+  public void unShareDocumetTest() throws Exception {
+    Session systemSession = mock(Session.class);
+    Identity identity = mock(Identity.class);
+    Node rootNode = mock(Node.class);
+    Node sharedNode = mock(Node.class);
+    Node currentNode = Mockito.mock(ExtendedNode.class);
+    ExtendedNode linkNode = mock(ExtendedNode.class);
+    when(currentNode.isNodeType(NodeTypeConstants.EXO_SYMLINK)).thenReturn(false);
+    when(linkNode.isNodeType(NodeTypeConstants.EXO_SYMLINK)).thenReturn(true);
+    SessionProvider sessionProvider = mock(SessionProvider.class);
+    when(SessionProvider.createSystemProvider()).thenReturn(sessionProvider);
+    ManageableRepository manageableRepository = mock(ManageableRepository.class);
+    RepositoryEntry repositoryEntry = mock(RepositoryEntry.class);
+    when(repositoryService.getCurrentRepository()).thenReturn(manageableRepository);
+    when(manageableRepository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
+    when(sessionProvider.getSession(manageableRepository.getConfiguration().getDefaultWorkspaceName(),
+            manageableRepository)).thenReturn(systemSession);
+    when(JCRDocumentsUtil.getNodeByIdentifier(systemSession, "1")).thenReturn(currentNode);
+    when(JCRDocumentsUtil.getIdentityRootNode(spaceService, nodeHierarchyCreator,identity, systemSession)).thenReturn(rootNode);
+    when(identity.getProviderId()).thenReturn("USER");
+    when(rootNode.getNode("Documents")).thenReturn(rootNode);
+    when(identityManager.getIdentity("1")).thenReturn(null);
+
+    assertThrows(IllegalStateException.class, () -> jcrDocumentFileStorage.unShareDocument("1", 1L));
+
+    when(identityManager.getIdentity("1")).thenReturn(identity);
+    when(rootNode.hasNode("Shared")).thenReturn(false);
+
+    verify(linkNode, times(0)).remove();
+    verify(sessionProvider, times(1)).close();
+
+    when(rootNode.hasNode("Shared")).thenReturn(true);
+    when(rootNode.getNode("Shared")).thenReturn(sharedNode);
+    when(sharedNode.hasNode(currentNode.getName())).thenReturn(true);
+    when(sharedNode.getNode(currentNode.getName())).thenReturn(linkNode);
+
+    jcrDocumentFileStorage.unShareDocument("1", 1L);
+
+    verify(linkNode, times(1)).remove();
+    verify(sessionProvider, Mockito.atLeast(1)).close();
+  }
 }


### PR DESCRIPTION
Prior to this change ,When a document was re-shared with a user (after being removed from the document collaborators list and reassigned), they did not receive a notification. This was because the symlink already exists with the same permissions, but it was hidden from the collaborators by removing the permissions from the target node.
This change is going to remove the symlink from the shared folder if a user or a space is removed from the document collaborators list.