### PR TITLE
fix: 1.3 Clicking to thumbnail from detail drawer is not working - EXO-80064

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/document-info-drawer/components/DocumentInfoDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/document-info-drawer/components/DocumentInfoDrawer.vue
@@ -544,7 +544,6 @@ export default {
         return;
       }
       this.loading = true;
-      this.close();
       if (this.isFileEditable)  {
         if (this.file?.acl?.canEdit){
           this.openFileInEditor();
@@ -570,6 +569,7 @@ export default {
         document.dispatchEvent(new CustomEvent('open-attachments-preview', {detail: {'attachments': attachments,'id': this.fileId }}));
       }
       document.dispatchEvent(new CustomEvent('mark-attachment-as-viewed', {detail: {file: this.file}}));
+      this.close();
       this.loading = false;
     },
     openFileInEditor(mode) {


### PR DESCRIPTION
This commit will fix opening documents preview from the details drawer.