### PR TITLE
fix: Improve copy link of a document/folder - EXO-77150

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/CopyLinkMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/CopyLinkMenuAction.vue
@@ -33,7 +33,7 @@ export default {
       if (this.file.folder){
         path = `${path}?folderId=${this.file.id}`;
       } else {
-        path = `${path}?documentPreviewId=${this.file.id}`;
+        path = `${window.location.host}${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/oeditor?docId=${this.file.id}&mode=view`;
       }
       $('body').append(inputTemp);
       inputTemp.val(path).select();


### PR DESCRIPTION
Prior to this fix, the copy link of a document generates a link to the old preview link. 
This fix changes the generated link for documents to get the link onlyoffice page with view mode .