### PR TITLE
fix: [BUG] - Document - Wrong creator on file and folder symlink when designate as collaborator - EXO-72919

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
@@ -229,9 +229,10 @@ public interface DocumentFileService {
    *
    * @param documentId document id
    * @param destId target user or space identity id
+   * @param authenticatedUserId current user Identity id
    * @throws IllegalAccessException
    */
-  void shareDocument(String documentId, long destId, boolean broadcast) throws IllegalAccessException;
+  void shareDocument(String documentId, long destId, long authenticatedUserId, boolean broadcast) throws IllegalAccessException;
 
   void notifyMember(String documentId, long destId) throws IllegalAccessException;
 

--- a/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
@@ -189,9 +189,10 @@ public interface DocumentFileStorage {
    *
    * @param documentId document id
    * @param destId target user or space identity id
+   * @param aclIdentity current user Identity
    * @throws IllegalAccessException
    */
-  void shareDocument(String documentId, long destId, boolean broadcast) throws IllegalAccessException;
+  void shareDocument(String documentId, long destId, Identity aclIdentity, boolean broadcast) throws IllegalAccessException;
 
   void unShareDocument(String documentId, long destId) throws RepositoryException;
 

--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -27,10 +27,6 @@ import javax.jcr.RepositoryException;
 
 import org.apache.commons.lang3.StringUtils;
 
-import io.meeds.analytics.api.service.AnalyticsService;
-import io.meeds.analytics.model.StatisticData;
-import io.meeds.analytics.model.filter.AnalyticsFilter;
-import io.meeds.analytics.utils.AnalyticsUtils;
 import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.commons.api.settings.SettingValue;
@@ -51,6 +47,11 @@ import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
+
+import io.meeds.analytics.api.service.AnalyticsService;
+import io.meeds.analytics.model.StatisticData;
+import io.meeds.analytics.model.filter.AnalyticsFilter;
+import io.meeds.analytics.utils.AnalyticsUtils;
 
 public class DocumentFileServiceImpl implements DocumentFileService {
 
@@ -318,7 +319,7 @@ public class DocumentFileServiceImpl implements DocumentFileService {
     nodePermissionEntity.getToShare().keySet().forEach(destId-> {
       try {
         boolean notifyMember = nodePermissionEntity.getToNotify() != null && nodePermissionEntity.getToNotify().containsKey(destId);
-        shareDocument(documentId, destId, notifyMember);
+        shareDocument(documentId, destId, authenticatedUserId, notifyMember);
       } catch (IllegalAccessException e) {
         throw new IllegalStateException("Error updating sharing of document'" + documentId + " to identity " + destId, e);
       }
@@ -335,8 +336,8 @@ public class DocumentFileServiceImpl implements DocumentFileService {
   }
 
   @Override
-  public void shareDocument(String documentId, long destId, boolean notifyMember) throws IllegalAccessException {
-    documentFileStorage.shareDocument(documentId, destId, notifyMember );
+  public void shareDocument(String documentId, long destId, long authenticatedUserId, boolean notifyMember) throws IllegalAccessException {
+    documentFileStorage.shareDocument(documentId, destId, getAclUserIdentity(authenticatedUserId), notifyMember );
   }
 
   @Override

--- a/documents-services/src/test/java/org/exoplatform/documents/service/DocumentFileServiceTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/service/DocumentFileServiceTest.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.meeds.analytics.api.service.AnalyticsService;
 import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.documents.constant.FileListingType;
@@ -56,6 +55,8 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.core.storage.api.ActivityStorage;
 import org.exoplatform.social.core.storage.cache.CachedActivityStorage;
+
+import io.meeds.analytics.api.service.AnalyticsService;
 
 public class DocumentFileServiceTest {
 
@@ -447,14 +448,14 @@ public class DocumentFileServiceTest {
     when(identityManager.getIdentity("1")).thenReturn(socialIdentity);
     documentFileService.updatePermissions("123", nodePermission, 1L);
     verify(documentFileStorage, times(1)).updatePermissions("123", nodePermission, identity);
-    verify(documentFileStorage, times(1)).shareDocument("123", 1L, false);
+    verify(documentFileStorage, times(1)).shareDocument("123", 1L,identity, false);
     //
     Map<Long, String> toNotify = new HashMap<>();
     toNotify.put(1L, "read");
     nodePermission.setToNotify(toNotify);
     documentFileService.updatePermissions("123", nodePermission, 1L);
     verify(documentFileStorage, atLeast(1)).updatePermissions("123", nodePermission, identity);
-    verify(documentFileStorage, atLeast(1)).shareDocument("123", 1L, true);
+    verify(documentFileStorage, atLeast(1)).shareDocument("123", 1L,identity, true);
 
   }
 

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -140,6 +140,7 @@ public class JCRDocumentFileStorageTest {
   public void shareDocument() throws Exception {
     Session systemSession = mock(Session.class);
     Identity identity = mock(Identity.class);
+    org.exoplatform.services.security.Identity aclIdentity = mock(org.exoplatform.services.security.Identity.class);
     Node rootNode = mock(Node.class);
     Node sharedNode = mock(Node.class);
     Node currentNode = Mockito.mock(ExtendedNode.class);
@@ -181,7 +182,7 @@ public class JCRDocumentFileStorageTest {
     AccessControlList acl1 = new AccessControlList("username", Arrays.asList(accessControlEntry));
     when(((ExtendedNode) currentNode).getACL()).thenReturn(acl1);
     when(linkNode.canAddMixin(NodeTypeConstants.EXO_PRIVILEGEABLE)).thenReturn(true);
-    jcrDocumentFileStorage.shareDocument("1", 1L, false);
+    jcrDocumentFileStorage.shareDocument("1", 1L,aclIdentity, false);
 
     UTILS.verify(() -> times(1));
     Utils.broadcast(listenerService, "share_document_event", identity, linkNode);
@@ -194,14 +195,14 @@ public class JCRDocumentFileStorageTest {
     AccessControlEntry accessControlEntry1 = new AccessControlEntry("username", "edit");
     AccessControlList acl = new AccessControlList("username", Arrays.asList(accessControlEntry1));
     when(((ExtendedNode) currentNode).getACL()).thenReturn(acl);
-    jcrDocumentFileStorage.shareDocument("1", 1L, false);
+    jcrDocumentFileStorage.shareDocument("1", 1L,aclIdentity, false);
 
     //assert that the linkNode set edit permission
     verify(linkNode).setPermissions(argThat((Map<String, String[]> map) -> map.containsKey("username") && Arrays.equals(map.get("username"),new String[]{"edit"})));
 
     // case of space member
     boolean notifyMember = true ;
-    jcrDocumentFileStorage.shareDocument("1", 1L, notifyMember);
+    jcrDocumentFileStorage.shareDocument("1", 1L,aclIdentity, notifyMember);
     //assert that the event broadcast with the target node as parameter
     UTILS.verify(() -> Utils.broadcast(listenerService, "share_document_event", identity, currentNode) ,atLeast(1));
 
@@ -211,14 +212,14 @@ public class JCRDocumentFileStorageTest {
     when(sharedNode.getNode(currentNode.getName())).thenReturn(linkNode);
     when(linkNode.getACL()).thenReturn(acl);
     // no member
-    jcrDocumentFileStorage.shareDocument("1", 1L, false);
+    jcrDocumentFileStorage.shareDocument("1", 1L,aclIdentity, false);
 
     // Assert that the shared document event was not broadcast
     UTILS.verify(() -> Utils.broadcast(listenerService, "share_document_event", identity, linkNode), atLeast(0));
     verify(sessionProvider, atLeast(1)).close();
 
     // space member
-    jcrDocumentFileStorage.shareDocument("1", 1L, notifyMember);
+    jcrDocumentFileStorage.shareDocument("1", 1L,aclIdentity, notifyMember);
     // Assert that the shared document event was not broadcast for member
     UTILS.verify(() -> Utils.broadcast(listenerService, "share_document_event", identity, currentNode), atLeast(0));
     verify(sessionProvider, atLeast(1)).close();

--- a/documents-webapp/src/main/webapp/vue-app/documents/extensions.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/extensions.js
@@ -151,7 +151,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   enabled: (file) => {
     return file && !file.cloudDriveFolder
                 && file.acl.canEdit
-                && file.creatorUserName!=='__system'
+                && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system')
                 && Vue.prototype?.$supportedDocuments.filter(doc => doc.edit && doc.mimeType === file?.mimeType).length > 0;
   },
   enabledForMultiSelection: () => false,
@@ -169,7 +169,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 5,
   enabled: (file) => {
-    return file && !file.cloudDriveFolder && file.acl.canEdit && file.creatorUserName!=='__system';
+    return file && !file.cloudDriveFolder && file.acl.canEdit && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system');
   },
   enabledForMultiSelection: () => false,
   componentOptions: {
@@ -186,7 +186,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 6,
   enabled: (file) => {
-    return file && !file.cloudDriveFolder && file.acl.canEdit && file.creatorUserName!=='__system';
+    return file && !file.cloudDriveFolder && file.acl.canEdit && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system');
   },
   enabledForMultiSelection: () => true,
   componentOptions: {
@@ -203,7 +203,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 7,
   enabled: (file) => {
-    return file && !file.cloudDriveFolder && file.acl.canEdit && file.creatorUserName!=='__system';
+    return file && !file.cloudDriveFolder && file.acl.canEdit && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system');
   },
   enabledForMultiSelection: () => false,
   componentOptions: {
@@ -220,7 +220,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 8,
   enabled: (file) => {
-    return file && !file.cloudDriveFolder && file.acl.canEdit && file.creatorUserName!=='__system' && !file.sourceID;
+    return file && !file.cloudDriveFolder && file.acl.canEdit && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system') && !file.sourceID;
   },
   enabledForMultiSelection: () => false,
   componentOptions: {
@@ -243,7 +243,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
     }
     return file && !file.cloudDriveFolder
                 && file.acl.canEdit
-                && file.creatorUserName!=='__system'
+                && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system')
                 && !file.sourceID
                 && !file.path.includes('News Attachments');
   },
@@ -336,7 +336,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 15,
   enabled: (file) => {
-    return file && !file.cloudDriveFolder && file.acl.canEdit && file.creatorUserName!=='__system';
+    return file && !file.cloudDriveFolder && file.acl.canEdit && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system');
   },
   enabledForMultiSelection: () => true,
   componentOptions: {


### PR DESCRIPTION
Prior to this change,  when a space or a user is designed as a collaborator, this symlink is created by system session, so no way to any user to edit the shared content, this fix change the creator to be the user updating the permissions for spaces and let the current user edit the content if it's in the user drive app.