### PR TITLE
fix: Activity stream documents folder creation issue - EXO-68612

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/model/AbstractNode.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/model/AbstractNode.java
@@ -16,7 +16,9 @@
  */
 package org.exoplatform.documents.model;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
@@ -38,6 +40,8 @@ public abstract class AbstractNode {
   private String         parentFolderId;
 
   private long           creatorId;
+
+  private String         creatorUserName;
 
   private long           createdDate;
 

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/model/AbstractNodeEntity.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/model/AbstractNodeEntity.java
@@ -50,6 +50,8 @@ public class AbstractNodeEntity {
 
   private IdentityEntity                        creatorIdentity;
 
+  private String                                creatorUserName;
+
   private IdentityEntity                        modifierIdentity;
 
   private NodePermissionEntity                        acl;

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -247,6 +247,7 @@ public class EntityBuilder {
       nodeEntity.setDescription(node.getDescription());
       nodeEntity.setAcl(toNodePermissionEntity(node,identityManager, spaceService, publicDocumentAccessService));
       nodeEntity.setCreatedDate(node.getCreatedDate());
+      nodeEntity.setCreatorUserName(node.getCreatorUserName());
       nodeEntity.setModifiedDate(node.getModifiedDate());
       nodeEntity.setParentFolderId(node.getParentFolderId());
       nodeEntity.setSourceID(node.getSourceID());

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -28,9 +28,10 @@ import java.util.zip.ZipOutputStream;
 import javax.jcr.*;
 import javax.jcr.version.Version;
 
-import com.ibm.icu.text.Transliterator;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+
+import com.ibm.icu.text.Transliterator;
 
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.documents.constant.DocumentSortField;
@@ -432,6 +433,7 @@ public class JCRDocumentsUtil {
     }
     if (node.hasProperty(NodeTypeConstants.EXO_OWNER)) {
       String owner = node.getProperty(NodeTypeConstants.EXO_OWNER).getString();
+      documentNode.setCreatorUserName(owner);
       documentNode.setCreatorId(getUserIdentityId(identityManager, owner));
     }
     if (node.hasProperty(NodeTypeConstants.EXO_DATE_MODIFIED)) {

--- a/documents-webapp/src/main/webapp/vue-app/documents/extensions.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/extensions.js
@@ -116,6 +116,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   enabled: (file) => {
     return file && !file.cloudDriveFolder
                 && file.acl.canEdit
+                && file.creatorUserName!=='__system'
                 && Vue.prototype?.$supportedDocuments.filter(doc => doc.edit && doc.mimeType === file?.mimeType).length > 0;
   },
   enabledForMultiSelection: () => false,
@@ -133,7 +134,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 3,
   enabled: (file) => {
-    return file && !file.cloudDriveFolder && file.acl.canEdit;
+    return file && !file.cloudDriveFolder && file.acl.canEdit && file.creatorUserName!=='__system';
   },
   enabledForMultiSelection: () => false,
   componentOptions: {
@@ -150,7 +151,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 4,
   enabled: (file) => {
-    return file && !file.cloudDriveFolder && file.acl.canEdit;
+    return file && !file.cloudDriveFolder && file.acl.canEdit && file.creatorUserName!=='__system';
   },
   enabledForMultiSelection: () => true,
   componentOptions: {
@@ -167,7 +168,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 5,
   enabled: (file) => {
-    return file && !file.cloudDriveFolder && file.acl.canEdit;
+    return file && !file.cloudDriveFolder && file.acl.canEdit && file.creatorUserName!=='__system';
   },
   enabledForMultiSelection: () => false,
   componentOptions: {
@@ -184,7 +185,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 6,
   enabled: (file) => {
-    return file && !file.cloudDriveFolder && file.acl.canEdit && !file.sourceID;
+    return file && !file.cloudDriveFolder && file.acl.canEdit && file.creatorUserName!=='__system' && !file.sourceID;
   },
   enabledForMultiSelection: () => false,
   componentOptions: {
@@ -207,6 +208,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
     }
     return file && !file.cloudDriveFolder
                 && file.acl.canEdit
+                && file.creatorUserName!=='__system'
                 && !file.sourceID
                 && !file.path.includes('News Attachments');
   },
@@ -299,7 +301,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 10,
   enabled: (file) => {
-    return file && !file.cloudDriveFolder && file.acl.canEdit;
+    return file && !file.cloudDriveFolder && file.acl.canEdit && file.creatorUserName!=='__system';
   },
   enabledForMultiSelection: () => true,
   componentOptions: {


### PR DESCRIPTION
Before this change, "System" folder created by the attachement drawer for entities like task, activity, processes... etc. had the same permissions of other folders, so any user member of the space have the ability to rename, delete, or move this folders that can lead to loose attachements.
The proper way to fix this issue is to set the appropriate permissions to avoid this problem, but this cannot be possible with what we have as access management in the document app (we have only edit and view permissions).
Now with attachement drawer these folders are created with syestem session, in this fix, in the app documents, edit actions will be not allowed for all folders created by the system.
