### PR TITLE
fix: Export Documents : Uppercase characters are lowered - EXO-70820

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -896,7 +896,7 @@ public class JCRDocumentsUtil {
     Node jrcNode = node.getNode("jcr:content");
     InputStream inputStream = jrcNode.getProperty("jcr:data").getStream();
     String path = "";
-    String nodePath = node.getPath();
+    String nodePath = getPath(node);
     if (StringUtils.isNotEmpty(symlinkPath) || StringUtils.isNotEmpty(sourcePath)) {
       nodePath = symlinkPath + nodePath.replace(sourcePath, "");
     }
@@ -921,7 +921,7 @@ public class JCRDocumentsUtil {
       return;
     }
     if (JCRDocumentsUtil.isFolder(node)) {
-      String nodePath = node.getPath();
+      String nodePath = getPath(node);
       if (StringUtils.isNotEmpty(symlinkPath) || StringUtils.isNotEmpty(sourcePath)) {
         nodePath = symlinkPath + nodePath.replace(sourcePath, "");
       }
@@ -937,12 +937,30 @@ public class JCRDocumentsUtil {
         String sourceID = node.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString();
         Node sourceNode = JCRDocumentsUtil.getNodeByIdentifier(node.getSession(), sourceID);
         if (sourceNode != null) {
-          createTempFilesAndFolders(sourceNode, node.getPath(), sourceNode.getPath(), tempFolderPath, parentPath);
+          createTempFilesAndFolders(sourceNode, getPath(node), getPath(sourceNode), tempFolderPath, parentPath);
         }
       } else {
         createFile(node, symlinkPath, sourcePath, tempFolderPath, parentPath);
       }
     }
+  }
+
+  static String getPath(Node node) {
+    Node parent = node;
+    LinkedList<String> parents = new LinkedList<String>();
+    while (parent != null) {
+      try {
+        if (parent.hasProperty(NodeTypeConstants.EXO_TITLE)) {
+          parents.addFirst(Utils.getStringProperty(parent, NodeTypeConstants.EXO_TITLE));
+        } else {
+          parents.addFirst(parent.getName());
+        }
+        parent = parent.getParent();
+      } catch (RepositoryException e) {
+        parent = null;
+      }
+    }
+    return String.join("/", parents);
   }
 
   public static void cleanFiles(File file) {


### PR DESCRIPTION
Prior to this fix, when user tries to export files/folders, file names are in lowercase, this is due to using file path based on file names. this fix regenerate the paths using the file tiltles.