### PR TITLE
fix : Enable the search for document descriptions using the tag name - EXO-65172 (#1085)

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
@@ -473,6 +473,9 @@ public class DocumentSearchServiceConnector {
     if (StringUtils.isBlank(term)) {
       return "";
     }
+    if (term.startsWith("#")) {
+      term = term.substring(1);
+    }
     String originalTerm = term;
     term = escapeReservedCharacters(term);
     String escapedQueryWithAndOperator = buildEscapedQueryWithAndOperator(term);


### PR DESCRIPTION
This change is going to enable the search for document descriptions using the tag name.