### PR TITLE
fix: [BUG] Delete document: file reappear again - EXO-72918

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -1037,7 +1037,13 @@ export default {
       this.$root.$emit('set-documents-search', { 'extended': this.extendedSearch, 'query': this.query});
       this.$root.$emit('set-documents-filter', 'All');
       this.checkDefaultViewOptions();
-      this.refreshFiles({'primaryFilter': this.primaryFilter})
+      const options = {'primaryFilter': this.primaryFilter};
+      const deletedDocument = localStorage.getItem('deletedDocument');
+      if (deletedDocument != null) {
+        options.deleted=true;
+        options.documentId=deletedDocument;
+      }
+      this.refreshFiles(options)
         .finally(() => {
           if (this.selectedView === 'folder') {
             this.$nextTick().then(() => this.$root.$emit('update-breadcrumb'));


### PR DESCRIPTION
Prior to this, when the user clicks on delete documents, the document disappears from the current view, but if the user immediately changes the view the deleted document reappears. This fix checks if a document is being deleted and removes it from the list of documents when changing the view. 