### PR TITLE
fix: No versioning when a documents is imported by a zip file - EXO-67504

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/bulkactions/ActionThread.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/bulkactions/ActionThread.java
@@ -43,6 +43,7 @@ import org.exoplatform.documents.model.ActionType;
 import org.exoplatform.documents.storage.DocumentFileStorage;
 import org.exoplatform.documents.storage.JCRDeleteFileStorage;
 import org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil;
+import org.exoplatform.services.jcr.ext.utils.VersionHistoryUtils;
 import org.exoplatform.services.jcr.util.Text;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
@@ -539,6 +540,7 @@ public class ActionThread implements Runnable {
     String mimeType = mimeTypes.getMimeType(file.getName());
     jcrContent.setProperty(JCR_MIME_TYPE, mimeType);
     folderNode.save();
+    VersionHistoryUtils.createVersion(fileNode);
   }
 }
 


### PR DESCRIPTION
Prior to this change, files imported from a zip file were not versioned.
This change creates a new version for all imported files.
(cherry picked from commit c4980f91076b8571c2db02e20fa4c9039a8d39b0)