### PR TITLE
fix: [BUG] - Document - Wrong creator on file and folder symlink when designate as collaborator - EXO-72919

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1325,10 +1325,9 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       }
       if(!rootNode.hasNode(SHARED_FOLDER_NAME)){
         shared = rootNode.addNode(SHARED_FOLDER_NAME);
-
+        rootNode.save();
       }else{
         shared = rootNode.getNode(SHARED_FOLDER_NAME);
-        session.save();
       }
       if(destIdentity.isSpace()){
         sessionProvider = getUserSessionProvider(repositoryService, aclIdentity);


### PR DESCRIPTION
Prior to this change, when a space or a user is designed as a collaborator, this symlink is created by system session, so no way to any user to edit the shared content, this fix change the creator to be the user updating the permissions for spaces and let the current user edit the content if it's in the user drive app.