### PR TITLE
fix: Prevent dragging and dropping documents when the Edit Name mode is active - EXO-67175

### DIFF
--- a/documents-webapp/src/main/webapp/js/DocumentsDraggable.js
+++ b/documents-webapp/src/main/webapp/js/DocumentsDraggable.js
@@ -58,6 +58,9 @@
             return true;
         }
         const target = getTargetRow(event.target);
+        if (isEditModeActive(target)) {
+            return ;
+        }
         const selections = getSelectedRows();
         parentDragElement = getParentDragElement();
         if (selections.length) {
@@ -166,6 +169,10 @@
 
     function getSelectedRows() {
         return document.querySelectorAll("tr.v-data-table__selected");
+    }
+
+    function isEditModeActive(target) {
+        return target.querySelectorAll(".documentEditName").length;
     }
 
     function getTargetRow(target) {


### PR DESCRIPTION
Prior to this change, users were able to drag and drop documents when the 'Edit Name' mode was active, causing confusion. This change prevents dragging and dropping documents when the 'Edit Name' mode is active