### PR TITLE
fix: Fix renaming documents with accents - EXO-67736

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -784,7 +784,9 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       Node parent = node.getParent();
       String srcPath = node.getPath();
       String destPath = (parent.getPath().equals(SLASH) ? org.apache.commons.lang.StringUtils.EMPTY : parent.getPath()).concat(SLASH).concat(name);
-      node.getSession().getWorkspace().move(srcPath, destPath);
+      if (!srcPath.equals(destPath)) {
+        node.getSession().getWorkspace().move(srcPath, destPath);
+      }
       if (!node.isNodeType(NodeTypeConstants.EXO_RSS_ENABLE) && node.canAddMixin(NodeTypeConstants.EXO_RSS_ENABLE)) {
         node.addMixin(NodeTypeConstants.EXO_RSS_ENABLE);
       }


### PR DESCRIPTION
Before this change, when renaming a document by deleting the accent and making its name as the old name when it is cleaned by removing accents, an item already exists exception is thrown when trying to move srcPath to desPath since they are similar.
After this change, we will avoid to move srcPath to desPath when they are equal.