### PR TITLE
fix: Fix application-ref of the documents application configured for spaceDocuments page template - EXO-79265

### DIFF
--- a/documents-webapp/src/main/webapp/WEB-INF/conf/documents/portal/template/pages/spaceDocuments/page.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/conf/documents/portal/template/pages/spaceDocuments/page.xml
@@ -25,7 +25,7 @@
       <column col-span="12">
         <portlet-application>
           <portlet>
-            <application-ref>documents</application-ref>
+            <application-ref>documents-portlet</application-ref>
             <portlet-ref>Documents</portlet-ref>
           </portlet>
           <title>Space Documents</title>


### PR DESCRIPTION

Prior to this change, when adding a new page based on the spaceDocuments page template, some options "show actions" and "show details" of "documents" portlet are not displayed due to the "documents" portlet skin not well loaded caused by the wrong configuration of application-ref <application-ref>documents</application-ref> instead of <application-ref>documents-portlet</application-ref>. After this commit, we ensure to fix the configured application-ref in order to load correctly the "documents" portlet skin.