### PR TITLE
fix: Documents : file saved on root path if Document app node name isn't default - EXO-71098

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -969,6 +969,10 @@ export default {
         if (newParentPath.includes(`/spaces/${eXo.env.portal.spaceGroup}`)) {
           newParentPath = newParentPath.replace(`/spaces/${eXo.env.portal.spaceGroup}`, `/spaces/${eXo.env.portal.spaceGroup}/${eXo.env.portal.spaceName}`);
           const nodeUri = eXo.env.portal.selectedNodeUri.replace('/documents', '/Documents');
+          const appPageName = nodeUri.replace(`/${eXo.env.portal.spaceGroup}`,'');
+          if (appPageName!=='Documents'){
+            newParentPath = newParentPath.replace('Documents', appPageName);
+          }
           let pathParts = newParentPath.split(nodeUri);
           if (pathParts.length>1){
             folderPath = pathParts[1];


### PR DESCRIPTION
Prior to this, when document us is added to a space in page with name different from "Documents" and user ties to upload files under subfolders of the space, files are uploaded on the root folder
This issue is caused by wrong path computing that is based on default page name, the fix takes into account the current page name to get the correct folder path when uploading documents.