### PR TITLE
fix: Harmonize the font of document titles with other preferred titles in favorites list - EXO-75150.

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents-favorite-drawer-extensions/components/DocumentsFavoriteItem.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents-favorite-drawer-extensions/components/DocumentsFavoriteItem.vue
@@ -9,7 +9,7 @@
     </v-list-item-icon>
 
     <v-list-item-content>
-      <v-list-item-title class="text-color body-2">{{ documentTitle }}</v-list-item-title>
+      <v-list-item-title class="text-color text-truncate">{{ documentTitle }}</v-list-item-title>
     </v-list-item-content>
 
     <v-list-item-action>


### PR DESCRIPTION
Before this change, when open the favorite list, the font of documents is different than the other favorite items in the list. To resolve this problem, change the body-2 class to text-truncate in documentsFavoriteItem. After this change, document titles and other favorite elements in other applications have the same font.