### PR TITLE
fix: Favorite's Documents filter issue - EXO-70647

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/DocumentsHeader.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/DocumentsHeader.vue
@@ -14,7 +14,7 @@
 
         :right-select-box="{
           hide: isMobile,
-          selected:'all', 
+          selected: primaryFilter,
           items: [{
             value: 'all',
             text: $t('documents.filter.all'),


### PR DESCRIPTION
Before this change, when access to document application where there are some favorite documents and select the option Favorite of the filter to select favorite documents only, The filter remains stuck on All while the result displays the favorite documents. After this change, the option of the filter persists directly when choosing.

(cherry picked from commit 6e43515de33169e6cbdcb5b0304557875430d84f)