### PR TITLE
fix: No results displayed if search starts with a special character - EXO-65198 (#1112) 

### DIFF
--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnectorTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnectorTest.java
@@ -56,7 +56,7 @@ public class DocumentSearchServiceConnectorTest {
   private static final String  SEARCH_QUERY_FILE_PATH_PARAM      = "query.file.path";
 
   public static String         SEARCH_QUERY_TERM                 = "\"must\":{" + "    \"query_string\":{"
-      + "    \"fields\": [\"title\"]," + "    \"query\": \"*@term@*\"" + "  }" + "},";
+      + "    \"fields\": [\"title.raw\"]," + "    \"query\": \"@term@\"" + "  }" + "},";
 
   private static String        SEARCH_QUERY;
 
@@ -116,7 +116,7 @@ public class DocumentSearchServiceConnectorTest {
     filter.setIncludeHiddenFiles(false);
     filter.setSortField(DocumentSortField.NAME);
     filter.setAscending(true);
-    filter.setQuery("test");
+    filter.setQuery("(test OR *test*)");
     int limit = 51;
     int offset = 0;
     String path = "/Groups/spaces/test/Documents/";
@@ -192,8 +192,8 @@ public class DocumentSearchServiceConnectorTest {
     // when
     // search term contains ES reserved character
     filter.setQuery("term with reserved - character");
-    String esquipedReservedCharactersTermQuery = "*term* AND *with* AND *reserved* AND \\\\*\\\\-\\\\* AND *character*";
-    String oldSearchedTermQuery = "*test*";
+    String esquipedReservedCharactersTermQuery = "(term OR *term*) AND (*\\\\ *) AND (with OR *with*) AND (reserved OR *reserved*) AND (\\\\- OR *\\\\-*) AND (character OR *character*)";
+    String oldSearchedTermQuery = "(test OR *test*)";
     when(client.sendRequest(expectedQuery.replace(oldSearchedTermQuery, esquipedReservedCharactersTermQuery),
                             ES_INDEX)).thenReturn(searchWithReservedCharacterResult);
     result = documentSearchServiceConnector.search(userIdentity,


### PR DESCRIPTION
Prior to this change, when launching a search in the application documents with a special character at the start, the list of documents to search for is always empty. To fix this problem, ignored in the query of the elastic search the special char. After this change, documents which has the search filter values used are displayed.

(cherry picked from commit 0b648df26cbbf6871fa01974e0d7925e130118c7)