### PR TITLE
fix: [BUG] - Documents: Folders view filter issue if folder title has Umlaut  - EXO-76165 (#1338)

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderView.vue
@@ -347,11 +347,20 @@ export default {
     },
     customSort: function (items, sortBy, isDesc) {
       let sorted = items;
+      const accentedExp = /[À-ÖØ-öø-ÿ]/;
       if (sortBy[1] === 'name') {
+        const folders = items.filter((item) => item.folder);
+        const files = items.filter((item) => !item.folder);
+        const nonAccentedFolders = folders.filter((item) => !accentedExp.test(item.name[0]));
+        const accentedFolders = folders.filter((item) => accentedExp.test(item.name[0]));
+        const nonAccentedFiles = files.filter((item) => !accentedExp.test(item.name[0]));
+        const accentedFiles = files.filter((item) => accentedExp.test(item.name[0]));
         const collator = new Intl.Collator(eXo.env.portal.language, {numeric: true, sensitivity: 'base'});
-        sorted = items.sort((a, b) => {
-          return (b.folder - a.folder) || collator.compare(a.name, b.name);
-        });
+        nonAccentedFolders.sort((a, b) =>collator.compare(a.name, b.name)); 
+        accentedFolders.sort((a, b) =>collator.compare(a.name, b.name)); 
+        nonAccentedFiles.sort((a, b) =>collator.compare(a.name, b.name)); 
+        accentedFiles.sort((a, b) =>collator.compare(a.name, b.name)); 
+        sorted =  [...nonAccentedFolders,...accentedFolders, ...nonAccentedFiles, ...accentedFiles];
         if (isDesc[1]) {
           return sorted.reverse();
         }


### PR DESCRIPTION
Prior to this fix, Files starting with accented characters, returned by load more are placed among the items retrieved with the first call. This is because these characters are retrieved at the end of the sorted items from the database but in the front side we apply a natural sorting that ensures that accented characters are placed after their non-accented counterparts.

This commit fix this by splitting the list of items (accented and not accented) and then sort them separately.