### PR TITLE
fix: after migration from 6.4 to 6.5 Personal drive has blank page - EXO-68728 

### DIFF
--- a/documents-webapp/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -9,5 +9,6 @@
   <import>war:/conf/documents/notification-configuration.xml</import>
   <import>war:/conf/documents/dynamic-container-configuration.xml</import>
   <import>war:/conf/documents/spaces-templates-configuration.xml</import>
+  <import>war:/conf/documents/portal-upgrade-configuration.xml</import>
   <import profiles="app-center">war:/conf/documents/app-center-configuration.xml</import>
 </configuration>

--- a/documents-webapp/src/main/webapp/WEB-INF/conf/documents/portal-upgrade-configuration.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/conf/documents/portal-upgrade-configuration.xml
@@ -1,0 +1,55 @@
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+  xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+    <component-plugin>
+      <name>ExoDrivesPageUpgrade</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <description>Replaces the old property value with the new property value</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>140</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>drives.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updatePageLayout">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/documents/portal</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>global</string>
+            </field>
+            <field name="pageNames">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>drives</string>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+</configuration>


### PR DESCRIPTION
Before this change, in the 6.5.0 version, the page of the drives had changes in the dynamic container names causing when migrating from 6.4 the container name changed and the portlet not integrated After this change, an upgrade plugin to upgrade the page layout so the portlet will be integrated