### PR TITLE
fix: Open file location  - URL + breadcrumb not displaying the good content - EXO-70410

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -1015,6 +1015,9 @@ export default {
       const url = new URL(window.location.href.substring(0, realPageUrlIndex));
       const params = new URLSearchParams(document.location.search);
       params.set('view', view);
+      if (view !== 'folder'){
+        params.delete('folderId');
+      }
       params.forEach((value, key) => { url.searchParams.append(key, value); });
       window.history.replaceState('documents', 'Documents', url.toString());
       this.selectedView = view;


### PR DESCRIPTION
Prior to this, when user click on go to location for a file, then changes the view to timeline, then change to folder view again, it shows the content of the root folder but the breadcrumb is related to the file location.
This is due to that the folderid path param still in the url, this fix remove the folderId param from the url for time line view.