### PR TITLE
fix: The loading color when uploading new versions to files should be the same as the primary color - EXO-67385 .

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -19,6 +19,7 @@
       <div class="mt-auto mb-auto">
         <v-progress-circular
           v-if="loading"
+          color="primary"
           indeterminate
           size="16" />
         <i


### PR DESCRIPTION
Before this change, when open documents application personal/space add file and open the option menu of the file and click on upload new version, The loading color is black. After this change, The loading color should be set as the primary color.