### PR TITLE
fix: Enable the import documents notification plugin by default after migration context - EXO-68085

### DIFF
--- a/documents-webapp/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -10,5 +10,6 @@
   <import>war:/conf/documents/dynamic-container-configuration.xml</import>
   <import>war:/conf/documents/spaces-templates-configuration.xml</import>
   <import>war:/conf/documents/portal-upgrade-configuration.xml</import>
+  <import>war:/conf/documents/notification-upgrade-plugin.xml</import>
   <import profiles="app-center">war:/conf/documents/app-center-configuration.xml</import>
 </configuration>

--- a/documents-webapp/src/main/webapp/WEB-INF/conf/documents/notification-upgrade-plugin.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/conf/documents/notification-upgrade-plugin.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+Copyright (C) 2024 eXo Platform SAS.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+               xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+    <component-plugin>
+      <name>ImportDocumentsNotificationUpgradePluginV1</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.notification.upgrade.NotificationUpgradePlugin</type>
+      <description>An upgrade plugin to set a notification plugin</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>1</value>
+        </value-param>
+        <value-param>
+          <name>notificationPluginId</name>
+          <description>Notification Plugin Id</description>
+          <value>ImportDocumentsPlugin</value>
+        </value-param>
+        <value-param>
+          <name>notificationChannelId</name>
+          <description>Notification Channel Id, applied to all when empty</description>
+          <value></value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute only once, not each version change</description>
+          <value>true</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+</configuration>


### PR DESCRIPTION
This change is going to reuse the NotificationUpgradePlugin to enable the import document notification plugin by default after the migration context.