### PR TITLE
fix: Details drawer of documents memorize description - EXO-72820

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
@@ -317,6 +317,11 @@ export default {
       return url.toString();
     },
   },
+  watch: {
+    showDescription() {
+      this.$refs.activityShareMessage.initCKEditorData(this.file.description);
+    }
+  },
   created() {
     this.$root.$on('open-info-drawer', this.open);
     this.$root.$on('close-info-drawer', this.close);
@@ -358,6 +363,7 @@ export default {
           this.showNoDescription = !this.file.description;
           this.displayEditor=false;
           this.fileInitialDescription = this.file.description;
+          this.$refs.activityShareMessage.initCKEditorData(this.file.description);
         }).catch(() => {
           this.$root.$emit('show-alert', {
             type: 'error',
@@ -376,6 +382,7 @@ export default {
       this.fileInitialDescription = this.file.description;      
       this.$nextTick(()=>{
         this.$refs.documentInfoDrawer.open();
+        this.$refs.activityShareMessage.initCKEditorData(this.file.description);
       });
     },
     openEditor(){
@@ -384,6 +391,9 @@ export default {
       this.showDescription = false;
       this.displayEditor=true;
       this.originDescription = this.file.description;
+      if (!this.originDescription.length) {
+        this.$refs.activityShareMessage.initCKEditorData('');
+      }
     },
     close() {
       this.file.description = this.fileInitialDescription;


### PR DESCRIPTION
Before this change, when open doc app of space then open details drawer of file1 and add a description then open details drawer of file2 which have no description and click on (add a description) link, the ckeditor is opened and it contains the previously added description (even after hard reload) and is file2 already has a description, there is no need to click on (add a description) link, since the previously added description is displayed instead. After this change, the description is not memorized.

(cherry picked from commit 1e3ea7fb7ec9de038f86221f9f12812a16baf6d5)