### PR TITLE
fix: add property to deactivate computing documents size including versions - EXO-78104

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -491,8 +491,15 @@ public class JCRDocumentsUtil {
     if (content.hasProperty(NodeTypeConstants.JCR_DATA)) {
       long fileSize = content.getProperty(NodeTypeConstants.JCR_DATA).getLength();
       fileNode.setSize(fileSize);
-      long versionsFileSize = computeVersionsSize(content.getParent());
-      fileNode.setSizeWithVersions(fileSize+versionsFileSize);
+
+      boolean computeVersionSize = Boolean.parseBoolean(System.getProperty("documents.content.compute.version.size","true"));
+
+      if (computeVersionSize) {
+        long versionsFileSize = computeVersionsSize(content.getParent());
+        fileNode.setSizeWithVersions(fileSize+versionsFileSize);
+      } else {
+        fileNode.setSizeWithVersions(fileSize);
+      }
 
     }
   }


### PR DESCRIPTION
Before this fix, when a document is modified, the indexation compute the size including all versions of a document This can lead to platform outage when documents have a lot of versions (in case of coedition in OO)

When setting the property documents.content.compute.version.size to false, the sizeWithVersions is not computed and use current fileSize. This modification also apply in documents app when displaying file informations.

(cherry picked from commit a209e231a98ef59372133b11269c87645899256f)