### PR TITLE
fix: Fix Opening Dialog using Right Click - EXIP-17

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -90,6 +90,8 @@
         <documents-download-drawer />
         <document-import-from-zip-drawer />
         <documents-offline-changes-reminder />
+        <open-in-desktop-credentials-dialog
+          ref="dialog" />
         <documents-actions-menu-mobile
           :is-mobile="isMobile"
           :current-view="selectedView"

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/OpenInDesktopCredentialsDialog.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/OpenInDesktopCredentialsDialog.vue
@@ -127,19 +127,10 @@
 </template>
 <script>
 export default {
-  props: {
-    value: {
-      type: Boolean,
-      default: false,
-    },
-    href: {
-      type: String,
-      default: null,
-    },
-  },
   data: () => ({
     dialog: false,
     userName: eXo.env.portal.userName,
+    href: null,
     password: null,
     passwordType: 'password',
     canCopy: false,
@@ -173,8 +164,15 @@ export default {
       this.$emit('input', this.dialog);
     },
   },
+  created() {
+    this.$root.$on('open-in-desktop-dialog', this.open);
+  },
+  beforeDestroy() {
+    this.$root.$off('open-in-desktop-dialog', this.open);
+  },
   methods: {
-    async open() {
+    async open(href) {
+      this.href = href;
       const resp = await fetch('/social/rest/digest', {credentials: 'include'});
       this.password = await resp.text();
       this.dialog = true;

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/OpenInDesktopMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/OpenInDesktopMenuAction.vue
@@ -21,17 +21,13 @@
     color="transparent"
     class="pa-2"
     flat
-    @click.prevent.stop="openDialog">
+    @click="openDialog">
     <v-icon
       size="16"
       class="px-1px me-1">
       {{ icon }}
     </v-icon>
     <span class="ps-1 text-body menu-text-color">{{ $t('documents.label.openInDesktop') }}</span>
-    <open-in-desktop-credentials-dialog
-      v-if="open"
-      ref="dialog"
-      :href="href" />
   </v-card>
 </template>
 <script>
@@ -42,9 +38,6 @@ export default {
       default: null,
     },
   },
-  data: () => ({
-    open: false,
-  }),
   computed: {
     iconExtension() {
       return this.$documentsIconsExtension?.[0]?.get?.(this.file?.mimeType);
@@ -60,10 +53,8 @@ export default {
     },
   },
   methods: {
-    async openDialog() {
-      this.open = true;
-      await this.$nextTick();
-      window.setTimeout(() => this.$refs?.dialog?.open?.(), 200);
+    openDialog() {
+      this.$root.$emit('open-in-desktop-dialog', this.href);
     },
   },
 };


### PR DESCRIPTION
Prior to this change, when opening the 'Open In Desktop' dialog using the right click, the open gets closed when clicking anywhere else, due to the fact that the Menu is destroyed at any click. This change will move the dialog into Main Area to avoid making the dialog display depends on Menu display.