### PR TITLE
fix: Documents : [bug][document]sort of documents not ok before clicking on show more - EXO-71738 (#1265)

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -246,9 +246,9 @@ public class JCRDocumentsUtil {
           }
         } else {
           if (filter.isAscending()) {
-            return o1.getName().compareTo(o2.getName());
+            return o1.getName().toLowerCase().compareTo(o2.getName().toLowerCase());
           } else {
-            return o2.getName().compareTo(o1.getName());
+            return o2.getName().toLowerCase().compareTo(o1.getName().toLowerCase());
           }
         }
       } else if (o1.isFolder()) {


### PR DESCRIPTION
Prior to this, Documents in the folder view was not well sorted, since the sort was case sensitive (Documents starting with uppercase were always sorted first), the fix sort all documents in lowercase to be sure to have a good sort.