### PR TITLE
Fix: Action Menu - 3 dots and right click - EXO-73143.

### DIFF
--- a/documents-webapp/src/main/webapp/skin/less/documents.less
+++ b/documents-webapp/src/main/webapp/skin/less/documents.less
@@ -2,6 +2,10 @@
 
 .VuetifyApp {
   .v-application
+    .my-10px {
+      margin-top: 10px !important;
+      margin-bottom: 10px !important;
+    }
     .v-alert__content {
        padding-right: 10px !important;
   }
@@ -819,8 +823,6 @@
   min-width: 130px !important;
 
   .v-list {
-    padding-top: 4px !important;
-    padding-bottom: 4px !important;
 
     .v-list-item:not(.v-list-item--disabled) {
       .iconStyle {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/CopyLinkMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/CopyLinkMenuAction.vue
@@ -1,17 +1,19 @@
 <template>
-  <div
-    class="clickable pt-1 mx-2"
-    @click="copyLink()">
-    <v-icon
-      size="13"
-      class="pe-1 iconStyle">
-      mdi-link-variant
-    </v-icon>
-    <span class="ps-1">{{ $t('documents.label.copy.link') }}</span>
+  <div>
+    <div
+      class="clickable my-10px mx-2"
+      @click="copyLink()">
+      <v-icon
+        size="16"
+        class="pe-1">
+        fas fa-link
+      </v-icon>
+      <span class="ps-1 text-body menu-text-color">{{ $t('documents.label.copy.link') }}</span>
+    </div>
     <v-divider
       v-if="!file.cloudDriveFolder"
-      class="mt-1 dividerStyle" />
-  </div>
+      class="mt-1" />
+  </div>  
 </template>
 <script>
 export default {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DeleteMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DeleteMenuAction.vue
@@ -1,13 +1,13 @@
 <template>
   <div
-    class="clickable mx-2"
+    class="clickable my-10px mx-2"
     @click="deleteAction()">
     <v-icon
-      size="13"
-      class="pe-1 iconStyle">
+      size="16"
+      class="pe-1 error-color">
       fas fa-trash
     </v-icon>
-    <span class="ps-1">{{ $t('documents.label.delete') }}</span>
+    <span class="ps-1 ml-n2px text-body menu-text-color">{{ $t('documents.label.delete') }}</span>
   </div>
 </template>
 <script>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DetailsMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DetailsMenuAction.vue
@@ -1,13 +1,13 @@
 <template>
   <div
-    class="clickable mx-2"
+    class="clickable my-10px mx-2"
     @click="displayDetails()">
     <v-icon
-      size="13"
-      class="pe-1 iconStyle">
+      size="16"
+      class="pe-1">
       fa-info-circle
     </v-icon>
-    <span class="ps-1">{{ $t('documents.drawer.details.title') }}</span>
+    <span class="ps-1 text-body menu-text-color">{{ $t('documents.drawer.details.title') }}</span>
   </div>
 </template>
 <script>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DownloadMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DownloadMenuAction.vue
@@ -1,13 +1,13 @@
 <template>
   <div
-    class="downloadDocumentNewApp clickable mx-2"
+    class=" clickable my-10px mx-2"
     @click="download()">
     <v-icon
-      size="13"
-      class="pe-1 iconStyle">
+      size="16"
+      class="pe-1">
       fas fa-download
     </v-icon>
-    <span class="ps-1">{{ $t('documents.label.download') }}</span>
+    <span class="ps-1 text-body menu-text-color">{{ $t('documents.label.download') }}</span>
   </div>
 </template>
 <script>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DuplicateMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DuplicateMenuAction.vue
@@ -1,13 +1,13 @@
 <template>
   <div
-    class="clickable pt-1 mx-2"
+    class="clickable my-10px mx-2"
     @click="duplicate()">
     <v-icon
-      size="13"
-      class="pe-1 iconStyle">
+      size="16"
+      class="pe-1">
       fas fa-clone
     </v-icon>
-    <span class="ps-1">{{ $t('documents.label.duplicate') }}</span>
+    <span class="ps-1 text-body menu-text-color">{{ $t('documents.label.duplicate') }}</span>
   </div>
 </template>
 <script>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/EditMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/EditMenuAction.vue
@@ -1,14 +1,13 @@
 <template>
   <div
-    class="clickable mx-2 theme--light"
+    class="clickable my-10px mx-2"
     @click="editFile()">
     <v-icon
-      size="13"
-      dark
-      class="pe-1 iconStyle grey--text text--darken-1">
+      size="16"
+      class="pe-1">
       fas fa-edit
     </v-icon>
-    <span class="ps-1">{{ $t('document.label.edit') }}</span>
+    <span class="ps-1 text-body menu-text-color">{{ $t('document.label.edit') }}</span>
   </div>
 </template>
 <script>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/MoveMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/MoveMenuAction.vue
@@ -15,18 +15,20 @@
 * along with this program.  If not, see <gnu.org/licenses>.
 -->
 <template>
-  <div
-    class="clickable pt-1 mx-2"
-    @click="moveDocument()">
-    <v-icon
-      size="13"
-      class="pe-1 iconStyle">
-      fa-arrows-alt
-    </v-icon>
-    <span class="ps-1">{{ $t('document.label.move') }}</span>
+  <div>
+    <div
+      class="clickable my-10px mx-2"
+      @click="moveDocument()">
+      <v-icon
+        size="16"
+        class="pe-1">
+        fa-arrows-alt
+      </v-icon>
+      <span class="ps-1 text-body menu-text-color">{{ $t('document.label.move') }}</span>
+    </div>
     <v-divider
       v-if="isMultiSelection"
-      class="mt-1 dividerStyle" />
+      class="mt-1" />
   </div>
 </template>
 <script>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/OpenLocationMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/OpenLocationMenuAction.vue
@@ -1,13 +1,13 @@
 <template>
   <div
-    class="clickable pt-1 mx-2"
+    class="clickable my-10px mx-2"
     @click="openLocation()">
     <v-icon
-      size="13"
-      class="pe-1 iconStyle">
+      size="16"
+      class="pe-1">
       fa-external-link-alt
     </v-icon>
-    <span class="ps-1">{{ $t('document.label.go.location') }}</span>
+    <span class="ps-1 text-body menu-text-color">{{ $t('document.label.go.location') }}</span>
   </div>
 </template>
 <script>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/OpenReadOnlyMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/OpenReadOnlyMenuAction.vue
@@ -1,14 +1,13 @@
 <template>
   <div
-    class="clickable mx-2 theme--light"
+    class="clickable ma-auto my-10px mx-2"
     @click="openReadOnlyFile()">
     <v-icon
-      size="13"
-      dark
-      class="pe-1 iconStyle grey--text text--darken-1">
+      size="16"
+      class="pe-1">
       fab fa-readme
     </v-icon>
-    <span class="ps-1">{{ $t('document.label.open.read.only') }}</span>
+    <span class="ps-1 text-body menu-text-color">{{ $t('document.label.open.read.only') }}</span>
   </div>
 </template>
 <script>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/RenameMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/RenameMenuAction.vue
@@ -1,13 +1,15 @@
 <template>
-  <div
-    class="clickable pt-1 mx-2"
-    @click="editNameMode()">
-    <v-icon
-      size="13"
-      class="pe-1 iconStyle">
-      mdi-form-textbox
-    </v-icon>
-    <span class="ps-1">{{ $t('document.label.rename') }}</span>
+  <div>
+    <div
+      class="clickable my-10px mx-2"
+      @click="editNameMode()">
+      <v-icon
+        size="16"
+        class="pe-1">
+        fas fa-pen
+      </v-icon>
+      <span class="text-body menu-text-color ps-1">{{ $t('document.label.rename') }}</span>
+    </div>
     <v-divider
       v-if="!isMobile"
       class="mt-1 dividerStyle" />

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/ShortcutMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/ShortcutMenuAction.vue
@@ -15,15 +15,17 @@
 * along with this program.  If not, see <gnu.org/licenses>.
 -->
 <template>
-  <div
-    class="clickable mx-2"
-    @click="addShortcut()">
-    <v-icon
-      size="13"
-      class="pe-1 iconStyle">
-      fas fa-share-square
-    </v-icon>
-    <span class="ps-1">{{ $t('documents.label.shortcut') }}</span>
+  <div>
+    <div
+      class="clickable my-10px mx-2"
+      @click="addShortcut()">
+      <v-icon
+        size="16"
+        class="pe-1">
+        fas fa-share-square
+      </v-icon>
+      <span class="ps-1 text-body menu-text-color">{{ $t('documents.label.shortcut') }}</span>
+    </div>
     <v-divider
       class="mt-1 dividerStyle" />
   </div>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/UploadNewVersionMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/UploadNewVersionMenuAction.vue
@@ -15,15 +15,17 @@
 * along with this program.  If not, see <gnu.org/licenses>.
 -->
 <template>
-  <div
-    class="clickable pt-1 mx-2"
-    @click="uploadVersion">
-    <v-icon
-      size="13"
-      class="pe-1 iconStyle">
-      fas fa-upload
-    </v-icon>
-    {{ $t('documents.label.upload.newVersion') }}
+  <div>
+    <div
+      class="clickable my-10px mx-2"
+      @click="uploadVersion">
+      <v-icon
+        size="16"
+        class="pe-1">
+        fas fa-upload
+      </v-icon>
+      <span class="ps-1 text-body menu-text-color">{{ $t('documents.label.upload.newVersion') }}</span>
+    </div>
     <v-divider
       class="mt-1 dividerStyle" />
   </div>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/VersionHistoryMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/VersionHistoryMenuAction.vue
@@ -16,14 +16,14 @@
 -->
 <template>
   <div
-    class="clickable ma-auto pt-1 mx-2"
+    class="clickable my-10px mx-2"
     @click="showVersionHistory">
     <v-icon
-      size="13"
-      class="pe-1 iconStyle">
+      size="16"
+      class="pe-1">
       fa fa-history
     </v-icon>
-    <span class="ps-1">{{ $t('documents.label.showVersionHistory') }}</span>
+    <span class="ps-1 text-body menu-text-color">{{ $t('documents.label.showVersionHistory') }}</span>
   </div>
 </template>
 

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/VisibilityMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/VisibilityMenuAction.vue
@@ -1,13 +1,13 @@
 <template>
   <div
-    class="clickable ma-auto pt-1 mx-2"
+    class="clickable ma-auto my-10px mx-2"
     @click="changeVisibility()">
     <v-icon
-      size="13"
-      class="pe-1 iconStyle">
+      size="16"
+      class="pe-1">
       fas fa-eye
     </v-icon>
-    <span class="ps-1">{{ $t('documents.label.visibility') }}</span>
+    <span class="ps-1 text-body menu-text-color">{{ $t('documents.label.visibility') }}</span>
   </div>
 </template>
 <script>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
@@ -1,5 +1,7 @@
 <template>
-  <v-list dense>
+  <v-list 
+    class="py-0"
+    dense>
     <v-list-item
       v-for="(extension, i) in menuExtensions"
       :key="i"


### PR DESCRIPTION
Before this change, when right-clicking or clicking via 3 dots, menus did not respect the formats of the existing menu template for the menu in the navigation. To fix this problem, apply the style of the menu in the navigation. After this change, the menu is adapted to the menu in the navigation.