### PR TITLE
fix: Remove the space between the document name and description in the document drawer details - EXO-73142

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentInfoDrawer.vue
@@ -46,7 +46,7 @@
       </div>
       <v-hover>
         <div slot-scope="{ hover }">
-          <v-row class="col-12 py-4 pl-8">
+          <v-row class="col-12">
             <v-col class="col-11 px-0 py-0">
               <div
                 v-show="showDescription"


### PR DESCRIPTION
this change is going to remove the space between the document name and description in the document drawer details