### PR TITLE
fix: White space glitches the search - EXO-69893

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
@@ -499,9 +499,6 @@ public class DocumentSearchServiceConnector {
             String inputWithAsteriskStr = ASTERISK_STR.concat(replaceSpecialCharInputValue).concat(ASTERISK_STR);
             inputSplittedValue.append(" OR ").append(inputWithAsteriskStr);
             inputSplittedValue.append(")");
-            if (term.contains(" ") && inputSplittedValue.indexOf(" AND (*\\\\ *)")==-1) {
-              inputSplittedValue.append(" AND (*\\\\ *)");
-            }
           }
         }
       return SEARCH_QUERY_TERM.replace(QUERY_TAG_TERM, inputSplittedValue.toString());

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnectorTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnectorTest.java
@@ -192,7 +192,7 @@ public class DocumentSearchServiceConnectorTest {
     // when
     // search term contains ES reserved character
     filter.setQuery("term with reserved - character");
-    String esquipedReservedCharactersTermQuery = "(term OR *term*) AND (*\\\\ *) AND (with OR *with*) AND (reserved OR *reserved*) AND (\\\\- OR *\\\\-*) AND (character OR *character*)";
+    String esquipedReservedCharactersTermQuery = "(term OR *term*) AND (with OR *with*) AND (reserved OR *reserved*) AND (\\\\- OR *\\\\-*) AND (character OR *character*)";
     String oldSearchedTermQuery = "(test OR *test*)";
     when(client.sendRequest(expectedQuery.replace(oldSearchedTermQuery, esquipedReservedCharactersTermQuery),
                             ES_INDEX)).thenReturn(searchWithReservedCharacterResult);


### PR DESCRIPTION
Prior to this fix, when searching for documents with words separated by spaces gliches the serach.
The commit updates the way the ES query is created to fix this problem