### PR TITLE
fix: Filter by documents type not working - EXO-79302

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
@@ -238,9 +238,12 @@ public class DocumentSearchServiceConnector {
 
     List<String> types = filter.getMimeTypes();
     if (CollectionUtils.isEmpty(types) && StringUtils.isNotEmpty(filter.getFileTypes())) {
+      types = new ArrayList<>();
       for (String type : filter.getFileTypes().split(",")) {
         try {
-          types.add((String) this.getClass().getDeclaredField(type.toUpperCase()).get(0));
+          String fileType = this.getClass().getDeclaredField(type.toUpperCase()).get(0).toString();
+          fileType = fileType.replaceAll("^\"|\"$", "").toString();
+          types.add(fileType);
         } catch (Exception e) {
           LOG.warn("Cannot get list of mimeTypes related to type {}", type, e);
         }


### PR DESCRIPTION
Before this change, when in space upload multiple types of documents then filter by any available type, nothing changed in document display. To fix this problem, initialize the list types when it is null to be able to use the add method and remove the double side which is not necessary in the items of the list types. After this change, results displayed are related to used filter.