### PR TITLE
fix: Remove padding before folders when using mobile - EXO-80054

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderView.vue
@@ -134,7 +134,7 @@
                     :is-search-result="isSearchResult"
                     :select-all-checked="selectAll"
                     :selected-documents="selectedDocuments"
-                    :class="header.value === 'name' && isXScreen && 'ms-10'" />
+                    :class="header.value === 'name' && isXScreen && 'ms-0'" />
                 </td>
               </tr>
             </template>


### PR DESCRIPTION
This commit will remove space before folders and aligned them to the plus button / tree view option