### PR TITLE
fix: Display file size including version size in DocumentsSizeGadget - EXO-70223

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/model/FileNode.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/model/FileNode.java
@@ -27,6 +27,7 @@ public class FileNode extends AbstractNode {
   private String linkedFileId;
 
   private long   size;
+  private long   sizeWithVersions;
 
   private long   views;
 

--- a/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
@@ -75,7 +75,26 @@ public interface DocumentFileService {
                                   int limit,
                                   long userIdentityId) throws IllegalAccessException, ObjectNotFoundException;
 
+  /**
+   * Retrieves a list of accessible files, for a selected user, by applying the
+   * designated filter. The returned results will be of type {@link FileNode}
+   * only. The ownerId of filter object will be used to select the list of
+   * accessible Nodes to retrieve switch a timeline.
 
+   * @param offset Offset of the result list
+   * @param limit Limit of the result list
+   * @param userIdentity {@link Identity} technical identifier of the user
+   *          acessing files
+   * @param ownerId {@link Identity} technical identifier of the where search files
+   * @return {@link List} of {@link FileNode}
+   * @throws IllegalAccessException when the user isn't allowed to access
+   *           documents of the designated ownerId
+   * @throws ObjectNotFoundException when ownerId doesn't exisits
+   */
+  List<AbstractNode> getBiggestDocuments(long ownerId,
+                                     Identity userIdentity,
+                                     int offset,
+                                     int limit) throws IllegalAccessException, ObjectNotFoundException;
   /**
    * Retrieves the number of existing files by group.
    *

--- a/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
@@ -50,6 +50,23 @@ public interface DocumentFileStorage {
                                   int offset,
                                   int limit) throws ObjectNotFoundException;
 
+  /**
+   * Retrieves a list of biggest accessible files, for a selected user.
+   * The returned results will be of type {@link FileNode}
+   * only. The ownerId of filter object will be used to select the list of
+   * accessible Nodes to retrieve.
+   *
+   * @param offset Offset of the result list
+   * @param limit Limit of the result list
+   * @param aclIdentity {@link Identity} of the user acessing files
+   * @param ownerId {@link Identity} of the identity in which search files
+   * @return {@link List} of {@link AbstractNode}
+   * @throws ObjectNotFoundException when parentFolderId doesn't exisits
+   */
+  List<AbstractNode> getBiggestDocuments(Long ownerId,
+                                 Identity aclIdentity,
+                                 int offset,
+                                 int limit) throws ObjectNotFoundException;
 
   long calculateFilesSize(Long ownerId, Identity aclIdentity) throws ObjectNotFoundException;
 

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import javax.annotation.security.RolesAllowed;
 import javax.jcr.AccessDeniedException;
 import jakarta.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -1071,6 +1072,44 @@ public class DocumentFileRest implements ResourceContainer {
       return Response.ok(documentFileService.addDocumentsSizeStat(ownerId, Long.parseLong(currentUserIdentity.getId()))).build();
     } catch (Exception e) {
       LOG.error("Error while calculating documents size", e);
+      return Response.serverError().entity(e.getMessage()).build();
+    }
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @RolesAllowed("users")
+  @Path("/biggest/{ownerId}")
+  @Operation(summary = "Get biggest documents", method = "GET")
+  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+      @ApiResponse(responseCode = "500", description = "Internal server error"), })
+  public Response getBiggestDocuments(@Parameter(description = "Identity technical identifier, required = true")
+                          @PathParam("ownerId")
+                          Long ownerId,
+                          @Parameter(description = "Offset of results to return") @Schema(defaultValue = "0")
+                          @QueryParam("offset")
+                          int offset,
+                          @Parameter(description = "Limit of results to return") @Schema(defaultValue = "10")
+                          @QueryParam("limit")
+                          int limit) {
+    if (ownerId == null || ownerId < 1) {
+      return Response.status(Response.Status.BAD_REQUEST).build();
+    }
+    Identity currentUserIdentity = RestUtils.getCurrentUserIdentity(identityManager);
+    try {
+      List<AbstractNode> results = documentFileService.getBiggestDocuments(ownerId, currentUserIdentity, offset,limit);
+      List<AbstractNodeEntity> documentEntities = EntityBuilder.toDocumentItemEntities(documentFileService,
+                                                                                       identityManager,
+                                                                                       spaceService,
+                                                                                       metadataService,
+                                                                                       publicDocumentAccessService,
+                                                                                       results,
+                                                                                       "creator,owner",
+                                                                                       Long.parseLong(currentUserIdentity.getId()));
+
+      return Response.ok(documentEntities).build();
+    } catch (Exception e) {
+      LOG.error("Error retrieving documents size", e);
       return Response.serverError().entity(e.getMessage()).build();
     }
   }

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/model/FileNodeEntity.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/model/FileNodeEntity.java
@@ -28,6 +28,7 @@ public class FileNodeEntity extends AbstractNodeEntity {
   private String             linkedFileId;
 
   private long               size;
+  private long               sizeWithVersions;
 
   private long               views;
 

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -154,6 +154,7 @@ public class EntityBuilder {
     fileEntity.setVersionnedFileId(file.getVersionnedFileId());
     fileEntity.setMimeType(file.getMimeType());
     fileEntity.setSize(file.getSize());
+    fileEntity.setSizeWithVersions(file.getSizeWithVersions());
     fileEntity.setViews(file.getViews());
     if (expandProperties.contains("versions")) {
       fileEntity.setVersions(toVersionEntities(documentFileService.getFileVersions(file.getId(), RestUtils.getCurrentUser())));

--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -176,6 +176,15 @@ public class DocumentFileServiceImpl implements DocumentFileService {
   }
 
   @Override
+  public List<AbstractNode> getBiggestDocuments(long ownerId, Identity userIdentity, int offset, int limit) throws
+                                                                                                     IllegalAccessException,
+                                                                                                     ObjectNotFoundException {
+
+    org.exoplatform.services.security.Identity aclIdentity = getAclUserIdentity(userIdentity.getRemoteId());
+    return documentFileStorage.getBiggestDocuments(ownerId,aclIdentity,offset,limit);
+  }
+
+  @Override
   public DocumentGroupsSize getGroupDocumentsCount(DocumentTimelineFilter filter,
                                          long userIdentityId) throws IllegalAccessException, ObjectNotFoundException {
     org.exoplatform.services.security.Identity aclIdentity = getAclUserIdentity(userIdentityId);

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -40,7 +40,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import org.apache.commons.math3.analysis.function.Abs;
 import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.comparators.NaturalComparator;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
@@ -82,7 +81,6 @@ import org.exoplatform.social.metadata.tag.model.TagName;
 import org.exoplatform.social.metadata.tag.model.TagObject;
 import org.exoplatform.upload.UploadResource;
 import org.exoplatform.upload.UploadService;
-import org.picketlink.idm.spi.cache.Search;
 
 public class JCRDocumentFileStorage implements DocumentFileStorage {
 

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
@@ -152,6 +152,9 @@ public class DocumentSearchServiceConnector {
       case "title" :
         sortField = "title.raw";
         break;
+      case "fileSizeWithVersions" :
+        sortField = "fileSizeWithVersions";
+        break;
       default:
         sortField = "_score";
     }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
@@ -313,7 +313,7 @@ public class DocumentSearchServiceConnector {
 
   private String getSizeAgg(boolean getTotalSize) {
     if (getTotalSize) {
-      return "\"aggs\": {\n" + "      \"total_size\": { \"sum\": { \"field\": \"fileSize\" } }\n" + "    },";
+      return "\"aggs\": {\n" + "      \"total_size\": { \"sum\": { \"field\": \"fileSizeWithVersions\" } }\n" + "    },";
     }
     return "";
   }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -27,6 +27,8 @@ import java.util.zip.ZipOutputStream;
 
 import javax.jcr.*;
 import javax.jcr.version.Version;
+import javax.jcr.version.VersionHistory;
+import javax.jcr.version.VersionIterator;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -82,6 +84,9 @@ public class JCRDocumentsUtil {
   public static final String                           USER_PUBLIC_ROOT_NODE           = "Public";
 
   private static final String                          SPACE_PATH_PREFIX = "/Groups/spaces/";
+
+  public static final String MIX_VERSIONABLE  = "mix:versionable";
+
 
   protected static final Map<DocumentSortField, String> SORT_FIELDS_ES_CORRESPONDING  = new EnumMap<>(DocumentSortField.class);
 
@@ -485,7 +490,36 @@ public class JCRDocumentsUtil {
     }
     if (content.hasProperty(NodeTypeConstants.JCR_DATA)) {
       fileNode.setSize(content.getProperty(NodeTypeConstants.JCR_DATA).getLength());
+      fileNode.setSizeWithVersions(computeVersionsSize(content.getParent()));
+
     }
+  }
+
+  public static long computeVersionsSize(Node node) {
+    long versionSize=0;
+    try {
+      if (node.isNodeType(MIX_VERSIONABLE)) {
+        VersionHistory versionHistory = node.getVersionHistory();
+        VersionIterator iterator = versionHistory.getAllVersions();
+        while (iterator.hasNext()) {
+          Version version = iterator.nextVersion();
+          try {
+            if (version.hasNode("jcr:frozenNode")) {
+              Node frozen = version.getNode("jcr:frozenNode");
+              if (frozen.hasNode("jcr:content")) {
+                long currentVersionSize = frozen.getNode("jcr:content").getProperty("jcr:data").getLength();
+                versionSize += currentVersionSize;
+              }
+            }
+          } catch (Exception e) {
+            LOG.error("Unable to read version {}",version.getPath(),e);
+          }
+         }
+      }
+    }catch (Exception e) {
+      versionSize=0;
+    }
+    return versionSize;
   }
 
   public static void computeDocumentAcl(Node node, AbstractNode documentNode, Identity aclIdentity, IdentityManager identityManager, SpaceService spaceService) throws RepositoryException {

--- a/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
+++ b/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
@@ -332,3 +332,6 @@ documents.label.btn.upload.zip.disabled.tooltip=Several jobs are already being p
 documents.details.view.label=View
 documents.details.views.label={0} views
 documents.details.view.location=Location
+documents.label.seeMore=See more
+documents.label.largeDocumentHeader.title=10 Biggest documents
+documents.label.largeDocumentHeader.header=Document size includes versions size

--- a/documents-webapp/src/main/resources/locale/portlet/Documents_fr.properties
+++ b/documents-webapp/src/main/resources/locale/portlet/Documents_fr.properties
@@ -329,3 +329,6 @@ documents.label.btn.upload.zip.tooltip=Import de dossiers et documents
 documents.label.btn.upload.zip.disabled.tooltip=Plusieurs imports sont d\u00E9j\u00E0 en cours par d'autres utilisateurs. Veuillez r\u00E9essayer dans quelques minutes. 
 documents.details.view.label=Vue 
 documents.details.views.label={0} vues
+documents.label.seeMore=Voir plus
+documents.label.largeDocumentHeader.title=10 Documents les plus volumineux
+documents.label.largeDocumentHeader.header=La taille indiqu\u00E9e inclue les versions des documents

--- a/documents-webapp/src/main/webapp/skin/less/global-documents.less
+++ b/documents-webapp/src/main/webapp/skin/less/global-documents.less
@@ -5,3 +5,8 @@
   &:extend(.fas);
   .fa-folder-open();
 }
+
+
+#biggestDocumentsDrawer .uploadedFileDetails .document-time {
+  display:inline;
+}

--- a/documents-webapp/src/main/webapp/vue-app/documents-size-gadget/components/DocumentSizeDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents-size-gadget/components/DocumentSizeDrawer.vue
@@ -1,0 +1,132 @@
+<template>
+  <exo-drawer
+    ref="drawer"
+    v-model="drawer"
+    right>
+    <template slot="title">
+     {{ $t('documents.label.largeDocumentHeader.title') }}
+    </template>
+    <template #content>
+      <div class="ma-5">
+        <span class="subtitle-1">
+          {{ $t('documents.label.largeDocumentHeader.header') }}
+        </span>
+      </div>
+
+      <div v-for="document in documents" :key="document" class="ml-5 d-flex">
+        <v-list-item-avatar
+          :class="smallAttachmentIcon ? 'me-0' :'me-3'"
+          class="border-radius">
+          <span class="list-complete-item">
+            <div
+              :class="smallAttachmentIcon && 'smallAttachmentIcon'"
+              class="fileType">
+              <v-icon
+                size="41"
+                :color="getIcon(document).color">
+                {{ getIcon(document).class }}
+              </v-icon>
+            </div>
+          </span>
+        </v-list-item-avatar>
+        <v-list-item-content>
+          <v-list-item-title class="uploadedFileTitle" :title="document.name">
+            {{ document.name }}
+          </v-list-item-title>
+          <v-list-item-subtitle>
+            {{ getSize(document).value }} {{ $t('document.size.label.unit.'+getSize(document).unit) }}
+          </v-list-item-subtitle>
+        </v-list-item-content>
+      </div>
+    </template>
+  </exo-drawer>
+</template>
+
+
+<script>
+export default {
+  data: () => ({
+    documents: [],
+  }),
+  created() {
+    this.$root.$on('documents-size-drawer', this.open);
+  },
+  methods: {
+    open() {
+      this.$documentSizeService.getBiggestDocuments(0,10).then(data => {
+        this.documents=data;
+        this.$refs.drawer.open();
+      });
+    },
+    close() {
+      return this.$nextTick().then(() => this.$refs.drawer.close());
+    },
+    getIcon(document) {
+      const type = document && document.mimeType || '';
+      if (type.includes('pdf')) {
+        return {
+          class: 'fas fa-file-pdf',
+          color: '#FF0000',
+        };
+      } else if (type.includes('presentation') || type.includes('powerpoint')) {
+        return {
+          class: 'fas fa-file-powerpoint',
+          color: '#CB4B32',
+        };
+      } else if (type.includes('sheet') || type.includes('excel') || type.includes('csv')) {
+        return {
+          class: 'fas fa-file-excel',
+          color: '#217345',
+        };
+      } else if (type.includes('word') || type.includes('opendocument') || type.includes('rtf')) {
+        return {
+          class: 'fas fa-file-word',
+          color: '#2A5699',
+        };
+      } else if (type.includes('plain')) {
+        return {
+          class: 'fas fa-file-alt',
+          color: '#385989',
+        };
+      } else if (type.includes('image')) {
+        return {
+          class: 'fas fa-file-image',
+          color: '#999999',
+        };
+      } else if (type.includes('video') || type.includes('octet-stream') || type.includes('ogg')) {
+        return {
+          class: 'fas fa-file-video',
+          color: '#79577A',
+        };
+      } else if (type.includes('zip') || type.includes('war') || type.includes('rar')) {
+        return {
+          class: 'fas fa-file-archive',
+          color: '#717272',
+        };
+      } else if (type.includes('illustrator') || type.includes('eps')) {
+        return {
+          class: 'fas fa-file-contract',
+          color: '#E79E24',
+        };
+      } else if (type.includes('html') || type.includes('xml') || type.includes('css')) {
+        return {
+          class: 'fas fa-file-code',
+          color: '#6cf500',
+        };
+      } else {
+        return {
+          class: 'fas fa-file',
+          color: '#476A9C',
+        };
+      }
+    },
+    getSize(document) {
+      const size = this.$documentsUtils.getSize(document.sizeWithVersions);
+      return {
+        value: size.value,
+        unit: size.unit
+      };
+    },
+  }
+};
+</script>

--- a/documents-webapp/src/main/webapp/vue-app/documents-size-gadget/components/DocumentSizeDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents-size-gadget/components/DocumentSizeDrawer.vue
@@ -1,3 +1,20 @@
+<!--
+ * Copyright (C) 2024 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+-->
 <template>
   <exo-drawer
     ref="drawer"

--- a/documents-webapp/src/main/webapp/vue-app/documents-size-gadget/components/DocumentSizeMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents-size-gadget/components/DocumentSizeMain.vue
@@ -30,6 +30,22 @@
             indeterminate />
           {{ $t('document.size.computing.progress.label') }}
         </div>
+        <v-spacer />
+        <div
+          class="flex-grow-0 flex-shrink-0 text-end">
+          <v-btn
+            @click="openDrawer"
+            :title="$t('documents.label.seeMore')"
+            target="_blank"
+            color="primary"
+            text="true"
+            small>
+            <span
+              class="text-none text-font-size">
+                {{ $t('documents.label.seeMore') }}
+            </span>
+          </v-btn>
+        </div>
       </div>
       <div v-if="initialized" class="d-flex flex-wrap">
         <v-tooltip :disabled="isMobile" top> 
@@ -75,7 +91,8 @@
           </div>
         </div>
       </div>
-    </v-main> 
+    </v-main>
+    <documents-size-drawer />
   </v-app>
 </template>
 
@@ -153,6 +170,13 @@ export default {
           }
         });
     },
+    openDrawer() {
+      window.setTimeout(() => {
+        this.$nextTick().then(() => {
+          this.$root.$emit('documents-size-drawer');
+        });
+      }, 200);
+    }
   },
 
 };

--- a/documents-webapp/src/main/webapp/vue-app/documents-size-gadget/initComponents.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents-size-gadget/initComponents.js
@@ -16,9 +16,11 @@
  *
 */
 import DocumentSizeMain from './components/DocumentSizeMain.vue';
+import DocumentSizeDrawer from './components/DocumentSizeDrawer.vue';
 
 const components = {
-  'documents-size-main': DocumentSizeMain
+  'documents-size-main': DocumentSizeMain,
+  'documents-size-drawer': DocumentSizeDrawer
 };
 
 for (const key in components) {

--- a/documents-webapp/src/main/webapp/vue-app/documents-size-gadget/js/DocumentSizeService.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents-size-gadget/js/DocumentSizeService.js
@@ -43,3 +43,18 @@ export function updateSize() {
     }
   });   
 }
+export function getBiggestDocuments(offset,limit) {
+  const ownerId = eXo.env.portal.spaceIdentityId || eXo.env.portal.userIdentityId;
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/documents/biggest/${ownerId}?offset=${offset}&limit=${limit}`, {
+    headers: {
+      'Content-Type': 'text/plain'
+    },
+    method: 'GET'
+  }).then((resp) => {
+    if (resp && resp.ok) {
+      return resp.json();
+    } else {
+      throw new Error('Server indicates an error while sending request');
+    }
+  });
+}


### PR DESCRIPTION
Before this modification, the document size gadget compute size without take care of file versions
This change add a field in file index to store fileSizeWithVersion