### PR TITLE
feat: Open file location  - URL + breadcrumb not displaying the good content - EXO-70410

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/DocumentsHeader.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/DocumentsHeader.vue
@@ -206,15 +206,18 @@ export default {
       }
     },
     changeDocumentView(view) {
-      this.$root.$emit('document-change-view', view);
-      const viewTab = view ==='folder'? 'FOLDER' : 'RECENT';
-      document.dispatchEvent(new CustomEvent('document-change', {
-        detail: {
-          'type': 'document',
-          'spaceId': this.spaceId,
-          'name': `Switch View ${viewTab} Tab`
-        }
-      }));
+      if (this.tab!==view){
+        this.$root.$emit('document-change-view', view);
+        const viewTab = view ==='folder'? 'FOLDER' : 'RECENT';
+        document.dispatchEvent(new CustomEvent('document-change', {
+          detail: {
+            'type': 'document',
+            'spaceId': this.spaceId,
+            'name': `Switch View ${viewTab} Tab`
+          }
+        }));
+      }
+
     },
     openAdvacedDrawer(){
       if (this.isMobile){


### PR DESCRIPTION
Prior to this, in folder view, if the user clicks on the folder tab, it changes the location, This fix will avoid this by disabling the click on the tab.