### PR TITLE
fix: Fix displaying toggle button of document edit permission - EXO-79298

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsVisibilityDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsVisibilityDrawer.vue
@@ -548,6 +548,7 @@ export default {
     },
     open(file) {
       this.file = file;
+      this.allMembersCanEdit = this.file.acl.allMembersCanEdit;
       this.visibilityChoice = this.file.acl.visibilityChoice;
       this.publicDocumentAccess = null;
       this.publicDocumentAccessOptions = null;


### PR DESCRIPTION
Prior to this change, in the document manage access drawer, the toggle button of document edit permission is not displayed correctly and when switching it the save button still disabled.
This is due to the allMembersCanEdit value set to false when the drawer is opened. After this commit, we ensure to set the allMembersCanEdit value correctly with the stored value in order to
fix these issues.