### PR TITLE
fix: resolve document copy link issue after migration - EXO-78359 

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/CopyLinkMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/CopyLinkMenuAction.vue
@@ -30,7 +30,7 @@ export default {
       let path = `${window.location.host}${eXo.env.portal.context}`;
       if (eXo.env.portal.spaceId){
         const pathParts = eXo.env.portal.selectedNodeUri.split('home');
-        const nodeUri = pathParts.length > 1 ? pathParts[1] : eXo.env.portal.selectedNodeUri;
+        const nodeUri = pathParts.length > 1 ? pathParts[1] : eXo.env.portal.selectedNodeUri.substring(eXo.env.portal.selectedNodeUri.indexOf('/documents'));
         path = `${path}/s/${eXo.env.portal.spaceId}${nodeUri}`;
       } else {
         path = `${path}/${eXo.env.portal.metaPortalName}/${eXo.env.portal.selectedNodeUri}`;


### PR DESCRIPTION


Prior to this change, the copied document link after a migration context was redirecting to a 'Not Found' page. This issue was due to an incorrect construction of the document URL, which did not consider the old nodeUri format (exo 6.5.x). This change ensures the document URL is now built correctly.