### PR TITLE
fix: Prevent to display the add document for members if the space has a redactor - EXO-68922 

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -45,6 +45,7 @@
           @dragover="startDrag">
           <documents-no-body
             :query="query"
+            :can-add="canAdd"
             :is-mobile="isMobile" />
         </div>
         <div

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsNoBody.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/DocumentsNoBody.vue
@@ -23,7 +23,7 @@
           <p> <strong>{{ spaceDisplayName }}</strong></p>
         </div>
 
-        <a @click="openDrawer" class="text-decoration-underline">{{ $t('documents.label.addNewFile') }}</a>
+        <a v-if="canAdd" @click="openDrawer" class="text-decoration-underline">{{ $t('documents.label.addNewFile') }}</a>
       </div>
     </div>
   </div>
@@ -39,6 +39,10 @@ export default {
     query: {
       type: String,
       default: null,
+    },
+    canAdd: {
+      type: Boolean,
+      default: false,
     }
   },
   data: () => ({


### PR DESCRIPTION
Prior to this change, space members were able to create a new document from the recent view if the space had a redactor , With this change space members will no longer be able to create a new document if the space has a redactor.