### PR TITLE
fix: Documents : [BUG]Space home application : Documents vue change isn't working - EXO-71534 (#1258)

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -321,7 +321,7 @@ export default {
       this.refreshFiles();
     });
     this.$root.$on('open-folder-by-id', (folderId) => {
-      const realPageUrlIndex = window.location.href.toLowerCase().indexOf(eXo.env.portal.selectedNodeUri.toLowerCase()) + eXo.env.portal.selectedNodeUri.length;
+      const realPageUrlIndex = window.location.href.toLowerCase().indexOf(location.pathname.toLowerCase()) + location.pathname.length;
       const url = new URL(window.location.href.substring(0, realPageUrlIndex));
       const params = new URLSearchParams(document.location.search);
       params.set('folderId', folderId);
@@ -1015,7 +1015,7 @@ export default {
       this.selectedDocuments = [];
     },
     changeView(view) {
-      const realPageUrlIndex = window.location.href.toLowerCase().indexOf(eXo.env.portal.selectedNodeUri.toLowerCase()) + eXo.env.portal.selectedNodeUri.length;
+      const realPageUrlIndex = window.location.href.toLowerCase().indexOf(location.pathname.toLowerCase()) + location.pathname.length;
       const url = new URL(window.location.href.substring(0, realPageUrlIndex));
       const params = new URLSearchParams(document.location.search);
       params.set('view', view);


### PR DESCRIPTION
Prior to this change, when space navigation is changed to set documents page as home node, the change view botton stop woeking, this due to that the url changed and don't contain the document page name. the fix change the way the url is generated to take into account this case