### PR TITLE
fix : Cleaning the document's name from accents when renaming a document - EXO-66370

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -746,6 +746,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         node = getNodeByIdentifier(session, documentID);
       }
       String name = Text.escapeIllegalJcrChars(cleanName(title.toLowerCase(), node.getPrimaryNodeType().getName()));
+      name = cleanNameWithAccents(name, node.getPrimaryNodeType().getName());
       //clean node name
       name = URLDecoder.decode(name, "UTF-8");
       if (name.indexOf('.') == -1) {

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -31,6 +31,7 @@ import java.util.zip.ZipOutputStream;
 import javax.jcr.*;
 import javax.jcr.version.Version;
 
+import com.ibm.icu.text.Transliterator;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -50,6 +51,7 @@ import org.exoplatform.services.jcr.core.ManageableRepository;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
+import org.exoplatform.services.jcr.util.Text;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.Group;
@@ -682,6 +684,16 @@ public class JCRDocumentsUtil {
     }
     ret.append(extension);
     return ret.toString();
+  }
+  public static String cleanNameWithAccents(String fileName, String nodeType) {
+    Transliterator accentsconverter = Transliterator.getInstance("Latin; NFD; [:Nonspacing Mark:] Remove; NFC;");
+    if (NodeTypeConstants.NT_FILE.equals(nodeType) && fileName.indexOf('.') > 0) {
+      String ext = fileName.substring(fileName.lastIndexOf('.'));
+      fileName = accentsconverter.transliterate(fileName.substring(0, fileName.lastIndexOf('.'))).concat(ext);
+    } else {
+      fileName = accentsconverter.transliterate(fileName);
+    }
+    return Text.escapeIllegalJcrChars(fileName);
   }
 
   public static boolean isValidDocumentTitle(String name) {

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -638,6 +638,7 @@ public class JCRDocumentFileStorageTest {
     when(identity.getUserId()).thenReturn("user");
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.isValidDocumentTitle(anyString())).thenCallRealMethod();
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.cleanName(anyString(), anyString())).thenCallRealMethod();
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.cleanNameWithAccents(anyString(), anyString())).thenCallRealMethod();
     when(node.getName()).thenReturn("oldName");
     when(node.canAddMixin(NodeTypeConstants.EXO_MODIFY)).thenReturn(true);
     when(node.canAddMixin(NodeTypeConstants.EXO_SORTABLE)).thenReturn(true);

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -408,5 +408,15 @@ public class JCRDocumentsUtilTest {
     assertEquals("__system",fileVersion.getAuthorFullName());
 
   }
+  @Test
+  public void testCleanNameWithAccents(){
+    String fileName = "filName";
+    String fileNameWithAccent = "fileNameWithAccént";
+    assertEquals("filName", JCRDocumentsUtil.cleanNameWithAccents(fileName, NodeTypeConstants.NT_FILE));
+    assertEquals("fileNameWithAccent", JCRDocumentsUtil.cleanNameWithAccents(fileNameWithAccent, NodeTypeConstants.NT_FILE));
+    //folder name with '.' character followed by a accented character
+    String folderNameWithPointFollowedByAccent = "folderName.followedByAccént";
+    assertEquals("folderName.followedByAccent", JCRDocumentsUtil.cleanNameWithAccents(folderNameWithPointFollowedByAccent, NodeTypeConstants.NT_FOLDER));
+  }
 
 }


### PR DESCRIPTION
Before this change, when renaming a document with an accentuated name, we were able to add a new document with the same title. This issue was caused by the removal of accents from the document name during the creation of a new document, and the absence of this cleaning during the rename action. This change is adds the cleanNameWithAccents method to clean the document's name from accents when renaming a document

(cherry picked from commit 4aefe29881dce1d8e76a0f8591a1bb87b78e74c4)