### PR TITLE
fix: Downloading documents keeps loading when we download multiple elements from different locations - EXO-67972

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/bulkactions/ActionThread.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/bulkactions/ActionThread.java
@@ -237,9 +237,7 @@ public class ActionThread implements Runnable {
           JCRDocumentsUtil.cleanFiles(folder);
           break;
         }
-        if (StringUtils.isEmpty(parentPath)) {
-          parentPath = node.getParent().getPath();
-        }
+        parentPath = node.getParent().getPath();
         if (hasFolders) {
           JCRDocumentsUtil.createTempFilesAndFolders(node, "", "", tempFolderPath, parentPath);
         } else {


### PR DESCRIPTION
Prior to this change, downloading documents would keep loading when we attempted to download multiple elements from different locations. an 'ItemNotFoundException' being thrown because of an incorrect 'parentPath' value which was assigned a value at the start of the loop and not updated with each iteration. This change addresses this issue.