### PR TITLE
Feat : eXIP16: Avoid requesting to click twice to open a folder - exo-79767

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/TreeView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/TreeView.vue
@@ -118,6 +118,7 @@ export default {
               ));
             });
             item.children.push(...newItems[0].children);
+            this.currentFolderPathTab.push(item.id);
           }
           this.$root.$emit('tree-loading', false);
         });


### PR DESCRIPTION
This commit will avoid clicking twice to list subfolders the treeview