### PR TITLE
fix: Technical label for Copy Link - EXO-80140

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/document-info-drawer/components/DocumentInfoDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/document-info-drawer/components/DocumentInfoDrawer.vue
@@ -24,7 +24,7 @@
             </v-btn>
           </div>
         </template>
-        <span>$t('documents.label.copy.link')</span>
+        <span>{{$t('documents.label.copy.link')}}</span>
       </v-tooltip>
       <v-tooltip bottom>
         <template #activator="{on, bind}">


### PR DESCRIPTION
This commit will fix label of copy link button tooltip in the info drawer.