### PR TITLE
fix: [BUG] - Document - Restriction for system folder - EXO-73202

### DIFF
--- a/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
+++ b/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
@@ -93,6 +93,7 @@ documents.drawer.tree=Folder tree
 documents.label.extension.visibility=Access
 documents.label.visibility.specific.collaborator=Only hosts and designated collaborators can  view and edit
 documents.label.visibility.all=All space member can edit
+documents.label.visibility.system=System folder edition is locked
 documents.label.visibility.specific.manger=Only hosts and redactors can edit
 documents.label.visibility=Manage access
 documents.label.visibilityTitle=Manage access to: {0}

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
@@ -44,6 +44,12 @@ export default {
   }),
   computed: {
     icon() {
+      if (this.file.folder && this.file.creatorUserName === '__system'){
+        return {
+          icon: 'fas fa-lock',
+          title: this.$t('documents.label.visibility.system'),
+        };
+      }
       if (this.file.folder && this.file.id < 0) {
         return {
           icon: 'fas fa-layer-group',
@@ -116,11 +122,11 @@ export default {
     },
     btnClass(){
       return this.isMobile && 'ms-2' || 'me-4' ;
-    },
+    }
   },
   methods: {
     changeVisibility() {
-      if (!this.file.acl.canEdit || this.$shareDocumentSuspended) {
+      if (!this.file.acl.canEdit || this.$shareDocumentSuspended || (this.file.folder && this.file.creatorUserName === '__system')) {
         return;
       }
       this.$root.$emit('open-visibility-drawer', this.file);


### PR DESCRIPTION
Prior to this fix, On a space, when the System creates a folder the modification permissions are restricted but the access icon still shows "All space members can edit and view": The information is contradictory.
This commit changes the visibility icon to a "Lock" and disables the visibility drawer for system folders.