### PR TITLE
feat: eXIP10: Behaviour when clicking to thumbnail from info detail drawer - EXO-79118

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/document-info-drawer/components/DocumentInfoDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/document-info-drawer/components/DocumentInfoDrawer.vue
@@ -582,7 +582,7 @@ export default {
     openFileInEditor(mode) {
       if (this.file && this.file.id) {
         const url = this.$documentsUtils.getEditorUrl(this.file,mode);
-        window.open(url,'_self');
+        window.open(url,'_blank');
       }
     },
     favoriteRemoved() {


### PR DESCRIPTION
Prior to this change, when a user clicks on the thumbnail of an office file from the detail drawer it opens the only office editor in the same tab. This commit changes this behaviour to open the only office in a new tab.