### PR TITLE
fix: The loading color when uploading new versions to files should be the same as the primary color - EXO-67385 .

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -506,6 +506,7 @@ export default {
         this.newVersionFile = null;
         return;
       }
+      this.loading = true;
       const targetFileId = this.newVersionFile.targetFileId;
       const reader = new FileReader();
       reader.onloadstart = () => {


### PR DESCRIPTION
Before this change, when open documents application personal/space add file1 and open the option menu of the file and click on upload new version, The loading color is black. After this change, The loading color should be set as the primary color.