### PR TITLE
fix: Expiration date format in public access in not i18n - EXO-73910

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/PublicDocumentOptionsDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/PublicDocumentOptionsDrawer.vue
@@ -197,7 +197,7 @@
                     min-width="auto">
                     <template #activator="{ on, attrs }">
                       <v-text-field
-                        v-model="expirationDate"
+                        v-model="dateFormatted"
                         v-bind="attrs"
                         v-on="on"
                         :placeholder="$t('documents.public.access.choose.date.placeholder')"
@@ -212,6 +212,7 @@
                     <v-date-picker
                       v-model="expirationDate"
                       :min="new Date().toISOString().slice(0,10)"
+                      :locale="lang"
                       required
                       @input="expirationDateMenu = false" />
                   </v-menu>
@@ -338,6 +339,9 @@ export default {
     },
     currentPasswordType() {
       return this.showCurrentPassword && 'text' || 'password';
+    },
+    dateFormatted() {
+      return this.computeDate(this.expirationDate);
     }
   },
   watch: {
@@ -431,6 +435,14 @@ export default {
       this.expirationDate = null;
       this.startCheckPassword = false;
       this.publicDocumentAccess = {};
+    },
+    computeDate(value) {
+      if (value && String(value).trim()) {
+        const dateObj = this.$dateUtil.getDateObjectFromString(String(value).trim(), true);
+        return dateObj.toLocaleDateString(this.lang, this.dateFormat).replaceAll('/','-');
+      } else {
+        return null;
+      }
     }
   }
 };


### PR DESCRIPTION
Before this change, when set the plf language to French and define an expiration date for a document, the date format is in English YYYY-MM-DD. To resolve this problem, add the local props to the v-date-picker component which defines the actual language and add the computeDate method which formats the date displayed on the input. After this change, The date format corresponds to the format of the defined language in the user settings.

(cherry picked from commit 41490967e10af51c6b0f5394527b45967c99dd03)