### PR TITLE
fix: Fix restored document not displayed in the folder view - EXO-77282

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/snackbar/ExoDocumentNotificationAlert.vue
+++ b/documents-webapp/src/main/webapp/vue-app/snackbar/ExoDocumentNotificationAlert.vue
@@ -69,6 +69,7 @@ export default {
     displayAlert() {
       if (!this.displayAlert) {
         this.$emit('dismissed');
+        document.dispatchEvent(new CustomEvent('document-alert-notification-dismissed'));
       }
     },
   },

--- a/documents-webapp/src/main/webapp/vue-app/snackbar/ExoDocumentNotificationAlerts.vue
+++ b/documents-webapp/src/main/webapp/vue-app/snackbar/ExoDocumentNotificationAlerts.vue
@@ -47,6 +47,7 @@ export default {
           clickMessage,
         });
       }
+      document.addEventListener('document-alert-notification-dismissed', this.handleDocumentDeletionDismissal);
     });
   },
   methods: {
@@ -73,6 +74,12 @@ export default {
           });
         });
     },
+    handleDocumentDeletionDismissal() {
+      setTimeout(() => {
+        localStorage.removeItem('deletedDocument');
+        document.removeEventListener('document-alert-notification-dismissed', this.handleDocumentDeletionDismissal);
+      }, 2000);
+    }
   },
 };
 </script>


### PR DESCRIPTION
Prior to this change, restored documents weren't displayed in the document folder view. This issue was caused by the presence of the deleted document item in the local storage, which is used to handle the undo delete action. This change will remove the deleted document from the local storage after the dismissal of the confirm document delete alert, resolving this issue.