### PR TITLE
fix: Change edit document redirection url from current portal name to meta portal name - EXO-69070 

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/EditMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/EditMenuAction.vue
@@ -31,7 +31,7 @@ export default {
   methods: {
     editFile() {
       if (this.fileId) {
-        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/oeditor?docId=${this.fileId}`, '_blank');
+        window.open(`${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/oeditor?docId=${this.fileId}`, '_blank');
       }
     },
   },

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -288,7 +288,7 @@ export default {
     },
     openInEditMode(file) {
       const fileId = file.sourceID? file.sourceID: file.id;
-      window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/oeditor?docId=${fileId}`, '_blank');
+      window.open(`${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/oeditor?docId=${fileId}`, '_blank');
     },
     openPreview() {
       this.loading = true;


### PR DESCRIPTION


Before this change, after opening the administration site and then accessing the document space application in new page to edit a file, we would be redirected to a wrong URL that displayed the administration page. This change is going to address the issue by modifying the edit document redirection URL from the current portal name to the meta portal name.