### PR TITLE
fix: Document search is case sensitive - EXO-68811

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
@@ -56,7 +56,7 @@ public class DocumentSearchServiceConnector {
 
   public static final String           SEARCH_QUERY_TERM            = "\"must\":{"
           + "    \"query_string\":{"
-          + "    \"fields\": [\"title.raw\"],"
+          + "    \"fields\": [\"title.whitespace\"],"
           + "    \"query\": \"@term@\""
           + "  }"
           + "},";

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnectorTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnectorTest.java
@@ -56,7 +56,7 @@ public class DocumentSearchServiceConnectorTest {
   private static final String  SEARCH_QUERY_FILE_PATH_PARAM      = "query.file.path";
 
   public static String         SEARCH_QUERY_TERM                 = "\"must\":{" + "    \"query_string\":{"
-      + "    \"fields\": [\"title.raw\"]," + "    \"query\": \"@term@\"" + "  }" + "},";
+      + "    \"fields\": [\"title.whitespace\"]," + "    \"query\": \"@term@\"" + "  }" + "},";
 
   private static String        SEARCH_QUERY;
 


### PR DESCRIPTION
Before this change, when open doc app of spacex and create docx named azErty then in search field type the title of the created doc in lower case -> azerty, the searched folder is not displayed unless the search is extended. After this change, the doc is retreived.

(cherry picked from commit 22973d67388b92218cb2b1233bcb8ab316c29dc9) (cherry picked from commit a8b4970283e35b38d3417e6f8373792d2e3d63ed)