### PR TITLE
fix: Top bar application - Black border when clicking on the New button - EXO-67787 .

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsAddNewFile.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsAddNewFile.vue
@@ -42,7 +42,7 @@
       <button
         v-else
         :id="isMobile ? 'addItemMenu mobile' : 'addItemMenu'"
-        class="btn btn-primary primary px-2 py-0"
+        class="btn-primary primary px-2 py-0"
         :key="postKey"
         :disabled="disableButton"
         @click="openAddItemMenu()">


### PR DESCRIPTION
Before this change, when open document app and click on New button, there is a black border on the button. After this change, no black border is displayed.