### PR TITLE
feat: eXIP19: Treeview must be expanded by default - EXO-80848

### DIFF
--- a/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
+++ b/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
@@ -400,7 +400,7 @@ documents.settings.filterListPerCategory=Per category
 documents.settings.filterExcludeCategory=Exclude category
 documents.settings.deleteCategory=Delete filtered category
 
-documents.settings.collapsedTreeView=Treeview is collapsed by default
+documents.settings.expendedTreeView=Treeview is extended by default
 
 documents.tree.title=Folder tree
 documents.tooltip.close.tree=Close folder tree

--- a/documents-webapp/src/main/resources/locale/portlet/Documents_fr.properties
+++ b/documents-webapp/src/main/resources/locale/portlet/Documents_fr.properties
@@ -400,7 +400,7 @@ documents.settings.filterListPerCategory=Par cat\u00e9gorie
 documents.settings.filterExcludeCategory=Exclure une cat\u00e9gorie
 documents.settings.deleteCategory=Supprimer la cat\u00e9gorie filtr\u00e9e
 
-documents.settings.collapsedTreeView=L'arborescence est r\u00e9duite par d\u00e9faut
+documents.settings.expendedTreeView=L'arborescence est d\u00e9velopp\u00e9e par d\u00e9faut
 
 documents.tree.title=Arborescence
 documents.tooltip.close.tree=Fermer l'arborescence

--- a/documents-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -28,7 +28,7 @@
           {
           "enabledViewList":[],
           "defaultView":"timeline",
-          "collapsedTreeView":true,
+          "expendedTreeView":true,
           "allowFilteringPerCategory":true,
           "categoryDepth":4,
           "categoryIds": [],

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="documentsBreadcrumbToDisplay.length" class="documents-breadcrumb-wrapper">
     <div class="documents-tree-items d-flex align-center">
-      <v-tooltip v-if="treeViewCollapsed || isMobile" bottom>
+      <v-tooltip v-if="!treeViewExpended || isMobile" bottom>
         <template #activator="{ on, attrs }">
           <v-btn
             icon
@@ -98,7 +98,7 @@ export default {
       type: Boolean,
       default: false,
     },
-    treeViewCollapsed: {
+    treeViewExpended: {
       type: String,
       default: null,
     },
@@ -295,7 +295,7 @@ export default {
         this.$root.$emit('documentsBreadcrumb',this.documentsBreadcrumb);
         this.$root.$emit('openTreeFolderDrawer',this.showHidden);
       } else {
-        this.$root.$emit('tree-view-collapse', false);
+        this.$root.$emit('tree-view-expend', true);
       }
     },
   }

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderView.vue
@@ -2,7 +2,7 @@
   <div class="d-flex">
     <component
       :is="isMobile ? 'folder-treeview-drawer' : 'folder-tree-view'"
-      :tree-view-collapsed="treeViewCollapsed"
+      :tree-view-expended="treeViewExpended"
       :is-mobile="isMobile"
       :folder-path="folderPath" />
     <v-card 
@@ -10,7 +10,7 @@
       class="width-full">
       <documents-breadcrumb
         :is-mobile="isMobile"
-        :tree-view-collapsed="treeViewCollapsed" />
+        :tree-view-expended="treeViewExpended" />
       <upload-overlay />
       <documents-no-body-folder
         v-if="items.length === 0"
@@ -258,7 +258,7 @@ export default {
     selectAll: false,
     showSelectAllInput: false,
     showSelectInputTimer: null,
-    treeViewCollapsed: false,
+    treeViewExpended: true,
     hoverTable: false,
   }),
   computed: {
@@ -334,14 +334,14 @@ export default {
     },
   },
   created() {
-    this.treeViewCollapsed =  localStorage.getItem('collapsedTreeView')!=null ? localStorage.getItem('collapsedTreeView') === 'true' : (this.$root.settings?.collapsedTreeView !== null ? this.$root.settings.collapsedTreeView : false);
+    this.treeViewExpended =  localStorage.getItem('expendedTreeView')!=null ? localStorage.getItem('expendedTreeView') === 'true' : (this.$root.settings?.expendedTreeView !== null ? this.$root.settings.expendedTreeView : true);
     this.$root.$on('select-all-documents', (value) => this.selectAll = value);
     this.$root.$on('reset-selections', () => this.selectAll = false);
     document.addEventListener(`extension-${this.headerExtensionApp}-${this.headerExtensionType}-updated`, this.refreshHeaderExtensions);
     this.refreshHeaderExtensions();
     this.setSortOptions(this.sortField, this.ascending);
     this.$root.$on('documents-filter', this.updateFilter);
-    this.$root.$on('tree-view-collapse', this.collapseTreeView );
+    this.$root.$on('tree-view-expend', this.extendTreeView );
     this.$root.$on('loading-documents', this.setLoading);
   },
   mounted(){
@@ -350,14 +350,14 @@ export default {
   },
   beforeDestroy() {
     this.$root.$off('documents-filter', this.updateFilter);
-    this.$root.$off('tree-view-collapse', this.collapseTreeView);
+    this.$root.$off('tree-view-expend', this.extendTreeView);
     this.$root.$off('openTreeFolderDrawer', this.folderTreeDrawer);
     this.$root.$off('loading-documents', this.setLoading);
   },
   methods: {
-    collapseTreeView(value) {
-      this.treeViewCollapsed = value;
-      localStorage.setItem('collapsedTreeView', value);
+    extendTreeView(value) {
+      this.treeViewExpended = value;
+      localStorage.setItem('expendedTreeView', value);
     },
     canEditFile(file) {
       return file?.acl?.canEdit;

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/FolderTreeView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/FolderTreeView.vue
@@ -19,13 +19,13 @@
 
 <template>
   <v-card 
-    v-if="!treeViewCollapsed"
+    v-if="treeViewExpended"
     flat
     :loading="loading"
     width="310"
     class="border-right-color expand-transition-enter-active">
     <v-card-title class="pa-0 border-bottom-color"> 
-      <span v-if="!treeViewCollapsed" class="text-header">{{ $t('documents.tree.title') }}</span>
+      <span v-if="!treeViewExpended" class="text-header">{{ $t('documents.tree.title') }}</span>
       <v-spacer />
       <v-tooltip bottom>
         <template #activator="{ on, attrs }">
@@ -33,7 +33,7 @@
             icon
             v-bind="attrs"
             v-on="on"
-            @click.stop.prevent="$root.$emit('tree-view-collapse', true)">
+            @click.stop.prevent="$root.$emit('tree-view-expend', false)">
             <img
               src="/social/images/sidebar.svg"
               class="icon-default-color mb-1"
@@ -63,7 +63,7 @@ export default {
       type: String,
       default: null
     },
-    treeViewCollapsed: {
+    treeViewExpended: {
       type: String,
       default: null
     },

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/setting/DocumentSettingsDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/setting/DocumentSettingsDrawer.vue
@@ -44,10 +44,10 @@
             :disabled="!view.enabled" />
         </v-radio-group>
         <div class="d-flex align-center text-start">
-          <div>{{ $t('documents.settings.collapsedTreeView') }}</div>
+          <div>{{ $t('documents.settings.expendedTreeView') }}</div>
           <v-spacer />
           <v-switch
-            v-model="settings.collapsedTreeView"
+            v-model="settings.expendedTreeView"
             class="ma-0 width-fit-content" />
         </div>
         <div class="mt-4 mb-2 text-header">{{ $t('documents.settings.filterOptions') }}</div>
@@ -267,7 +267,7 @@ export default {
         this.settings.enabledViewList = this.viewList.map(item => item.id);
       }
       this.settings.defaultView = this.$root.settings.defaultView || this.settings.enabledViewList[0]?.id;
-      this.settings.collapsedTreeView = this.$root.settings.collapsedTreeView !== null ? this.$root.settings.collapsedTreeView : true;
+      this.settings.expendedTreeView = this.$root.settings.expendedTreeView !== null ? this.$root.settings.expendedTreeView : true;
       this.$refs.drawer.open();
     },
     close() {


### PR DESCRIPTION
This commit will update the default documents app settings to make the treeview expended by default when the switch is on.