### PR TITLE
fix: could not load dolder content when redirected from the preview URL of a document - EXO-67548

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -372,7 +372,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         }
       }
       if (StringUtils.isNotBlank(folderPath)) {
-        parent = getNodeByPath(parent, folderPath.toLowerCase(), sessionProvider);
+        parent = getNodeByPath(parent, folderPath, sessionProvider);
       }
       if (parent != null) {
         if (StringUtils.isBlank(filter.getQuery()) && BooleanUtils.isNotTrue(filter.getFavorites())
@@ -1106,29 +1106,46 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       if ((node.getName().equals(USER_PRIVATE_ROOT_NODE))) {
         if (folderPath.startsWith(USER_PRIVATE_ROOT_NODE)) {
           folderPath = folderPath.split(USER_PRIVATE_ROOT_NODE + SLASH)[1];
-          return (node.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8).replace("%", "%25")));
+          folderPath = java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8).replace("%", "%25");
+          if(node.hasNode(folderPath)) {
+            return node.getNode(folderPath);
+          } else {
+            return node.getNode(folderPath.toLowerCase());
+          }
         }
         if (folderPath.startsWith(USER_PUBLIC_ROOT_NODE)) {
           SessionProvider systemSessionProvides = SessionProvider.createSystemProvider();
           Session systemSession = systemSessionProvides.getSession(sessionProvider.getCurrentWorkspace(),
                                                                    sessionProvider.getCurrentRepository());
-          Node parent = getNodeByIdentifier(systemSession, ((NodeImpl) node).getIdentifier()).getParent();
-          node = parent.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8).replace("%", "%25"));
-          Session session = sessionProvider.getSession(sessionProvider.getCurrentWorkspace(),
-                                                       sessionProvider.getCurrentRepository());
-          if (session.itemExists(parentPath)) {
-            return (Node) session.getItem(parentPath);
+          Node selectedNode = getNodeByIdentifier(systemSession, ((NodeImpl) node).getIdentifier());
+          folderPath = java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8).replace("%", "%25");
+          if(selectedNode != null) {
+            Node parent = selectedNode.getParent();
+            if (parent.hasNode(folderPath)) {
+              return parent.getNode(folderPath);
+            } else {
+              return parent.getNode(folderPath.toLowerCase());
+            }
           }
-          return null;
         }
       } else if ((node.getName().equals(USER_PUBLIC_ROOT_NODE))) {
         if (folderPath.startsWith(USER_PRIVATE_ROOT_NODE + SLASH + USER_PUBLIC_ROOT_NODE)) {
           folderPath = folderPath.split(USER_PRIVATE_ROOT_NODE + SLASH + USER_PUBLIC_ROOT_NODE + SLASH)[1];
-          return (node.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8).replace("%", "%25")));
+          folderPath = java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8).replace("%", "%25");
+          if(node.hasNode(folderPath)) {
+            return node.getNode(folderPath);
+          } else {
+            return node.getNode(folderPath.toLowerCase());
+          }
         }
         if (folderPath.startsWith(USER_PUBLIC_ROOT_NODE)) {
           folderPath = folderPath.split(USER_PUBLIC_ROOT_NODE + SLASH)[1];
-          return (node.getNode(java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8).replace("%", "%25")));
+          folderPath = java.net.URLDecoder.decode(folderPath, StandardCharsets.UTF_8).replace("%", "%25");
+          if(node.hasNode(folderPath)) {
+            return node.getNode(folderPath);
+          } else {
+            return node.getNode(folderPath.toLowerCase());
+          }
         }
       } else {
         String[] splittedNodePath = folderPath.split(SLASH);
@@ -1143,10 +1160,12 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
               currentNode = getNodeByIdentifier(currentNode.getSession(), sourceNodeId);
             }
             nodeName = java.net.URLDecoder.decode(nodeName, StandardCharsets.UTF_8).replace("%", "%25");
-            if (currentNode != null && currentNode.hasNode(nodeName)) {
-              currentNode = currentNode.getNode(nodeName);
-            } else {
-              currentNode = currentNode.getNode(nodeName.toLowerCase());
+            if(currentNode != null) {
+              if (currentNode.hasNode(nodeName)) {
+                currentNode = currentNode.getNode(nodeName);
+              } else {
+                currentNode = currentNode.getNode(nodeName.toLowerCase());
+              }
             }
           }
         }


### PR DESCRIPTION
Before the fix, when opening the preview of a document, the contents of the caontaining folder does not show up.
The fix makes sure to look for the folder by its name before looking for it using the lowercased value.