### PR TITLE
fix: upload files under symlink folders - EXO-66517 (#1115)

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/model/BreadCrumbItem.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/model/BreadCrumbItem.java
@@ -27,6 +27,7 @@ import lombok.NoArgsConstructor;
 public class BreadCrumbItem {
   private String                                id;
   private String                                name;
+  private String                                technicalName;
   private String                                path;
   private boolean                               isSymlink;
   private Map<String, Boolean>                  accessList;

--- a/documents-api/src/main/java/org/exoplatform/documents/model/DocumentNodeFilter.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/model/DocumentNodeFilter.java
@@ -45,7 +45,7 @@ public abstract class DocumentNodeFilter {
 
   private Long              afterDate;
 
-  private Long              beforDate;
+  private Long              beforeDate;
 
   private Long              minSize;
 

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
@@ -75,23 +75,23 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "/v1/documents", description = "Manages documents associated to users and spaces") // NOSONAR
 public class DocumentFileRest implements ResourceContainer {
 
-  private static final Log          LOG = ExoLogger.getLogger(DocumentFileRest.class);
+  private static final Log                  LOG                = ExoLogger.getLogger(DocumentFileRest.class);
 
-  private final DocumentFileService documentFileService;
+  private final DocumentFileService         documentFileService;
 
-  private final SpaceService        spaceService;
+  private final SpaceService                spaceService;
 
-  private final MetadataService     metadataService;
+  private final MetadataService             metadataService;
 
-  private final IdentityManager     identityManager;
+  private final IdentityManager             identityManager;
 
-  private final SettingService       settingService;
+  private final SettingService              settingService;
 
-  private final DocumentWebSocketService documentWebSocketService;
+  private final DocumentWebSocketService    documentWebSocketService;
 
   private final PublicDocumentAccessService publicDocumentAccessService;
-  
-  private final ExternalDownloadService        externalDownloadService;
+
+  private final ExternalDownloadService     externalDownloadService;
 
   public static final UserFieldValidator    PASSWORD_VALIDATOR = new UserFieldValidator("password", false, false, 9, 255);
 
@@ -188,8 +188,8 @@ public class DocumentFileRest implements ResourceContainer {
       @ApiResponse(responseCode = "401", description = "Unauthorized operation"),
       @ApiResponse(responseCode = "500", description = "Internal server error"), })
   public Response getDocumentItems(@Parameter(description = "Identity technical identifier")
-  @QueryParam("ownerId")
-  Long ownerId,
+                                   @QueryParam("ownerId")
+                                   Long ownerId,
                                    @Parameter(description = "Parent folder technical identifier")
                                    @QueryParam("parentFolderId")
                                    String parentFolderId,
@@ -201,13 +201,13 @@ public class DocumentFileRest implements ResourceContainer {
                                    String folderPath,
                                    @Parameter(description = "Listing type of folder. Can be 'TIMELINE' or 'FOLDER'.")
                                    @QueryParam("listingType")
-                                     FileListingType listingType,
+                                   FileListingType listingType,
                                    @Parameter(description = "Search query entered by the user")
-                                     @QueryParam("query")
-                                     String query,
+                                   @QueryParam("query")
+                                   String query,
                                    @Parameter(description = "extendedSearch")
-                                     @QueryParam("extendedSearch")
-                                     boolean extendedSearch,
+                                   @QueryParam("extendedSearch")
+                                   boolean extendedSearch,
                                    @Parameter(description = "userId")
                                    @QueryParam("userId")
                                    String userId,
@@ -238,9 +238,9 @@ public class DocumentFileRest implements ResourceContainer {
                                    @Parameter(description = "afterDate")
                                    @QueryParam("afterDate")
                                    Long afterDate,
-                                   @Parameter(description = "beforDate")
-                                   @QueryParam("beforDate")
-                                   Long beforDate,
+                                   @Parameter(description = "beforeDate")
+                                   @QueryParam("beforeDate")
+                                   Long beforeDate,
                                    @Parameter(description = "minSize")
                                    @QueryParam("minSize")
                                    Long minSize,
@@ -267,7 +267,7 @@ public class DocumentFileRest implements ResourceContainer {
       filter.setUserId(userId);
       filter.setFileTypes(fileType);
       filter.setAfterDate(afterDate);
-      filter.setBeforDate(beforDate);
+      filter.setBeforeDate(beforeDate);
       filter.setMaxSize(maxSize);
       filter.setMinSize(minSize);
       filter.setAscending(ascending);
@@ -277,7 +277,7 @@ public class DocumentFileRest implements ResourceContainer {
                                                                                        identityManager,
                                                                                        spaceService,
                                                                                        metadataService,
-              publicDocumentAccessService,
+                                                                                       publicDocumentAccessService,
                                                                                        documents,
                                                                                        expand,
                                                                                        userIdentityId);
@@ -349,8 +349,8 @@ public class DocumentFileRest implements ResourceContainer {
       @ApiResponse(responseCode = "401", description = "Unauthorized operation"),
       @ApiResponse(responseCode = "500", description = "Internal server error"), })
   public Response getBreadcrumb(@Parameter(description = "Identity technical identifier", required = false)
-  @QueryParam("ownerId")
-  Long ownerId,
+                                @QueryParam("ownerId")
+                                Long ownerId,
                                 @Parameter(description = "Folder technical identifier")
                                 @QueryParam("folderId")
                                 String folderId,

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/model/BreadCrumbItemEntity.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/model/BreadCrumbItemEntity.java
@@ -29,6 +29,7 @@ import lombok.Data;
 public class BreadCrumbItemEntity {
   private String                                id;
   private String                                name;
+  private String                                technicalName;
   private String                                path;
 
   private boolean isSymlink;

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -203,14 +203,22 @@ public class EntityBuilder {
   }
 
   public static List<BreadCrumbItemEntity> toBreadCrumbItemEntities(List<BreadCrumbItem> folders) {
-    List<BreadCrumbItemEntity>  brList = new ArrayList<BreadCrumbItemEntity>();
-    brList = folders.stream()
-                    .map(document -> new BreadCrumbItemEntity(document.getId(),
-                                                              document.getName(),
-                                                              document.getPath(),
-                                                              document.isSymlink(),
-                                                              document.getAccessList()))
-                    .collect(Collectors.toList());
+    List<BreadCrumbItemEntity>  brList = new ArrayList<>();
+    for(BreadCrumbItem breadCrumbItem : folders) {
+      BreadCrumbItemEntity breadCrumbItemEntity = new BreadCrumbItemEntity(breadCrumbItem.getId(),
+              breadCrumbItem.getName(),
+              breadCrumbItem.getTechnicalName(),
+              breadCrumbItem.getPath(),
+              breadCrumbItem.isSymlink(),
+              breadCrumbItem.getAccessList());
+
+      brList.add(breadCrumbItemEntity);
+      if(breadCrumbItem.isSymlink()) {
+        for(int i = brList.size() - 1; i > 0 ; i--) {
+          brList.get(i - 1).setPath(brList.get(i).getPath() + "/" + brList.get(i - 1).getTechnicalName());
+        }
+      }
+    }
     Collections.reverse(brList);
     return brList;
   }
@@ -533,7 +541,7 @@ public class EntityBuilder {
     return identityEntity;
   }
   private static boolean isEditPermission(String permission){
-    return  permission.contains("add_node") || permission.contains("set_property") || permission.contains("remove") ? true : false;
+    return  permission.contains("add_node") || permission.contains("set_property") || permission.contains("remove");
   }
 
   public static PublicDocumentAccessEntity toPublicDocumentAccessEntity(PublicDocumentAccess publicDocumentAccess) {

--- a/documents-services/src/test/java/org/exoplatform/documents/service/DocumentFileServiceTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/service/DocumentFileServiceTest.java
@@ -403,8 +403,8 @@ public class DocumentFileServiceTest {
     when(identityRegistry.getIdentity(username)).thenReturn(userID);
     when(identityManager.getIdentity(eq(String.valueOf(currentOwnerId)))).thenReturn(currentIdentity);
 
-    BreadCrumbItem breadCrumbItem1 = new BreadCrumbItem("1", "Folder1", "", false,new HashMap<>());
-    BreadCrumbItem breadCrumbItem2 = new BreadCrumbItem("2", "Folder2", "", false,new HashMap<>());
+    BreadCrumbItem breadCrumbItem1 = new BreadCrumbItem("1", "Folder1", "Folder1", "", false,new HashMap<>());
+    BreadCrumbItem breadCrumbItem2 = new BreadCrumbItem("2", "Folder2", "Folder1", "", false,new HashMap<>());
     BreadCrumbItem breadCrumbItem3 = new BreadCrumbItem();
     breadCrumbItem3.setId("3");
     breadCrumbItem3.setName("Folder3");

--- a/documents-storage-jcr/pom.xml
+++ b/documents-storage-jcr/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>documents-storage-jcr</artifactId>
   <name>eXo Documents - Storage JCR Implementation</name>
   <properties>
-    <exo.test.coverage.ratio>0.33</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.43</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
@@ -138,7 +138,7 @@ public class DocumentSearchServiceConnector {
     }
     if (StringUtils.isBlank(filter.getQuery()) && BooleanUtils.isFalse(filter.getFavorites())
         && StringUtils.isEmpty(filter.getFileTypes())
-        && filter.getAfterDate() == null && filter.getBeforDate() == null && filter.getMaxSize() == null
+        && filter.getAfterDate() == null && filter.getBeforeDate() == null && filter.getMaxSize() == null
         && filter.getMinSize() == null) {
       throw new IllegalArgumentException("Filter term is mandatory");
     }
@@ -283,13 +283,13 @@ public class DocumentSearchServiceConnector {
   }
 
   private String getDatesQuery(DocumentNodeFilter filter) {
-    if (filter.getAfterDate() != null || filter.getBeforDate() != null) {
+    if (filter.getAfterDate() != null || filter.getBeforeDate() != null) {
       List<String> dates = new ArrayList<>();
       if (filter.getAfterDate() != null) {
         dates.add("\"gte\": " + filter.getAfterDate());
       }
-      if (filter.getBeforDate() != null) {
-        dates.add("\"lte\": " + filter.getBeforDate());
+      if (filter.getBeforeDate() != null) {
+        dates.add("\"lte\": " + filter.getBeforeDate());
       }
       return "{\n" +
               "   \"bool\":{\n" +

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.*;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import javax.jcr.*;
@@ -273,7 +274,7 @@ public class JCRDocumentFileStorageTest {
     org.exoplatform.services.security.Identity identity = mock(org.exoplatform.services.security.Identity.class);
     Identity ownerIdentity = mock(Identity.class);
     when(identity.getUserId()).thenReturn("user");
-    DocumentFolderFilter filter = new DocumentFolderFilter("12e2", "documents/path", 1L, "");
+    DocumentFolderFilter filter = new DocumentFolderFilter("12e2", null, 1L, "");
 
     // mock session
     SessionProvider sessionProvider = mock(SessionProvider.class);
@@ -375,11 +376,18 @@ public class JCRDocumentFileStorageTest {
     when(parentNodeImp.getName()).thenReturn("documents");
     when(parentNodeImp.getNode(filter.getFolderPath())).thenReturn(parentNodeImp);
     when(parentNodeImp.getPath()).thenReturn("/documents/path");
+    when(parentNodeImp.getIdentifier()).thenReturn("parentNodeIdentifier");
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getIdentityRootNode(spaceService,
-                                              nodeHierarchyCreator,
-                                              "user",
-                                              ownerIdentity,
-                                              sessionProvider)).thenReturn(parentNodeImp);
+                                                                       nodeHierarchyCreator,
+                                                                       "user",
+                                                                       ownerIdentity,
+                                                                       sessionProvider))
+                      .thenReturn(parentNodeImp);
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getIdentityRootNode(spaceService,
+                                                                       nodeHierarchyCreator,
+                                                                       ownerIdentity,
+                                                                       userSession))
+                      .thenReturn(parentNodeImp); 
     NodeIterator nodeIterator1 = mock(NodeIterator.class);
     when(queryResult.getNodes()).thenReturn(nodeIterator1);
     when(nodeIterator1.hasNext()).thenReturn(true, true, false);
@@ -875,7 +883,7 @@ public class JCRDocumentFileStorageTest {
     Session userSession = mock(Session.class);
     org.exoplatform.services.security.Identity identity = mock(org.exoplatform.services.security.Identity.class);
     when(identity.getUserId()).thenReturn("user");
-    DocumentFolderFilter filter = new DocumentFolderFilter("12e2", "documents/path", 1L, "");
+    DocumentFolderFilter filter = new DocumentFolderFilter("12e2", "", 1L, "");
 
     // mock session
     SessionProvider sessionProvider = mock(SessionProvider.class);

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -19,7 +19,7 @@
           :primary-filter="primaryFilter"
           :file-type="fileType"
           :after-date="afterDate"
-          :befor-date="beforDate"
+          :before-date="beforeDate"
           :min-size="minSize"
           :max-size="maxSize"
           :is-mobile="isMobile"
@@ -70,7 +70,7 @@
             :primary-filter="primaryFilter"
             :file-type="fileType"
             :after-date="afterDate"
-            :befor-date="beforDate"
+            :before-date="beforeDate"
             :min-size="minSize"
             :max-size="maxSize"
             :selected-view="selectedView"
@@ -220,7 +220,7 @@ export default {
     newVersionFile: {},
     fileType: [],
     afterDate: null,
-    beforDate: null,
+    beforeDate: null,
     minSize: null,
     maxSize: null,
     publicLinkUrl: `${window.location.origin}/${eXo.env.portal.containerName}/download-document/`
@@ -313,7 +313,7 @@ export default {
     this.$root.$on('set-advanced-filter', advancedFilter => {
       this.fileType = advancedFilter.fileType;
       this.afterDate = advancedFilter.selectedPeriod?.min;
-      this.beforDate = advancedFilter.selectedPeriod?.max;
+      this.beforeDate = advancedFilter.selectedPeriod?.max;
       this.minSize = advancedFilter.minSize;
       this.maxSize = advancedFilter.maxSize;
       this.refreshFiles();
@@ -1081,8 +1081,8 @@ export default {
       if (this.afterDate) {
         filter.afterDate = this.afterDate;
       }      
-      if (this.beforDate) {
-        filter.beforDate = this.beforDate;
+      if (this.beforeDate) {
+        filter.beforeDate = this.beforeDate;
       }     
       if (this.minSize) {
         filter.minSize = this.minSize;

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsBody.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsBody.vue
@@ -83,7 +83,7 @@ export default {
       type: Number,
       default: null,
     },
-    beforDate: {
+    beforeDate: {
       type: Number,
       default: null,
     },
@@ -131,7 +131,7 @@ export default {
         selectedDocuments: this.selectedDocuments,
         fileType: this.fileType,
         afterDate: this.afterDate,
-        beforDate: this.beforDate,
+        beforeDate: this.beforeDate,
         minSize: this.minSize,
         maxSize: this.maxSize,
         primaryFilter: this.primaryFilter,

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderView.vue
@@ -189,7 +189,7 @@ export default {
       type: Number,
       default: null,
     },
-    beforDate: {
+    beforeDate: {
       type: Number,
       default: null,
     },

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsTimelineView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsTimelineView.vue
@@ -118,7 +118,7 @@
           :primary-filter="primaryFilterFavorite"
           :file-type="fileType"
           :after-date="afterDate"
-          :befor-date="beforDate"
+          :before-date="beforeDate"
           :min-size="minSize" />
       </template>
       <template v-if="hasMore" slot="footer">
@@ -195,7 +195,7 @@ export default {
       type: Number,
       default: null,
     },
-    beforDate: {
+    beforeDate: {
       type: Number,
       default: null,
     },
@@ -251,7 +251,7 @@ export default {
       return this.headers && this.headers.filter(header => header.cellExtension && header.cellExtension.componentOptions);
     },
     grouping() {
-      return !(this.query?.length > 0  || this.primaryFilter !== 'all' || this.fileType?.length>0 || this.afterDate || this.beforDate || this.minSize || this.maxSize) && (!this.sortField || this.sortField === 'lastUpdated') ;
+      return !(this.query?.length > 0  || this.primaryFilter !== 'all' || this.fileType?.length>0 || this.afterDate || this.beforeDate || this.minSize || this.maxSize) && (!this.sortField || this.sortField === 'lastUpdated') ;
     },
     querySearch() {
       return this.query && this.query.length;

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/DocumentsHeader.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/DocumentsHeader.vue
@@ -77,7 +77,7 @@ export default {
       type: Number,
       default: null,
     },
-    beforDate: {
+    beforeDate: {
       type: Number,
       default: null,
     },
@@ -147,7 +147,7 @@ export default {
       if (this.fileType?.length>0) {
         fNum++;
       }
-      if (this.afterDate && this.beforDate) {
+      if (this.afterDate && this.beforeDate) {
         fNum++;
       }
       if (this.minSize) {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/filters/DocumentFilterMenuMobile.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/filters/DocumentFilterMenuMobile.vue
@@ -75,7 +75,7 @@ export default {
         extendedSearch: this.extendedSearch,
         fileType: this.fileType,
         afterDate: this.afterDate,
-        beforDate: this.beforDate,
+        beforeDate: this.beforeDate,
         minSize: this.minSize,
         maxSize: this.maxSize,
       };


### PR DESCRIPTION
Before the fix, it was not possible to upload files under a symlink folder, the files are uploaded in another folder having the path of the original folder. The fix send correctly the symlink path instead of the source folder to do correctly the uploaded file under the destination.