### PR TITLE
feat: Upgrade To Tomcat 10 - Meeds-io/MIPs#76

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/controller/PublicAccessDownloadDocumentHandler.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/controller/PublicAccessDownloadDocumentHandler.java
@@ -31,9 +31,9 @@ import org.exoplatform.web.controller.QualifiedName;
 import org.json.JSONObject;
 import org.exoplatform.container.xml.InitParams;
 
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/documents-services/src/main/java/org/exoplatform/documents/filter/DocumentPreviewFilter.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/filter/DocumentPreviewFilter.java
@@ -22,11 +22,11 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.web.filter.Filter;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 
 public class DocumentPreviewFilter implements Filter {

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
@@ -26,7 +26,7 @@ import java.util.Map;
 
 import javax.annotation.security.RolesAllowed;
 import javax.jcr.AccessDeniedException;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;

--- a/documents-services/src/test/java/org/exoplatform/documents/filter/DocumentPreviewFilterTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/filter/DocumentPreviewFilterTest.java
@@ -10,11 +10,11 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
 
 import java.io.IOException;
 

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
@@ -29,7 +29,7 @@ import java.util.*;
 
 import javax.jcr.AccessDeniedException;
 import javax.jcr.RepositoryException;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 
 import org.junit.After;

--- a/documents-storage-jcr/pom.xml
+++ b/documents-storage-jcr/pom.xml
@@ -32,6 +32,11 @@
       <artifactId>jcr</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.ibm.icu</groupId>
+      <artifactId>icu4j</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.exoplatform.jcr</groupId>
         <artifactId>exo.jcr.component.core</artifactId>
     </dependency>


### PR DESCRIPTION
This change will upgrade Java Servlet API 6.0 packages to be compatible with Tomcat 10. In addition, this will add `icu4j` dependency which is packaged in ecms addon (thus, `provided` scope is used) and removed from Meeds packaging.