### PR TITLE
fix: Fix wrong count for expiration delay when choosing day option - EXO-67306

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/PublicDocumentOptionsDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/PublicDocumentOptionsDrawer.vue
@@ -402,7 +402,7 @@ export default {
       const delayDate = new Date(new Date());
       switch (this.delayType) {
       case 'day':
-        return delayDate.setDate(delayDate.getDate() + this.delayTypeTimes);
+        return delayDate.setDate(delayDate.getDate() + parseInt(this.delayTypeTimes));
       case 'week':
         return delayDate.setDate(delayDate.getDate() + this.delayTypeTimes * 7);
       case 'month':


### PR DESCRIPTION
In this commit, we improve the accuracy of date calculations by introducing `parseInt(this.delayTypeTimes)` to parse the `delayTypeTimes` variable. This improvement enables us to calculate the new expiry date correctly.