### PR TITLE
fix: Breadcrumb in doc app refers to trash and deleted shortcut instead of correct path of original folder - EXO-75899 

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
@@ -406,4 +406,6 @@ public interface DocumentFileStorage {
   default List<Long> getDocumentCategoryIds(long spaceIdentityId, Identity aclIdentity) {
     throw new UnsupportedOperationException();
   }
+
+  void clearSymlinksNavHistory();
 }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDeleteFileStorageImpl.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDeleteFileStorageImpl.java
@@ -28,6 +28,7 @@ import javax.jcr.lock.LockException;
 import javax.jcr.version.VersionException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.documents.model.TrashElementNode;
 import org.exoplatform.documents.model.TrashElementNodeFilter;
 import org.picocontainer.Startable;
@@ -58,6 +59,7 @@ import org.exoplatform.services.security.Identity;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.metadata.favorite.FavoriteService;
 import org.exoplatform.social.metadata.favorite.model.Favorite;
+import org.exoplatform.documents.storage.jcr.JCRDocumentFileStorage;
 
 public class JCRDeleteFileStorageImpl implements JCRDeleteFileStorage, Startable {
 
@@ -152,8 +154,10 @@ public class JCRDeleteFileStorageImpl implements JCRDeleteFileStorage, Startable
                              long delay,
                              Identity identity,
                              long userIdentityId) throws ObjectNotFoundException, RepositoryException {
+    Node nodeToDelete = JCRDocumentsUtil.getNodeByIdentifier(session, documentId);
+    boolean isSymlink = nodeToDelete != null && nodeToDelete.isNodeType(NodeTypeConstants.EXO_SYMLINK);
     if (folderPath == null) {
-      folderPath = JCRDocumentsUtil.getNodeByIdentifier(session, documentId).getPath();
+      folderPath = nodeToDelete.getPath();
     }
     if (delay > 0) {
       documentsToDeleteQueue.put(documentId, String.valueOf(userIdentityId));
@@ -164,7 +168,7 @@ public class JCRDeleteFileStorageImpl implements JCRDeleteFileStorage, Startable
           RequestLifeCycle.begin(container);
           try {
             documentsToDeleteQueue.remove(documentId);
-            moveToTrash(finalFolderPath, session, userIdentityId, favorite, checkToMoveToTrash);
+            moveToTrash(finalFolderPath, session, userIdentityId, favorite, !isSymlink && checkToMoveToTrash);
           } catch (Exception e) {
             LOG.error("Error when deleting the document with path" + finalFolderPath, e);
           } finally {
@@ -173,7 +177,10 @@ public class JCRDeleteFileStorageImpl implements JCRDeleteFileStorage, Startable
         }
       }, delay, TimeUnit.SECONDS);
     } else {
-      moveToTrash(folderPath, session, userIdentityId, favorite, checkToMoveToTrash);
+      moveToTrash(folderPath, session, userIdentityId, favorite, !isSymlink && checkToMoveToTrash);
+    }
+    if (isSymlink) {
+      clearSymlinksNavHistory();
     }
   }
 
@@ -462,6 +469,11 @@ public class JCRDeleteFileStorageImpl implements JCRDeleteFileStorage, Startable
       node.removeMixin(NodeTypeConstants.EXO_RESTORE_LOCATION);
       node.save();
     }
+  }
+
+  private void clearSymlinksNavHistory() {
+    JCRDocumentFileStorage jCRDocumentFileStorage = CommonsUtils.getService(JCRDocumentFileStorage.class);
+    jCRDocumentFileStorage.clearSymlinksNavHistory();
   }
 
 }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -2416,5 +2416,9 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     QueryResult queryResult = jcrQuery.execute();
     return queryResult.getNodes().getSize() > 0;
   }
+  @Override
+  public void clearSymlinksNavHistory() {
+    symlinksNavHistory.clear();
+  }
 
 }


### PR DESCRIPTION
Before this change, when delete symlink from folder and open folder original then check breadcrumb, the breadcrumb of this folder appears trash. To fix this problem, when deleting the folder if it is symlink we delete the symlink and clear the symlinkNavHistory. After this change, the breadcrumb is displayed correctly.