### PR TITLE
fix: fix save version summary if it include '*' and ':' char - EXO-66009

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -705,6 +705,7 @@ export default {
         this.$root.$emit('version-description-update-error', version);
         return;
       }
+      summary = summary.replaceAll(':', ' ').replaceAll('*', ' ');
       return this.$documentFileService.updateVersionSummary(version.originId, version.id, summary).then(version => {
         this.$root.$emit('version-description-updated', version);
         this.$root.$emit('show-alert', {type: 'success', message: this.$t('documents.summary.added.success')});


### PR DESCRIPTION
Before this change, when updating a version summary  containing "*" and ":"  exceptions were generated since these chars are not accepted in JCR version names 
After this change, the summary is cleaned up of the illegal chars, and the version summary is well-updated