### PR TITLE
feat: Enable edit document in mobile - EXO-65016

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/EditMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/EditMenuAction.vue
@@ -1,11 +1,11 @@
 <template>
   <div
-    class="clickable mx-2"
+    class="clickable mx-2 theme--light"
     @click="editFile()">
     <v-icon
       size="13"
       dark
-      class="pe-1 iconStyle">
+      class="pe-1 iconStyle grey--text text--darken-1">
       fas fa-edit
     </v-icon>
     <span class="ps-1">{{ $t('document.label.edit') }}</span>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
@@ -38,7 +38,6 @@ export default {
     menuExtensionApp: 'DocumentMenu',
     menuExtensionType: 'menuActionMenu',
     menuExtensions: [],
-    editExtensions: ['edit'],
     sharedDocumentSuspended: true,
     downloadDocumentSuspended: true,
     supportedDocuments: null
@@ -50,12 +49,6 @@ export default {
   },
   beforeDestroy() {
     this.$root.$off('selection-documents-list-updated', this.refreshMenuExtensions);
-  },
-  computed: {
-    fileCanEdit() {
-      const type = this.file && this.file.mimeType || '';
-      return this.$supportedDocuments && this.$supportedDocuments.filter(doc => doc.edit && doc.mimeType === type && !this.file.cloudDriveFile).length > 0;
-    }
   },
   methods: {
     getParams(extension) {
@@ -71,9 +64,6 @@ export default {
       let extensions = extensionRegistry.loadExtensions(this.menuExtensionApp, this.menuExtensionType);
 
       if (!this.isMultiSelection) {
-        if (!this.fileCanEdit) {
-          extensions = extensions.filter(extension => !this.editExtensions.includes(extension.id));
-        }
         extensions = extensions.filter(extension => extension.enabled(this.file, this.isMobile));
 
       } else {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -292,9 +292,9 @@ export default {
     },
     openPreview() {
       this.loading = true;
-      if (this.file && this.file.folder) {
+      if (this.file?.folder) {
         this.$root.$emit('document-open-folder', this.file);
-      } else if (!this.isMobile && this.isFileEditable && this.file.acl.canEdit)  {
+      } else if (this.isFileEditable && this.file?.acl?.canEdit)  {
         this.openInEditMode(this.file);
         this.loading = false;
       } else {

--- a/documents-webapp/src/main/webapp/vue-app/documents/extensions.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/extensions.js
@@ -113,8 +113,10 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   cssClass: 'font-weight-bold text-no-wrap ',
   width: '190px',
   rank: 2,
-  enabled: (file, isMobile) => {
-    return file && !file.cloudDriveFolder && file.acl.canEdit && !isMobile;
+  enabled: (file) => {
+    return file && !file.cloudDriveFolder
+                && file.acl.canEdit
+                && Vue.prototype?.$supportedDocuments.filter(doc => doc.edit && doc.mimeType === file?.mimeType).length > 0;
   },
   enabledForMultiSelection: () => false,
   componentOptions: {


### PR DESCRIPTION

Prior to this change, still in some cases on mobile the edit option not exists while we have enabled the mobile edition. This PR include theses cases and updates them to go in edit mode instead of preview for editable docs