### PR TITLE
fix: App center : Document app preferences never saved after server restart - EXO-72235

### DIFF
--- a/documents-webapp/src/main/webapp/WEB-INF/conf/documents/app-center-configuration.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/conf/documents/app-center-configuration.xml
@@ -32,7 +32,7 @@
         </value-param>
         <value-param>
           <name>override</name>
-          <value>${exo.app-center.drives.override:true}</value>
+          <value>${exo.app-center.drives.override:false}</value>
         </value-param>
         <value-param>
           <name>override-mode</name>


### PR DESCRIPTION
Prior to this fix, any change on the app center document app was lost after server restart, This is due to that the override parameter of the app configuration is set to true by default. This fix set the param to false so the app preferences will not be reset very restart.