### PR TITLE
Fix: Generate public link access issue - EXO-78542

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
@@ -1143,39 +1143,30 @@ public class DocumentFileRest implements ResourceContainer {
     if (userIdentityId == 0) {
       return Response.status(Response.Status.UNAUTHORIZED).build();
     }
-
-    //publicDocumentAccessOptionsEntity = null means no change
-    if (publicDocumentAccessOptionsEntity != null) {
-      //publicDocumentAccessOptionsEntity = {} with noPassword means delete password
-      String password = publicDocumentAccessOptionsEntity.getPassword();
-      Long expirationDate = publicDocumentAccessOptionsEntity.getExpirationDate();
-      boolean hasPassword = publicDocumentAccessOptionsEntity.isHasPassword();
-      if (password != null) {
-        String errorMessage = PASSWORD_VALIDATOR.validate(locale, publicDocumentAccessOptionsEntity.getPassword());
-        if (StringUtils.isNotBlank(errorMessage)) {
+    String password = publicDocumentAccessOptionsEntity != null ? publicDocumentAccessOptionsEntity.getPassword() : null;
+    Long expirationDate = publicDocumentAccessOptionsEntity != null ? publicDocumentAccessOptionsEntity.getExpirationDate() : 0L;
+    boolean hasPassword = publicDocumentAccessOptionsEntity != null && publicDocumentAccessOptionsEntity.isHasPassword();
+    if (password != null) {
+      String errorMessage = PASSWORD_VALIDATOR.validate(locale, publicDocumentAccessOptionsEntity.getPassword());
+      if (StringUtils.isNotBlank(errorMessage)) {
           return Response.status(Response.Status.BAD_REQUEST).entity(errorMessage).build();
-        }
       }
-      try {
-        boolean hasEditPermission = documentFileService.hasEditPermissionOnDocument(nodeId, userIdentityId);
-        if (!hasEditPermission) {
+    }
+    try {
+      boolean hasEditPermission = documentFileService.hasEditPermissionOnDocument(nodeId, userIdentityId);
+      if (!hasEditPermission) {
           return Response.status(Response.Status.UNAUTHORIZED).build();
-        }
-
-        return Response.ok(EntityBuilder.toPublicDocumentAccessEntity(publicDocumentAccessService.createPublicDocumentAccess(
-                           userIdentityId,
-                           nodeId,
-                           password,
-                           expirationDate,
-                           hasPassword)))
-                       .build();
-      } catch (Exception e) {
-        LOG.error("Error while creating a document public access for document: {}", nodeId, e);
-        return Response.serverError().build();
       }
+      return Response.ok(EntityBuilder.toPublicDocumentAccessEntity(publicDocumentAccessService.createPublicDocumentAccess(userIdentityId,
+                      nodeId,
+                      password,
+                      expirationDate,
+                      hasPassword)))
+              .build();
 
-    } else {
-      return Response.ok(EntityBuilder.toPublicDocumentAccessEntity(publicDocumentAccessService.getPublicDocumentAccess(nodeId))).build();
+    } catch (Exception e) {
+      LOG.error("Error while creating a document public access for document: {}", nodeId, e);
+      return Response.serverError().build();
     }
   }
 

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsVisibilityDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsVisibilityDrawer.vue
@@ -160,7 +160,7 @@
                 </v-label>
                 <v-spacer />
                 <v-switch
-                  v-model="file.acl.allMembersCanEdit"
+                  v-model="allMembersCanEdit"
                   class="mt-0 me-1" />
               </div>
             </div>
@@ -237,6 +237,7 @@
           </v-btn>
           <v-btn
             class="btn btn-primary"
+            :disabled="isDisabled"
             :loading="loading"
             @click="saveVisibility()">
             {{ $t('documents.label.visibility.save') }}
@@ -281,11 +282,32 @@ export default {
     searchOptions: {
       currentUser: '',
     },
+    originalFileProperties: {
+      visibilityChoice: '',
+      publicDocumentAccess: {
+        decodedPassword: null,
+        expirationDate: 0,
+        hasPassword: false,
+      },
+      allMembersCanEdit: false,
+      collaborators: '',
+    },
+    actualFileProperties: {
+      visibilityChoice: '',
+      publicDocumentAccess: {
+        decodedPassword: null,
+        expirationDate: 0,
+        hasPassword: false,
+      },
+      allMembersCanEdit: false,
+      collaborators: '',
+    },
     users: [],
     publicDocumentAccess: null,
     publicDocumentAccessOptions: null,
     isEditingPublicAccessOptions: false,
-    visibilityChoice: null
+    visibilityChoice: null,
+    allMembersCanEdit: false,
   }),
   computed: {
     publicAccessExpirationDate() {
@@ -400,6 +422,9 @@ export default {
     showMoreUsersNumber() {
       return `${this.users.length - this.maxUsersToShow  } ${  this.$t('documents.label.visibility.others')}`;
     },
+    isDisabled() {
+      return JSON.stringify(this.originalFileProperties) === JSON.stringify(this.actualFileProperties);
+    },
   },
   watch: {
     collaborators() {
@@ -418,6 +443,36 @@ export default {
       }
       this.collaborators = null;
     },
+    originalFileProperties() {
+      this.actualFileProperties = { ...this.originalFileProperties};
+    },
+    visibilityChoice() {
+      this.actualFileProperties = { ...this.actualFileProperties,visibilityChoice: this.visibilityChoice};
+    },
+    allMembersCanEdit(newVal) {
+      this.file.acl.allMembersCanEdit = newVal;
+      this.actualFileProperties = { ...this.actualFileProperties,allMembersCanEdit: newVal };
+    },
+    showPublicAccessOption() {
+      if (!this.showPublicAccessOption) {
+        this.actualFileProperties = {
+          ...this.actualFileProperties,
+          publicDocumentAccess: {
+            ...this.actualFileProperties.publicDocumentAccess,
+            decodedPassword: this.originalFileProperties.publicDocumentAccess.decodedPassword,
+            expirationDate: this.originalFileProperties.publicDocumentAccess.expirationDate,
+            hasPassword: this.originalFileProperties.publicDocumentAccess.hasPassword
+          }
+        };
+      } 
+    },
+    showSwitch() {
+      this.actualFileProperties = this.showSwitch ? { ...this.actualFileProperties,allMembersCanEdit: this.file.acl.allMembersCanEdit }
+        : { ...this.actualFileProperties,allMembersCanEdit: this.originalFileProperties.allMembersCanEdit };
+    },
+    usersToDisplay() {
+      this.actualFileProperties = { ... this.actualFileProperties, collaborators: this.stringifyArray(this.usersToDisplay) };
+    }
   },
   created() {
     this.$root.$on('set-document-public-access-options', this.setDocumentPublicAccessOptions);
@@ -432,13 +487,29 @@ export default {
   },
   methods: {
     setDocumentPublicAccessOptions(options) {
+      this.actualFileProperties = {
+        ...this.actualFileProperties,
+        publicDocumentAccess: {
+          ...this.actualFileProperties.publicDocumentAccess,
+          decodedPassword: options.decodedPassword ? options.decodedPassword : null,
+          expirationDate: options.expirationDate === null ? 0 : options.expirationDate,
+          hasPassword: options.hasPassword
+        }
+      };
       this.isEditingPublicAccessOptions = true;
-      this.publicDocumentAccessOptions = options;
-      this.publicDocumentAccess.hasPassword = options.hasPassword;
-      this.publicDocumentAccess.expirationDate = options.expirationDate;
+      this.publicDocumentAccessOptions = this.publicDocumentAccess = options;
     },
     getDocumentPublicAccessInfo() {
       this.$documentFileService.getDocumentPublicAccess(this.file.id).then(publicDocumentAccess => {
+        this.originalFileProperties = {
+          ...this.originalFileProperties,
+          publicDocumentAccess: {
+            ...this.originalFileProperties.publicDocumentAccess,
+            decodedPassword: publicDocumentAccess.decodedPassword ? publicDocumentAccess.decodedPassword : null,
+            expirationDate: publicDocumentAccess.expirationDate === null ? 0 : publicDocumentAccess.expirationDate.time,
+            hasPassword: publicDocumentAccess.hasPassword
+          }
+        };
         this.publicDocumentAccess = publicDocumentAccess;
       });
     },
@@ -480,7 +551,9 @@ export default {
       this.visibilityChoice = this.file.acl.visibilityChoice;
       this.publicDocumentAccess = null;
       this.publicDocumentAccessOptions = null;
-      this.getDocumentPublicAccessInfo();
+      if (this.visibilityChoice === 'COLLABORATORS_AND_PUBLIC_ACCESS'){
+        this.getDocumentPublicAccessInfo();
+      }
       if (this.file?.creatorIdentity?.remoteId){
         this.$userService.getUser(this.file.creatorIdentity.remoteId).then(user => {
           this.ownerIdentity = user;
@@ -492,11 +565,17 @@ export default {
         user.permission = collaborator.permission;
         this.users.push(user);
       }
+      this.originalFileProperties = { ...this.originalFileProperties, 
+        visibilityChoice: this.file.acl.visibilityChoice,
+        allMembersCanEdit: this.file.acl.allMembersCanEdit,
+        collaborators: this.stringifyArray(JSON.parse(JSON.stringify(this.users)))
+      };
       this.$refs.documentVisibilityDrawer.open();
     },
     close() {
       this.isEditingPublicAccessOptions = false;
       this.publicDocumentAccessOptions = {};
+      this.originalFileProperties.publicDocumentAccess = {};
       this.$refs.documentVisibilityDrawer.close();
 
     },
@@ -529,7 +608,7 @@ export default {
       if (this.visibilityChoice==='SPECIFIC_COLLABORATOR'){
         this.file.acl.allMembersCanEdit=false;
       }
-      const publicAccess = this.visibilityChoice === 'COLLABORATORS_AND_PUBLIC_ACCESS';
+      const publicAccess = this.isPublicAccess();
       this.file.acl.visibilityChoice = this.visibilityChoice;
       this.$root.$emit('save-visibility',this.file, publicAccess, this.publicDocumentAccessOptions);
     },
@@ -548,7 +627,26 @@ export default {
       if (index >= 0) {
         this.users[index].permission=user.permission;
       }
+      this.actualFileProperties = { ... this.actualFileProperties, collaborators: this.stringifyArray(this.usersToDisplay) };
     },
+    stringifyArray(collaborators) {
+      if (!collaborators) {
+        return '';
+      }
+      collaborators = JSON.parse(JSON.stringify(collaborators));
+      collaborators = collaborators
+        .map(c => {
+          const { id, permission, remoteId, providerId } = c;
+          return JSON.stringify({ id, permission, remoteId, providerId });
+        });
+      
+      return JSON.stringify(collaborators.sort());
+    },
+    isPublicAccess() {
+      return this.visibilityChoice === 'COLLABORATORS_AND_PUBLIC_ACCESS' 
+              && (JSON.stringify(this.originalFileProperties.publicDocumentAccess) !== JSON.stringify(this.actualFileProperties.publicDocumentAccess)
+              || this.originalFileProperties.visibilityChoice !== this.actualFileProperties.visibilityChoice);
+    }
   }
 };
 </script>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/PublicDocumentOptionsDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/PublicDocumentOptionsDrawer.vue
@@ -373,7 +373,7 @@ export default {
     },
     checkPasswordValid() {
       this.startCheckPassword = this.showPasswordInput;
-      const passwordValue = this.publicDocumentAccessOptionsObject?.password;
+      const passwordValue = this.publicDocumentAccessOptionsObject?.decodedPassword;
       return passwordValue && this.passwordRegex.test(passwordValue);
     },
     toggleShowPassword() {
@@ -403,9 +403,6 @@ export default {
       this.$refs.publicDocumentOptionsDrawer.close();
     },
     getExpirationDelayDate() {
-      if (!this.showExpirationDateInput) {
-        return null;
-      }
       const delayDate = new Date(new Date());
       switch (this.delayType) {
       case 'day':
@@ -423,11 +420,19 @@ export default {
         return;
       }
       this.publicDocumentAccessOptionsObject.expirationDate = 0;
-      if (this.expirationDate && this.expirationDateType === 'specificDate') {
-        const date = new Date(this.expirationDate).setHours(23, 59, 59, 0o00);
-        this.publicDocumentAccessOptionsObject.expirationDate = new Date(date).getTime();
-      } else if (this.expirationDateType === 'delayDate') {
-        this.publicDocumentAccessOptionsObject.expirationDate = this.getExpirationDelayDate();
+      if (this.showExpirationDateInput) {
+        if (this.expirationDate && this.expirationDateType === 'specificDate') {
+          const date = new Date(this.expirationDate).setHours(23, 59, 59, 0o00);
+          this.publicDocumentAccessOptionsObject.expirationDate = new Date(date).getTime();
+        } else if (this.expirationDateType === 'delayDate') {
+          this.publicDocumentAccessOptionsObject.expirationDate = this.getExpirationDelayDate();
+        }
+      }
+      if (this.hasPassword) {
+        this.publicDocumentAccessOptionsObject.decodedPassword = this.publicDocumentAccessOptionsObject.password 
+          ? this.publicDocumentAccessOptionsObject.password : this.publicDocumentAccess.decodedPassword;
+      } else {
+        this.publicDocumentAccessOptionsObject.decodedPassword = null;
       }
       this.publicDocumentAccessOptionsObject.hasPassword = this.hasPassword;
       this.$root.$emit('set-document-public-access-options', this.publicDocumentAccessOptionsObject);

--- a/documents-webapp/src/main/webapp/vue-app/documents/js/DocumentFileService.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/js/DocumentFileService.js
@@ -535,9 +535,6 @@ export function bulkMoveDocuments(actionId, documents, ownerId, destPath) {
 }
 
 export function createDocumentPublicAccess(nodeId, publicAccessOptions) {
-  if (!publicAccessOptions) {
-    return getDocumentPublicAccess(nodeId);
-  }
   const formData = new FormData();
   if (nodeId) {
     formData.append('nodeId', nodeId);


### PR DESCRIPTION
Before this change, when creating SpaceX and accessing its document application, then uploading many documents and on any document, making access public and saving, an error message was displayed and the public link displayed access denied. To fix this issue, add a disabled property to the save button of the documentVisibilityDrawer drawer. It should only be enabled when one of the drawer properties is changed. The creation of the public access link should only be triggered if the visibility choice is set to COLLABORATORS_AND_PUBLIC_ACCESS and one of the public document access options is different from the initial value. After this change, the generated link should allow downloading related documents.

(cherry picked from commit ef17db5f23ca3b36012323a3e7d41b6448b1bf34)