### PR TITLE
fix: Button change when selecting one item - EXO-64139

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsAddNewFile.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsAddNewFile.vue
@@ -240,7 +240,7 @@ export default {
       this.selectionsLength = 0;
     },
     handleSelectionListUpdate(selectedList) {
-      this.showSelectionsMenu = selectedList.length > 1;
+      this.showSelectionsMenu = selectedList.length > 0;
       this.selectionsLength = selectedList.length;
     },
     refreshFilesList() {


### PR DESCRIPTION
Prior to this change, when go to doc app of spaceX and hover beside doc1 then click on checkobox, no change on +new button .To fix this, change showSelectionsMenu to true if the selected list length is greater than 0.