### PR TITLE
feat: Documents_details_US: Location - EXO-70177 (#1234)

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
@@ -283,7 +283,13 @@ export default {
       || (!this.file?.description && !this.fileInitialDescription);
     },
     fileLocation() {
-      const pathParts = this.file.path.split('/Groups/spaces/')[1].split('/');
+      let pathParts = [];
+      if (this.file.path.includes('/Groups/spaces/')){
+        pathParts = this.file.path.split('/Groups/spaces/')[1].split('/');
+      } else if (this.file.path.includes(eXo.env.portal.userName)){
+        const partToRemove = this.file.path.split(eXo.env.portal.userName)[0];
+        pathParts = this.file.path.replace(partToRemove,'').split('/');
+      }
       pathParts.shift();
       pathParts.pop();
       return pathParts.join('/');


### PR DESCRIPTION
Prior to this fix, dispalying the location on the info drawer of a document in the private drive of the user throws an error since the url was splitted according to space location, this commit fix this by considering the personal drive location when splitting the path.