### PR TITLE
fix: Fix issue of multiple document selection deletion alert always showing 0 elements - EXO-68276

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -603,7 +603,7 @@ export default {
           this.setMultiActionLoading(false);
           this.displayMessage({
             type: 'success',
-            message: this.$t(`documents.bulk.${actionName}.doneSuccessfully`, {0: actionData.numberOfItems})
+            message: this.$t(`documents.bulk.${actionName}.doneSuccessfully`, {0: treatedItems.length})
           });
           if (actionName === 'move') {
             this.handleBulkMoveRedirect();


### PR DESCRIPTION
This commit corrects the display of the accurate count in the multiple document selection deletion alert.