### PR TITLE
fix: display of user popover in doc app - EXO-74875

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
@@ -102,7 +102,7 @@
                 {{ $t('documents.drawer.details.by') }}
                 <exo-user-avatar
                   v-if="identityModifier && !isCurrentUserModifier"
-                  :identity="identityModifier"
+                  :profile-id="identityModifier"
                   avatar-class="me-2"
                   size="42"
                   fullname
@@ -134,7 +134,7 @@
 
                 <exo-user-avatar
                   v-if="identityCreated && !isCurrentUserCreator"
-                  :identity="identityCreated"
+                  :profile-id="identityCreated"
                   avatar-class="me-2"
                   size="42"
                   fullname
@@ -288,10 +288,10 @@ export default {
       return this.currentUser === this.file?.creatorIdentity?.remoteId;
     },
     identityModifier(){
-      return this.file?.modifierIdentity;
+      return this.file?.modifierIdentity?.remoteId;
     },
     identityCreated(){
-      return this.file?.creatorIdentity;
+      return this.file?.creatorIdentity?.remoteId;
     },
     disableButton() {
       return this.file?.description && this.file?.description.replace( /(<([^>]+)>)/ig, '').length>1300


### PR DESCRIPTION
Before this change, when Access to Document application then click on Show details button of file1 created by user1 and hover on user1 who created/modified the document, user popover appears empty and when clicking on it (or on the user name), it doesn 't redirect to the user's profile.To resolve this problem, in card-carousel replace identity with the profile-id as props and pass as value the id of the profile displayed.After this change, user popover is appear as in AS and redirect to the user's profile.

(cherry picked from commit 3fa41860313750b5cd125422c1c8d34e202a3d37)