### PR TITLE
fix: [BUG] - Document - Remove access restriction for file and folder system for Personal Documents - EXO-73213 (#1297)

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -331,10 +331,10 @@ public class EntityBuilder {
         continue;
       }
       if(identity != null && permissionEntry.getIdentity().getId().equals(identity.getId())){
-        if (permissionEntry.getPermission().equals("read") && permissionEntry.getRole().equals(PermissionRole.ALL.name())){
+        if (permissionEntry.getPermission().equals("read") && permissionEntry.getRole().equals(PermissionRole.ALL.name()) && identity.isSpace()) {
           allCanRead = true;
         }
-        if (permissionEntry.getRole().equals(PermissionRole.ALL.name()) && isEditPermission(permissionEntry.getPermission())){
+        if (permissionEntry.getRole().equals(PermissionRole.ALL.name()) && isEditPermission(permissionEntry.getPermission()) && identity.isSpace()) {
           allCanEdit = true;
         }
       } else {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
@@ -44,7 +44,7 @@ export default {
   }),
   computed: {
     icon() {
-      if (this.file.folder && this.file.creatorUserName === '__system'){
+      if (this.file.folder && this.file.creatorUserName === '__system' && eXo.env.portal.spaceIdentityId){
         return {
           icon: 'fas fa-lock',
           title: this.$t('documents.label.visibility.system'),
@@ -126,7 +126,7 @@ export default {
   },
   methods: {
     changeVisibility() {
-      if (!this.file.acl.canEdit || this.$shareDocumentSuspended || (this.file.folder && this.file.creatorUserName === '__system')) {
+      if (!this.file.acl.canEdit || this.$shareDocumentSuspended || (this.file.folder && this.file.creatorUserName === '__system' &&  eXo.env.portal.spaceIdentityId)) {
         return;
       }
       this.$root.$emit('open-visibility-drawer', this.file);


### PR DESCRIPTION
Prior to this fix, In personnal drive, system folders access management cannot be done since the drawer cannot be opened, and when it's opened the access option is empty

This commit fix the visibility choice value for system folders in personal drive, and allow the user to open the access management drawer.