### PR TITLE
fix: When uploading a file if the request upload have a little delay (more than 200ms), the upload fails - EXO-77268

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/uploadZip/AttachmentsUploadInput.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/uploadZip/AttachmentsUploadInput.vue
@@ -170,8 +170,12 @@ export default {
         this.processNextQueuedUpload();
       } else {
         window.setTimeout(() => {
+          if (!file.countFirstProgressError) {
+            file.countFirstProgressError=0;
+          }
           this.$uploadService.getUploadProgress(file.uploadId)
             .then(percent => {
+              delete file.countFirstProgressError;
               file.uploadProgress = Number(percent);
               if (!file.uploadProgress || file.uploadProgress < 100) {
                 this.controlUpload(file);
@@ -180,12 +184,19 @@ export default {
                 this.processNextQueuedUpload();
               }
             })
-            .catch(() => {
-              this.removeAttachedFile(file);
-              this.$root.$emit('show-alert', {
-                message: this.uploadErrorMassage,
-                type: 'error',
-              });
+            .catch((err) => {
+              if (err.message==='Uploaded resource not found' && file.countFirstProgressError != null && file.countFirstProgressError < 5) {
+                //if the upload request take more than 200ms to initialize, then the progress request arrives too early.
+                //In this case, redo the progress, until 5 errors to be sure
+                file.countFirstProgressError++;
+                this.controlUpload(file);
+              } else {
+                this.removeAttachedFile(file);
+                this.$root.$emit('show-alert', {
+                  message: this.uploadErrorMassage,
+                  type: 'error',
+                });
+              }
             });
         }, 200);
       }


### PR DESCRIPTION
Before this fix, if the progress request is treaten by the server before the upload request (due to latency problem for example), the upload fails on browser side This commit add a replay of the progress request (5 times max) in order to accept some latency on upload request