### PR TITLE
fix: file moved to root folder by drag & drop using breadcrumb - EXO-73723

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -126,7 +126,8 @@ export default {
   },
   methods: {
     handleMoveDroppedOnBreadcrumb(event) {
-      event.detail.currentOpenedFolder =  this.documentsBreadcrumbToDisplay[0];
+      const indexLastItem = this.documentsBreadcrumbToDisplay.length - 1 > 0 ? this.documentsBreadcrumbToDisplay.length - 1 : 0;
+      event.detail.currentOpenedFolder =  this.documentsBreadcrumbToDisplay[indexLastItem];
       document.dispatchEvent(new CustomEvent('move-dropped-documents', event));
     },
     handleOpenRootFolder() {


### PR DESCRIPTION
Before this change, when try to move file1 from folder3 to folder2 (folder3 is sub-folder of folder2) by drag and drop it breadcrumb (hover over folder2 for a second and once folder2 is loaded drop the file), the file is moved to the root folder. To resolve this problem, in the move-dropped-documents event add the path of the last folder displayed in the breadcrumb (last item in the documentsBreadcrumbToDisplay table) not the root folder (ferst item in the documentsBreadcrumbToDisplay table). After this change, the file is moved to the concerned path in the breadcrumb.

(cherry picked from commit 582bc8f1586f9962a726ef0e426d94f80f2ae716)