### PR TITLE
feat: Limit to 2 folders for mobile view of breadcrumb - EXO-80299

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -118,11 +118,13 @@ export default {
   computed: {
     documentsBreadcrumbToDisplay() {
       this.$root.$emit('documentsBreadcrumb',this.documentsBreadcrumb);
-      if (!this.documentsBreadcrumb || this.documentsBreadcrumb.length <= 4) {
+      const maxItemsToDisplay = this.isMobile ? 2 : 4;
+      const maxItemsCount = this.isMobile ? 2 : 3;
+      if (!this.documentsBreadcrumb || this.documentsBreadcrumb.length <= maxItemsToDisplay) {
         return this.documentsBreadcrumb || [];
       } else {
         const length = this.documentsBreadcrumb.length;
-        const documentsBreadcrumbToDisplay = [this.documentsBreadcrumb[0], ... this.documentsBreadcrumb.slice(length - 3, length)];
+        const documentsBreadcrumbToDisplay = [this.documentsBreadcrumb[0], ... this.documentsBreadcrumb.slice(length - maxItemsCount, length)];
         documentsBreadcrumbToDisplay[1] = Object.assign({}, documentsBreadcrumbToDisplay[1], {
           name: '...',
         });


### PR DESCRIPTION
This commit limits the breadcrumb itmes to two on mobile.