### PR TITLE
feat: [Drives] Improve the loading UI of drives app - EXO-79119

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -6,7 +6,6 @@
     flat>
     <div class="application-body" @mouseover="hideOverlay">
       <div
-        v-show="initialized"
         class="pa-4"
         @dragover.prevent
         @drop.prevent
@@ -25,14 +24,14 @@
           :is-mobile="isMobile"
           :selected-documents="selectedDocuments"
           class="py-2" />
-        <div v-if="searchResult && !loading">
+        <div v-if="searchResult && !loading && initialized">
           <documents-no-result-body
             :is-mobile="isMobile"
             :show-extend-filter="showExtendFilter"
             :query="query" />
         </div>
         <div
-          v-else-if="!filesLoad && !loading && selectedView === 'folder' "
+          v-else-if="!filesLoad && !loading && selectedView === 'folder'  && initialized"
           @drop="dragFile"
           @dragover="startDrag">
           <documents-no-body-folder
@@ -40,7 +39,7 @@
             :is-mobile="isMobile" />
         </div>
         <div
-          v-else-if="!filesLoad && !loading"
+          v-else-if="!filesLoad && !loading && initialized"
           @drop="dragFile"
           @dragover="startDrag">
           <documents-no-body


### PR DESCRIPTION
Prior to this change, when a user opens the drives app, when there is lots of files to load, Then the page is empty. This commit display the header with loading bar until files are loaded.