### PR TITLE
fix: Public access : password and expiration date are lost - EXO-78184

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
@@ -1143,31 +1143,39 @@ public class DocumentFileRest implements ResourceContainer {
     if (userIdentityId == 0) {
       return Response.status(Response.Status.UNAUTHORIZED).build();
     }
-    String password = publicDocumentAccessOptionsEntity != null ? publicDocumentAccessOptionsEntity.getPassword() : null;
-    Long expirationDate = publicDocumentAccessOptionsEntity != null ? publicDocumentAccessOptionsEntity.getExpirationDate() : 0L;
-    boolean hasPassword = publicDocumentAccessOptionsEntity != null && publicDocumentAccessOptionsEntity.isHasPassword();
-    if (password != null) {
-      String errorMessage = PASSWORD_VALIDATOR.validate(locale, publicDocumentAccessOptionsEntity.getPassword());
-      if (StringUtils.isNotBlank(errorMessage)) {
-        return Response.status(Response.Status.BAD_REQUEST).entity(errorMessage).build();
+
+    //publicDocumentAccessOptionsEntity = null means no change
+    if (publicDocumentAccessOptionsEntity != null) {
+      //publicDocumentAccessOptionsEntity = {} with noPassword means delete password
+      String password = publicDocumentAccessOptionsEntity.getPassword();
+      Long expirationDate = publicDocumentAccessOptionsEntity.getExpirationDate();
+      boolean hasPassword = publicDocumentAccessOptionsEntity.isHasPassword();
+      if (password != null) {
+        String errorMessage = PASSWORD_VALIDATOR.validate(locale, publicDocumentAccessOptionsEntity.getPassword());
+        if (StringUtils.isNotBlank(errorMessage)) {
+          return Response.status(Response.Status.BAD_REQUEST).entity(errorMessage).build();
+        }
       }
-    }
-    try {
-      boolean hasEditPermission = documentFileService.hasEditPermissionOnDocument(nodeId, userIdentityId);
-      if (!hasEditPermission) {
-        return Response.status(Response.Status.UNAUTHORIZED).build();
+      try {
+        boolean hasEditPermission = documentFileService.hasEditPermissionOnDocument(nodeId, userIdentityId);
+        if (!hasEditPermission) {
+          return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+
+        return Response.ok(EntityBuilder.toPublicDocumentAccessEntity(publicDocumentAccessService.createPublicDocumentAccess(
+                           userIdentityId,
+                           nodeId,
+                           password,
+                           expirationDate,
+                           hasPassword)))
+                       .build();
+      } catch (Exception e) {
+        LOG.error("Error while creating a document public access for document: {}", nodeId, e);
+        return Response.serverError().build();
       }
 
-      return Response.ok(EntityBuilder.toPublicDocumentAccessEntity(publicDocumentAccessService.createPublicDocumentAccess(userIdentityId,
-                                                                                                                           nodeId,
-                                                                                                                           password,
-                                                                                                                           expirationDate,
-                                                                                                                           hasPassword)))
-                     .build();
-
-    } catch (Exception e) {
-      LOG.error("Error while creating a document public access for document: {}", nodeId, e);
-      return Response.serverError().build();
+    } else {
+      return Response.ok(EntityBuilder.toPublicDocumentAccessEntity(publicDocumentAccessService.getPublicDocumentAccess(nodeId))).build();
     }
   }
 

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/PublicDocumentOptionsDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/PublicDocumentOptionsDrawer.vue
@@ -403,6 +403,9 @@ export default {
       this.$refs.publicDocumentOptionsDrawer.close();
     },
     getExpirationDelayDate() {
+      if (!this.showExpirationDateInput) {
+        return null;
+      }
       const delayDate = new Date(new Date());
       switch (this.delayType) {
       case 'day':

--- a/documents-webapp/src/main/webapp/vue-app/documents/js/DocumentFileService.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/js/DocumentFileService.js
@@ -535,6 +535,9 @@ export function bulkMoveDocuments(actionId, documents, ownerId, destPath) {
 }
 
 export function createDocumentPublicAccess(nodeId, publicAccessOptions) {
+  if (!publicAccessOptions) {
+    return getDocumentPublicAccess(nodeId);
+  }
   const formData = new FormData();
   if (nodeId) {
     formData.append('nodeId', nodeId);


### PR DESCRIPTION
Before this fix, when editing public access without opening second level drawer removes password and expiration date configuration This commit ensure to not modify it if not necessary by check if option is null before sending. Option null means no change

This commit also fix a collateral problem for which it is no possible only unset expiration date and keep password