### PR TITLE
fix: fix displaying documents in documents app out of documents page - EXO-62356

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -1495,7 +1495,7 @@ export default {
         if (!path) {
           path = window.location.pathname;
         }
-        const pathParts  = path.split( `/${eXo.env.portal.selectedNodeUri.toLowerCase()}/`);
+        const pathParts  = path.toLowerCase().includes('/drives') || path.toLowerCase().includes('/documents')? path.split( `${eXo.env.portal.selectedNodeUri.toLowerCase()}/`) : [path];
         if (pathParts.length > 1) {
           this.folderPath = pathParts[1];
           this.selectedView = 'folder';

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -1495,7 +1495,7 @@ export default {
         if (!path) {
           path = window.location.pathname;
         }
-        const pathParts  = path.split( `${eXo.env.portal.selectedNodeUri.toLowerCase()}/`);
+        const pathParts  = path.split( `/${eXo.env.portal.selectedNodeUri.toLowerCase()}/`);
         if (pathParts.length > 1) {
           this.folderPath = pathParts[1];
           this.selectedView = 'folder';

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -192,7 +192,7 @@ export default {
         this.folderPath = path;
       } else {
         path = window.location.pathname;
-        const pathParts  = path.split( `/${eXo.env.portal.selectedNodeUri.toLowerCase()}/`);
+        const pathParts  = path.toLowerCase().includes('/drives') || path.toLowerCase().includes('/documents')? path.split( `${eXo.env.portal.selectedNodeUri.toLowerCase()}/`) : [path];
         if (pathParts.length > 1) {
           this.folderPath = pathParts[1];
         } else {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -192,7 +192,7 @@ export default {
         this.folderPath = path;
       } else {
         path = window.location.pathname;
-        const pathParts  = path.split( `${eXo.env.portal.selectedNodeUri.toLowerCase()}/`);
+        const pathParts  = path.split( `/${eXo.env.portal.selectedNodeUri.toLowerCase()}/`);
         if (pathParts.length > 1) {
           this.folderPath = pathParts[1];
         } else {


### PR DESCRIPTION
Before this change, when opening a space page containing the documents app the items were not displayed since the pathname was not well split to get the right path, and an object not found was displayed
After this change, the pathname is well split and the documents are well displayed