### PR TITLE
BACKPORT TASK-70643: Introduce new crowdin wf

### DIFF
--- a/.github/workflows/download-crowdin.yml
+++ b/.github/workflows/download-crowdin.yml
@@ -1,0 +1,19 @@
+name: Crowdin  download Action
+
+on:
+  schedule:
+    - cron: "20 21 * * *"
+  workflow_dispatch:
+
+jobs:
+  download-crowdin-exo:
+    name: CI Build
+    uses: exoplatform/swf-scripts/.github/workflows/download-crowdin-exoplatform.yml@master
+    with:
+      CROWDIN_MAINTENANCE_EXO_VERSION: ${{ vars.CROWDIN_MAINTENANCE_EXO_VERSION }}
+    secrets:
+      CROWDIN_GITHUB_TOKEN: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
+      CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+      CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+      SWF_GPG_PRIVATE_KEY: ${{ secrets.SWF_GPG_PRIVATE_KEY }}
+      SWF_GPG_PASSPHRASE: ${{ secrets.SWF_GPG_PASSPHRASE }}

--- a/.github/workflows/upload-crowdin-branches.yml
+++ b/.github/workflows/upload-crowdin-branches.yml
@@ -1,0 +1,14 @@
+name: Crowdin Upload branches
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - stable/*
+jobs:
+  download-crowdin-exo:
+    name: CI Build
+    uses: exoplatform/swf-scripts/.github/workflows/upload-crowdin-branches.yml@master
+    secrets:
+      CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+      CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/upload-crowdin-main.yml
+++ b/.github/workflows/upload-crowdin-main.yml
@@ -1,0 +1,14 @@
+name: Crowdin Upload main
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+jobs:
+  download-crowdin-exo:
+    name: CI Build
+    uses: exoplatform/swf-scripts/.github/workflows/upload-crowdin-main.yml@master
+    secrets:
+      CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+      CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,90 @@
+#
+# Your Crowdin credentials
+#
+"project_id_env" : "CROWDIN_PROJECT_ID"
+"api_token_env" : "CROWDIN_PERSONAL_TOKEN"
+"base_path" : "."
+"base_url" : "https://api.crowdin.com"
+
+#
+# Choose file structure in Crowdin
+# e.g. true or false
+#
+"preserve_hierarchy": true
+#
+# Files configuration
+#
+files: [
+  {
+    "source" : "/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties",
+
+    "translation" : "%original_path%/%file_name%!_%locale_with_underscore%.%file_extension%",
+    "translation_replace" : {
+      "_en!": "","ar_SA": "ar","ar_OM": "aro","az_AZ": "az","ca_ES": "ca","ceb_PH": "ceb",
+      "co_FR": "co","cs_CZ": "cs","de_DE": "de","el_GR": "el","en_US": "en","es_ES": "es_ES","eu_ES": "eu","fa_IR": "fa",
+      "fi_FI": "fi","fil_PH": "fil","fr_FR": "fr","hi_IN": "hi","hu_HU": "hu","id_ID": "id","it_IT": "it","ja_JP": "ja",
+      "kab_KAB": "kab","ko_KR": "ko","lt_LT": "lt","ms_MY": "ms","nl_NL": "nl","no_NO": "no","pcm_NG": "pcm","pl_PL": "pl",
+      "pt_BR": "pt_BR","pt_PT": "pt_PT","ro_RO": "ro","ru_RU": "ru","sk_SK": "sk","sl_SI": "sl","sq_AL": "sq",
+      "sv_SE": "sv_SE","th_TH": "th","tl_PH": "tl","tr_TR": "tr","uk_UA": "uk","ur_IN": "ur_IN","vi_VN": "vi",
+      "zh_CN": "zh_CN","zh_TW": "zh_TW",
+    },
+    "dest" : "add__ons/documents/Documents.properties",
+    "update_option" : "update_as_unapproved",
+    "escape_special_characters": 0,
+    "escape_quotes" : 0,
+  },
+  {
+    "source" : "/documents-webapp/src/main/resources/locale/portal/webui_en.properties",
+
+    "translation" : "%original_path%/%file_name%!_%locale_with_underscore%.%file_extension%",
+    "translation_replace" : {
+      "_en!": "","ar_SA": "ar","ar_OM": "aro","az_AZ": "az","ca_ES": "ca","ceb_PH": "ceb",
+      "co_FR": "co","cs_CZ": "cs","de_DE": "de","el_GR": "el","en_US": "en","es_ES": "es_ES","eu_ES": "eu","fa_IR": "fa",
+      "fi_FI": "fi","fil_PH": "fil","fr_FR": "fr","hi_IN": "hi","hu_HU": "hu","id_ID": "id","it_IT": "it","ja_JP": "ja",
+      "kab_KAB": "kab","ko_KR": "ko","lt_LT": "lt","ms_MY": "ms","nl_NL": "nl","no_NO": "no","pcm_NG": "pcm","pl_PL": "pl",
+      "pt_BR": "pt_BR","pt_PT": "pt_PT","ro_RO": "ro","ru_RU": "ru","sk_SK": "sk","sl_SI": "sl","sq_AL": "sq",
+      "sv_SE": "sv_SE","th_TH": "th","tl_PH": "tl","tr_TR": "tr","uk_UA": "uk","ur_IN": "ur_IN","vi_VN": "vi",
+      "zh_CN": "zh_CN","zh_TW": "zh_TW",
+    },
+    "dest" : "add__ons/documents/Webui.properties",
+    "update_option" : "update_as_unapproved",
+    "escape_special_characters": 0,
+    "escape_quotes" : 0,
+  },
+  {
+    "source" : "/documents-webapp/src/main/resources/locale/notification/DocumentsNotification_en.properties",
+
+    "translation" : "%original_path%/%file_name%!_%locale_with_underscore%.%file_extension%",
+    "translation_replace" : {
+      "_en!": "","ar_SA": "ar","ar_OM": "aro","az_AZ": "az","ca_ES": "ca","ceb_PH": "ceb",
+      "co_FR": "co","cs_CZ": "cs","de_DE": "de","el_GR": "el","en_US": "en","es_ES": "es_ES","eu_ES": "eu","fa_IR": "fa",
+      "fi_FI": "fi","fil_PH": "fil","fr_FR": "fr","hi_IN": "hi","hu_HU": "hu","id_ID": "id","it_IT": "it","ja_JP": "ja",
+      "kab_KAB": "kab","ko_KR": "ko","lt_LT": "lt","ms_MY": "ms","nl_NL": "nl","no_NO": "no","pcm_NG": "pcm","pl_PL": "pl",
+      "pt_BR": "pt_BR","pt_PT": "pt_PT","ro_RO": "ro","ru_RU": "ru","sk_SK": "sk","sl_SI": "sl","sq_AL": "sq",
+      "sv_SE": "sv_SE","th_TH": "th","tl_PH": "tl","tr_TR": "tr","uk_UA": "uk","ur_IN": "ur_IN","vi_VN": "vi",
+      "zh_CN": "zh_CN","zh_TW": "zh_TW",
+    },
+    "dest" : "add__ons/documents/DocumentsNotification.properties",
+    "update_option" : "update_as_unapproved",
+    "escape_special_characters": 0,
+    "escape_quotes" : 0,
+  },
+  {
+    "source" : "/documents-webapp/src/main/resources/locale/portlet/Analytics_en.properties",
+
+    "translation" : "%original_path%/%file_name%!_%locale_with_underscore%.%file_extension%",
+    "translation_replace" : {
+      "_en!": "","ar_SA": "ar","ar_OM": "aro","az_AZ": "az","ca_ES": "ca","ceb_PH": "ceb",
+      "co_FR": "co","cs_CZ": "cs","de_DE": "de","el_GR": "el","en_US": "en","es_ES": "es_ES","eu_ES": "eu","fa_IR": "fa",
+      "fi_FI": "fi","fil_PH": "fil","fr_FR": "fr","hi_IN": "hi","hu_HU": "hu","id_ID": "id","it_IT": "it","ja_JP": "ja",
+      "kab_KAB": "kab","ko_KR": "ko","lt_LT": "lt","ms_MY": "ms","nl_NL": "nl","no_NO": "no","pcm_NG": "pcm","pl_PL": "pl",
+      "pt_BR": "pt_BR","pt_PT": "pt_PT","ro_RO": "ro","ru_RU": "ru","sk_SK": "sk","sl_SI": "sl","sq_AL": "sq",
+      "sv_SE": "sv_SE","th_TH": "th","tl_PH": "tl","tr_TR": "tr","uk_UA": "uk","ur_IN": "ur_IN","vi_VN": "vi",
+      "zh_CN": "zh_CN","zh_TW": "zh_TW",
+    },
+    "dest" : "add__ons/documents/Analytics.properties",
+    "update_option" : "update_as_unapproved",
+    "escape_special_characters": 0,
+    "escape_quotes" : 0,
+  },
+]


### PR DESCRIPTION
Before this PR, the crowdin sync wf was based on a maven plugin using crowdin V1 API. This APIs are no longer used. The proposed PR introduce a github actions using V2 API for the crowdin sync WF. The project https://crowdin.com/project/exo-platform still used within this configuration