### PR TITLE
fix: Sorting by lates modification ko inside folders - EXO-68469

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -19,10 +19,7 @@ package org.exoplatform.documents.storage.jcr.util;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
@@ -225,20 +222,24 @@ public class JCRDocumentsUtil {
 
     fileNodes.sort((o1, o2) -> {
       if ((o1.isFolder() && o2.isFolder()) || (!o1.isFolder() && !o2.isFolder())) {
-        if(filter.getSortField().equals(DocumentSortField.MODIFIED_DATE)) {
-          if(filter.isAscending()) {
-            return (int) (o1.getModifiedDate() - o2.getModifiedDate());
-          } else {
-            return (int) (o2.getModifiedDate() - o1.getModifiedDate());
-          }
-        } else if(filter.getSortField().equals(DocumentSortField.CREATED_DATE)) {
+        if (filter.getSortField().equals(DocumentSortField.MODIFIED_DATE)) {
+          Date modifiedDateO1 = new Date(o1.getModifiedDate());
+          Date modifiedDateO2 = new Date(o2.getModifiedDate());
           if (filter.isAscending()) {
-            return (int) (o1.getCreatedDate() - o2.getCreatedDate());
+            return modifiedDateO1.compareTo(modifiedDateO2);
           } else {
-            return (int) (o2.getCreatedDate() - o1.getCreatedDate());
+            return modifiedDateO1.compareTo(modifiedDateO1);
+          }
+        } else if (filter.getSortField().equals(DocumentSortField.CREATED_DATE)) {
+          Date createdDateO1 = new Date(o1.getCreatedDate());
+          Date createdDateO2 = new Date(o2.getCreatedDate());
+          if (filter.isAscending()) {
+            return createdDateO1.compareTo(createdDateO2);
+          } else {
+            return createdDateO2.compareTo(createdDateO1);
           }
         } else {
-          if(filter.isAscending()) {
+          if (filter.isAscending()) {
             return o1.getName().compareTo(o2.getName());
           } else {
             return o2.getName().compareTo(o1.getName());

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -988,9 +988,9 @@ public class JCRDocumentFileStorageTest {
     filter.setAscending(false);
 
     fileNodes = jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 5);
-    assertEquals("Abc", fileNodes.get(2).getName());
-    assertEquals("Xyz", fileNodes.get(1).getName());
-    assertEquals("Efg.lnk", fileNodes.get(0).getName());
+    assertEquals("Efg.lnk", fileNodes.get(2).getName());
+    assertEquals("Abc", fileNodes.get(1).getName());
+    assertEquals("Xyz", fileNodes.get(0).getName());
 
     when(subItemsIterator.hasNext()).thenReturn(true, true, true, false);
     when(subItemsIterator.nextNode()).thenReturn(folderXyz, folderAbc, symlinkFolderEfg);


### PR DESCRIPTION
Before this fix, when create folder in documents app of a space & create/upload many files/folders onto it in different days/months with different users, sort these files and folders by last updated then check their sorting and click on load more button and recheck the sorting, files and folders aren't well sorted. To resolve this problem, during sorting, change the comparison between items by date. After this change, the information for sorting by last updated should be respected i.e all files/folders (new loaded and already listed files/folder) should be well sorted respecting the selected sorting order.

(cherry picked from commit 89260499e874b3da2d69b630883d1435feb4b47c)