### PR TITLE
fix: [BUG] - Documents imported: notification link isn't redirecting to related folder  - EXO-76576 (#1333)

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -999,8 +999,7 @@ public class JCRDocumentsUtil {
     String domain = CommonsUtils.getCurrentDomain();
     stringBuilder.append(domain).append("/").append(LinkProvider.getPortalName(null)).append("/");
     if (space != null) {
-      String groupId = space.getGroupId().replace("/", ":");
-      stringBuilder.append("g/").append(groupId).append("/").append(space.getPrettyName()).append("/documents");
+      stringBuilder.append("s/").append(space.getId()).append("/documents");
     } else {
       stringBuilder.append(portalOwner).append("/documents");
     }


### PR DESCRIPTION
Prior to this fix, after importing documents via zip the generated link in the notification is wrong and space home page is displayed instead of the documents app. this is due to the new apps navigation.

This commit change the generated document app link to use new spaces permalinks.