### PR TITLE
fix: Display file size including version size in DocumentsSizeGadget - EXO-70223

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
@@ -313,7 +313,7 @@ public class DocumentSearchServiceConnector {
 
   private String getSizeAgg(boolean getTotalSize) {
     if (getTotalSize) {
-      return "\"aggs\": {\n" + "      \"total_size\": { \"sum\": { \"field\": \"fileSize\" } }\n" + "    },";
+      return "\"aggs\": {\n" + "      \"total_size\": { \"sum\": { \"field\": \"fileSizeWithVersions\" } }\n" + "    },";
     }
     return "";
   }


### PR DESCRIPTION
Before this modification, the document size gadget compute size without take care of file versions This change add a field in file index to store fileSizeWithVersion