### PR TITLE
fix: Allow Admin s to delete System created files - EXO-75232

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsVisibilityCell.vue
@@ -44,6 +44,12 @@ export default {
   }),
   computed: {
     icon() {
+      if (this.file.folder && this.file.creatorUserName === '__system' && eXo.env.portal.spaceIdentityId && !eXo.env.portal.isAdministrator){
+        return {
+          icon: 'fas fa-lock',
+          title: this.$t('documents.label.visibility.system'),
+        };
+      }
       if (this.file.folder && this.file.id < 0) {
         return {
           icon: 'fas fa-layer-group',
@@ -120,7 +126,7 @@ export default {
   },
   methods: {
     changeVisibility() {
-      if (!this.file.acl.canEdit || this.$shareDocumentSuspended) {
+      if (!this.file.acl.canEdit || this.$shareDocumentSuspended || (this.file.folder && this.file.creatorUserName === '__system' &&  eXo.env.portal.spaceIdentityId &&  !eXo.env.portal.isAdministrator)) {
         return;
       }
       this.$root.$emit('open-visibility-drawer', this.file);

--- a/documents-webapp/src/main/webapp/vue-app/documents/extensions.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/extensions.js
@@ -153,7 +153,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   enabled: (file) => {
     return file && !file.cloudDriveFolder
                 && file.acl.canEdit
-                && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system')
+                && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system' || eXo.env.portal.isAdministrator)
                 && Vue.prototype?.$supportedDocuments.filter(doc => doc.edit && doc.mimeType === file?.mimeType).length > 0;
   },
   enabledForMultiSelection: () => false,
@@ -171,7 +171,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 5,
   enabled: (file) => {
-    return file && !file.cloudDriveFolder && file.acl.canEdit && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system');
+    return file && !file.cloudDriveFolder && file.acl.canEdit && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system' || eXo.env.portal.isAdministrator);
   },
   enabledForMultiSelection: () => false,
   componentOptions: {
@@ -188,7 +188,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 6,
   enabled: (file) => {
-    return file && !file.cloudDriveFolder && file.acl.canEdit && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system');
+    return file && !file.cloudDriveFolder && file.acl.canEdit && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system' || eXo.env.portal.isAdministrator);
   },
   enabledForMultiSelection: () => true,
   componentOptions: {
@@ -205,7 +205,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 7,
   enabled: (file) => {
-    return file && !file.cloudDriveFolder && file.acl.canEdit && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system');
+    return file && !file.cloudDriveFolder && file.acl.canEdit && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system' || eXo.env.portal.isAdministrator);
   },
   enabledForMultiSelection: () => false,
   componentOptions: {
@@ -222,7 +222,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 8,
   enabled: (file) => {
-    return file && !file.cloudDriveFolder && file.acl.canEdit && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system') && !file.sourceID;
+    return file && !file.cloudDriveFolder && file.acl.canEdit && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system' || eXo.env.portal.isAdministrator) && !file.sourceID;
   },
   enabledForMultiSelection: () => false,
   componentOptions: {
@@ -245,7 +245,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
     }
     return file && !file.cloudDriveFolder
                 && file.acl.canEdit
-                && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system')
+                && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system' || eXo.env.portal.isAdministrator)
                 && !file.sourceID
                 && !file.path.includes('News Attachments');
   },
@@ -338,7 +338,7 @@ extensionRegistry.registerExtension('DocumentMenu', 'menuActionMenu', {
   width: '190px',
   rank: 15,
   enabled: (file) => {
-    return file && !file.cloudDriveFolder && file.acl.canEdit && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system');
+    return file && !file.cloudDriveFolder && file.acl.canEdit && (eXo.env.portal.spaceIdentityId === '' || file.creatorUserName!=='__system' || eXo.env.portal.isAdministrator);
   },
   enabledForMultiSelection: () => true,
   componentOptions: {


### PR DESCRIPTION
Prior to this fix, System folders that was created by System session cannot be dited or deleted by any user using the Documents app

This commit allow the platform administrators to have the edit, delete and move actions.

(cherry picked from commit 5f5fcfa4a14e9f6cc1d69cc3faf3eedf912c027b)