### PR TITLE
fix: Documents : upload/create documents after the use of go to location action saves the item in the root folder - EXO-71438

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -1458,7 +1458,9 @@ export default {
           title: eXo.env.portal.spaceDisplayName,
         };
         const pathparts = window.location.pathname.toLowerCase().split(`${eXo.env.portal.selectedNodeUri.toLowerCase()}/`);
-        if (pathparts.length > 1) {
+        const currentUrlSearchParams = window.location.search;
+        const queryParams = new URLSearchParams(currentUrlSearchParams);
+        if (pathparts.length > 1 || queryParams.has('folderId')) {
           attachmentAppConfiguration.defaultFolder = this.extractDefaultFolder();
         }
       } else {


### PR DESCRIPTION
Prior to this change when user use go to location from the timeline view, and upload a document, it's uploaded on the root folder of a space. This is due to that the go to location feature use the folderId in the URL, so the new location is not correct in the uplaod drawer.