### PR TITLE
fix: [BUG] - Import zip with accents ko - EXO-70136

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/bulkactions/ActionThread.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/bulkactions/ActionThread.java
@@ -333,6 +333,7 @@ public class ActionThread implements Runnable {
       startTime = System.currentTimeMillis();
       actionData.setStatus(ActionStatus.UNZIPPING.name());
       brodcastEvent();
+      zip.setCharset(StandardCharsets.UTF_8);
       zip.extractAll(actionData.getTempFolderPath());
       List<String> files = new ArrayList<>();
       listFiles(new File(actionData.getTempFolderPath()), files);


### PR DESCRIPTION
Prior to this fix, zip files with non-standard charsets and accented names could not be imported properly in some cases.

This commit set the charset of the imported zip to utf-8 before creating the files in eXo.