### PR TITLE
fix: [BUG] - Add agenda & document page in the global site - EXO-75875

### DIFF
--- a/documents-webapp/src/main/webapp/WEB-INF/conf/documents/portal-upgrade-configuration.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/conf/documents/portal-upgrade-configuration.xml
@@ -51,5 +51,48 @@
         </object-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>DocumentsApplicationPageUpgrade</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.upgrade.LayoutUpgradePlugin</type>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <value>180</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <value>true</value>
+        </value-param>
+        <value-param>
+          <name>enabled</name>
+          <value>true</value>
+        </value-param>
+        <object-param>
+          <name>global.upgrade</name>
+          <object type="io.meeds.social.upgrade.model.LayoutUpgrade">
+            <field name="updateNavigation">
+              <boolean>true</boolean>
+            </field>
+            <field name="configPath">
+              <string>war:/conf/documents/portal</string>
+            </field>
+            <field name="portalType">
+              <string>portal</string>
+            </field>
+            <field name="portalName">
+              <string>global</string>
+            </field>
+            <field name="importMode">
+              <string>merge</string>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 </configuration>

--- a/documents-webapp/src/main/webapp/WEB-INF/conf/documents/portal/portal/global/navigation.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/conf/documents/portal/portal/global/navigation.xml
@@ -34,5 +34,16 @@
             <visibility>SYSTEM</visibility>
             <page-reference>portal::global::drives</page-reference>
         </node>
+        <node>
+            <name>home</name>
+            <label>#{portal.global.spaceHome}</label>
+            <visibility>SYSTEM</visibility>
+            <node>
+                <name>documents</name>
+                <label>#{portal.global.documents}</label>
+                <visibility>SYSTEM</visibility>
+                <page-reference>portal::global::drives</page-reference>
+            </node>
+        </node>
     </page-nodes>
 </node-navigation>

--- a/documents-webapp/src/main/webapp/vue-app/documents-size-gadget/components/DocumentSizeMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents-size-gadget/components/DocumentSizeMain.vue
@@ -140,7 +140,7 @@ export default {
     },
     documentsBaseLink (){
       if (eXo.env.portal.spaceIdentityId){
-        return `${eXo.env.portal.context}/g/:spaces:${eXo.env.portal.spaceGroup}/${eXo.env.portal.spaceName}/documents`;
+        return `${eXo.env.portal.context}/s/${eXo.env.portal.spaceId}/documents`;
       } else {
         return `${eXo.env.portal.context}/${eXo.env.portal.portalName}/drives`;
       }


### PR DESCRIPTION
Prior to this fix, clicking on the header of the document size widget don't redirect to the space documents application. this is due to the new apps navigation.

This commit adds the home/documents node to the global site navigation so the user will be redirected to it in this case.