### PR TITLE
fix: Prevent to display no content folder actions for users who don't  have permissions - EXO-68806

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsNoBodyFolder.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsNoBodyFolder.vue
@@ -16,7 +16,7 @@
         <p class="text-light-color">
           <span>{{ noContentFolderLabel }}</span>
         </p>
-        <div>
+        <div v-if="displayNoContentFolderActions">
           <span class="ps-1">{{ addFolderLabel }}</span>
           <v-icon
             size="13"
@@ -51,6 +51,7 @@ export default {
   },
   data: () => ({
     emptyDocs: '/documents-portlet/images/docs.png',
+    currentFolder: null
   }),
   computed: {
     noContentFolderLabel() {
@@ -62,6 +63,12 @@ export default {
     addDocumentLabel() {
       return this.$t && this.$t('documents.label.no-content.addDocument');
     },
+    displayNoContentFolderActions() {
+      return this.currentFolder?.accessList?.canEdit === true;
+    }
+  },
+  created() {
+    this.$root.$on('set-current-folder', (folder) => this.currentFolder = folder);
   },
   methods: {
     addFolder() {


### PR DESCRIPTION
Prior to this change , the no content folder actions was displayed for users who don't have permissions , this change is going to prevent to display no content folder actions for users who don't  have permissions 