### PR TITLE
fix: move drawer ko - EXO-67091

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
@@ -129,11 +129,12 @@ public interface DocumentFileService {
    * @param folderId Id of the given folder
    * @param authenticatedUserId of the user acessing files
    * @return {@link List} of {@link FullTreeItem}
+   * @param withChildren get all children
    * @throws IllegalAccessException when the user isn't allowed to access
    *           documents of the designated parentFolderId
    * @throws ObjectNotFoundException when folderId doesn't exisits
    */
-  List<FullTreeItem> getFullTreeData(long ownerId,String folderId, long authenticatedUserId) throws IllegalAccessException, ObjectNotFoundException;
+  List<FullTreeItem> getFullTreeData(long ownerId, String folderId, long authenticatedUserId, boolean withChildren) throws IllegalAccessException, ObjectNotFoundException;
 
   /**
    * Duplicate the given node.

--- a/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
@@ -100,9 +100,10 @@ public interface DocumentFileStorage {
    *
    * @param folderId Id of the given folder
    * @param aclIdentity {@link Identity} of the user acessing files
+   * @param withChildren get all children
    * @return {@link List} of {@link AbstractNode}
    */
-  List<FullTreeItem> getFullTreeData(long ownerId, String folderId, Identity aclIdentity) throws IllegalAccessException, ObjectNotFoundException;
+  List<FullTreeItem> getFullTreeData(long ownerId, String folderId, Identity aclIdentity, boolean withChildren) throws IllegalAccessException, ObjectNotFoundException;
 
   /**
    * Duplicate the given node.

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
@@ -390,14 +390,17 @@ public class DocumentFileRest implements ResourceContainer {
                                         Long ownerId,
                                 @Parameter(description = "Folder technical identifier")
                                 @QueryParam("folderId")
-                                        String folderId) {
+                                String folderId,
+                                  @Parameter(description = "Folder technical identifier")
+                                    @QueryParam("withChildren")
+                                    boolean withChildren) {
 
     if (ownerId == null && StringUtils.isBlank(folderId)) {
       return Response.status(Status.BAD_REQUEST).entity("either_ownerId_or_folderId_is_mandatory").build();
     }
     long userIdentityId = RestUtils.getCurrentUserIdentityId(identityManager);
     try {
-      return Response.ok(EntityBuilder.toFullTreeItemEntities(documentFileService.getFullTreeData(ownerId, folderId, userIdentityId)))
+        return Response.ok(EntityBuilder.toFullTreeItemEntities(documentFileService.getFullTreeData(ownerId, folderId, userIdentityId, withChildren)))
               .build();
     } catch (IllegalAccessException e) {
       return Response.status(Status.UNAUTHORIZED).entity(e.getMessage()).build();

--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -243,8 +243,8 @@ public class DocumentFileServiceImpl implements DocumentFileService {
     return documentFileStorage.getBreadcrumb(ownerId, folderId, folderPath, getAclUserIdentity(authenticatedUserId));
   }
   @Override
-  public List<FullTreeItem> getFullTreeData(long ownerId, String folderId, long authenticatedUserId) throws IllegalAccessException, ObjectNotFoundException {
-    return documentFileStorage.getFullTreeData(ownerId, folderId, getAclUserIdentity(authenticatedUserId));
+  public List<FullTreeItem> getFullTreeData(long ownerId, String folderId, long authenticatedUserId, boolean withChildren) throws IllegalAccessException, ObjectNotFoundException {
+    return documentFileStorage.getFullTreeData(ownerId, folderId, getAclUserIdentity(authenticatedUserId), withChildren);
   }
 
   @Override

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
@@ -825,8 +825,8 @@ public class DocumentFileRestTest {
     Response response1 = documentFileRest.renameDocument("11111111", 2L, "renameTest");
     assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
 
-    when(documentFileStorage.getFullTreeData(2L, "11111111", userID)).thenReturn(children);
-    Response response2 = documentFileRest.getFullTreeData(2L, "11111111");
+    when(documentFileStorage.getFullTreeData(2L, "11111111", userID, true)).thenReturn(children);
+    Response response2 = documentFileRest.getFullTreeData(2L, "11111111", true);
     assertEquals(Response.Status.OK.getStatusCode(), response2.getStatus());
 
     Response response3 = documentFileRest.moveDocument(null, null, "/Groups/spaces/test/Documents/test", null);
@@ -1209,16 +1209,16 @@ public class DocumentFileRestTest {
                                                               documentWebSocketService,
                                                               publicDocumentAccessService,
                                                               externalDownloadService);
-    Response response = documentFileRest1.getFullTreeData(null, null);
+    Response response = documentFileRest1.getFullTreeData(null, null, true);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-    when(documentFileRest1.getFullTreeData(1L, "123")).thenThrow(IllegalAccessException.class);
-    response = documentFileRest1.getFullTreeData(1L, "123");
+    when(documentFileRest1.getFullTreeData(1L, "123", true)).thenThrow(IllegalAccessException.class);
+    response = documentFileRest1.getFullTreeData(1L, "123", true);
     assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
-    when(documentFileRest1.getFullTreeData(1L, "123")).thenThrow(ObjectNotFoundException.class);
-    response = documentFileRest1.getFullTreeData(1L, "123");
+    when(documentFileRest1.getFullTreeData(1L, "123", true)).thenThrow(ObjectNotFoundException.class);
+    response = documentFileRest1.getFullTreeData(1L, "123", true);
     assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
-    when(documentFileRest1.getFullTreeData(1L, "123")).thenThrow(RuntimeException.class);
-    response = documentFileRest1.getFullTreeData(1L, "123");
+    when(documentFileRest1.getFullTreeData(1L, "123", true)).thenThrow(RuntimeException.class);
+    response = documentFileRest1.getFullTreeData(1L, "123", true);
     assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
   }
 

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.*;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import javax.jcr.*;
@@ -691,7 +690,7 @@ public class JCRDocumentFileStorageTest {
     when(sessionProvider.getSession("collaboration", manageableRepository)).thenReturn(session);
     when(identityManager.getIdentity(String.valueOf(ownerId))).thenReturn(ownerIdentity);
 
-    List<FullTreeItem> fullTreeItemList = jcrDocumentFileStorage.getFullTreeData(ownerId, folderId, identity);
+    List<FullTreeItem> fullTreeItemList = jcrDocumentFileStorage.getFullTreeData(ownerId, folderId, identity, true);
     assertTrue("When node is null, return empty list", fullTreeItemList.isEmpty());
 
     Node folderNode = mock(NodeImpl.class);
@@ -705,7 +704,7 @@ public class JCRDocumentFileStorageTest {
     when(getNodeByIdentifier(session, folderId)).thenReturn(folderNode);
 
     // return list with just the parent folder when the node has no child nodes
-    fullTreeItemList = jcrDocumentFileStorage.getFullTreeData(ownerId, folderId, identity);
+    fullTreeItemList = jcrDocumentFileStorage.getFullTreeData(ownerId, folderId, identity, true);
     assertEquals(1, fullTreeItemList.size());
 
     // when current folder is hidden
@@ -723,7 +722,7 @@ public class JCRDocumentFileStorageTest {
 
 
     // return list with just the parent folder when it contains just a hidden folder
-    fullTreeItemList = jcrDocumentFileStorage.getFullTreeData(ownerId, folderId, identity);
+    fullTreeItemList = jcrDocumentFileStorage.getFullTreeData(ownerId, folderId, identity, true);
     assertEquals(1, fullTreeItemList.size());
 
     Node folderNTFolder = mock(NodeImpl.class);
@@ -761,9 +760,14 @@ public class JCRDocumentFileStorageTest {
     when(nodeIterator.nextNode()).thenReturn(folderNTFolder, folderNTUnstructured, symlinkFolder);
     when(folderNode.getNodes()).thenReturn(nodeIterator);
 
-    fullTreeItemList = jcrDocumentFileStorage.getFullTreeData(ownerId, folderId, identity);
+    fullTreeItemList = jcrDocumentFileStorage.getFullTreeData(ownerId, folderId, identity, true);
     assertEquals(1, fullTreeItemList.size());
     assertEquals(3, fullTreeItemList.get(0).getChildren().size());
+
+    // withChildren is false, it should return list with just the parent folder children, sub folders should not have children
+    fullTreeItemList = jcrDocumentFileStorage.getFullTreeData(ownerId, folderId, identity, false);
+    assertEquals(1, fullTreeItemList.size());
+    assertEquals(0, fullTreeItemList.get(0).getChildren().size());
 
     // Natural sorted items
     Node folder1 = mock(NodeImpl.class);
@@ -792,7 +796,7 @@ public class JCRDocumentFileStorageTest {
     when(nodeIterator.nextNode()).thenReturn(folder1, folder10, folder2);
     when(folderNode.getNodes()).thenReturn(nodeIterator);
 
-    fullTreeItemList = jcrDocumentFileStorage.getFullTreeData(ownerId, folderId, identity);
+    fullTreeItemList = jcrDocumentFileStorage.getFullTreeData(ownerId, folderId, identity, true);
     assertEquals(1, fullTreeItemList.size());
     assertEquals(3, fullTreeItemList.get(0).getChildren().size());
     //assert that the folder1 on the first position
@@ -812,7 +816,7 @@ public class JCRDocumentFileStorageTest {
     when(userHome.getNodes()).thenReturn(nodeIterator);
     when(getIdentityRootNode(spaceService, nodeHierarchyCreator, userName, ownerIdentity, sessionProvider)).thenReturn(userHome);
 
-    fullTreeItemList = jcrDocumentFileStorage.getFullTreeData(ownerId, null, identity);
+    fullTreeItemList = jcrDocumentFileStorage.getFullTreeData(ownerId, null, identity, true);
 
     assertEquals(1, fullTreeItemList.size());
     assertEquals(2, fullTreeItemList.get(0).getChildren().size());
@@ -826,7 +830,7 @@ public class JCRDocumentFileStorageTest {
     when(folderNode.getNodes()).thenReturn(nodeIterator);
 
 
-    fullTreeItemList = jcrDocumentFileStorage.getFullTreeData(ownerId, folderId, identity);
+    fullTreeItemList = jcrDocumentFileStorage.getFullTreeData(ownerId, folderId, identity, true);
     assertEquals(1, fullTreeItemList.size());
     assertTrue(fullTreeItemList.get(0).getChildren().isEmpty());
 

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsTreeSelectorDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsTreeSelectorDrawer.vue
@@ -60,6 +60,7 @@
         </span>
         <v-treeview
           :open.sync="openLevel"
+          :load-children="fetchChildren"
           :items="items"
           class="treeView-item my-2"
           item-key="name"
@@ -179,6 +180,14 @@ export default {
     },
   },
   methods: {
+    fetchChildren (item) {
+      this.$documentFileService
+        .getFullTreeData(this.ownerId,item.id).then(data => {
+          if (data) {
+            item.children.push(...data[0].children);
+          }
+        });
+    },
     open(file) {
       this.file = file;
       const ownerId = eXo.env.portal.spaceIdentityId || eXo.env.portal.userIdentityId;

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/FolderTreeViewDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/FolderTreeViewDrawer.vue
@@ -11,6 +11,7 @@
       <v-treeview
         :open.sync="openLevel"
         :items="items"
+        :load-children="fetchChildren"
         class="treeView-item my-2"
         item-key="id"
         hoverable
@@ -67,7 +68,7 @@ export default {
     sortNestedItems(items) {
       this.sortItems(items);
       items.forEach(item => {
-        if (item.children.length) {
+        if (item.children?.length) {
           this.sortNestedItems(item.children);
         }
       });
@@ -82,6 +83,16 @@ export default {
     },
     openFolder(folder){
       this.$root.$emit('open-folder', folder);
+    },
+    fetchChildren (item) {
+      this.$refs.folderBreadcrumb?.startLoading();
+      this.$documentFileService
+        .getFullTreeData(this.ownerId,item.id).then(data => {
+          if (data) {
+            item.children.push(...data[0].children);
+          }
+          this.$refs.folderBreadcrumb?.endLoading();
+        });
     },
     retrieveDocumentTree(){
       this.items = [];


### PR DESCRIPTION
Prior to this change, if the user creates a shortcut to a folder in a destination that already contains a shortcut to the same folder. this breaks the tree view of the folder, since the service returns the full tree with all children and in this case, we will have an infinite loop.
This commit fixes the problem by retrieving only the first layer of children and then every time the user opens a folder in the tree, the sub-folders will be retrieved from the server.

(cherry-pick from [PR](https://github.com/exoplatform/documents/pull/1128))
