### PR TITLE
fix: Fix Display of Public Download UI - EXO-80912

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/controller/PublicAccessDownloadDocumentHandler.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/controller/PublicAccessDownloadDocumentHandler.java
@@ -21,6 +21,7 @@ import org.exoplatform.documents.model.PublicDocumentAccess;
 import org.exoplatform.documents.model.DownloadItem;
 import org.exoplatform.documents.service.PublicDocumentAccessService;
 import org.exoplatform.documents.service.ExternalDownloadService;
+import org.exoplatform.portal.application.localization.HttpRequestWrapper;
 import org.exoplatform.portal.branding.BrandingService;
 import org.exoplatform.portal.resource.SkinService;
 import org.exoplatform.services.resources.LocaleConfigService;
@@ -31,6 +32,7 @@ import org.exoplatform.web.controller.QualifiedName;
 import org.json.JSONObject;
 import org.exoplatform.container.xml.InitParams;
 
+import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -118,7 +120,13 @@ public class PublicAccessDownloadDocumentHandler extends JspBasedWebHandler {
                           Collections.emptyList(),
                           Collections.singletonList("portal/login"),
                           params -> extendApplicationParameters(params, parameters));
-    servletContext.getRequestDispatcher(publicDownloadJspPath).include(request, response);
+    RequestDispatcher requestDispatcher = servletContext.getRequestDispatcher(publicDownloadJspPath);
+    requestDispatcher.include(new HttpRequestWrapper(request) {
+      @Override
+      public String getContextPath() {
+        return "/documents-portlet";
+      }
+    }, response);
     return true;
   }
 }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -453,11 +453,7 @@ public class JCRDocumentsUtil {
       }
     }
 
-    if (node.hasProperty(NodeTypeConstants.EXO_TITLE)) {
-      documentNode.setName(node.getProperty(NodeTypeConstants.EXO_TITLE).getString());
-    } else {
-      documentNode.setName(node.getName());
-    }
+    documentNode.setName(getTitle(node));
     if (node.hasProperty(NodeTypeConstants.EXO_DATE_CREATED)) {
       long createdDate = node.getProperty(NodeTypeConstants.EXO_DATE_CREATED)
                              .getDate()
@@ -821,11 +817,7 @@ public class JCRDocumentsUtil {
     FileVersion versionFileNode = new FileVersion();
     String currentVersionName = node.getBaseVersion().getName();
     Node frozen = version.getNode(NodeTypeConstants.JCR_FROZEN_NODE);
-    if (node.hasProperty(NodeTypeConstants.EXO_TITLE)) {
-      versionFileNode.setTitle(Utils.getStringProperty(node, NodeTypeConstants.EXO_TITLE));
-    } else {
-      versionFileNode.setTitle(node.getName());
-    }
+    versionFileNode.setTitle(getTitle(node));
     String userName = frozen.getProperty(NodeTypeConstants.EXO_LAST_MODIFIER).getValue().getString();
     org.exoplatform.social.core.identity.model.Identity
         identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, userName);
@@ -909,7 +901,7 @@ public class JCRDocumentsUtil {
       }
     }
     return new DownloadItem(((NodeImpl) node).getIdentifier(),
-                            Utils.getStringProperty(node, NodeTypeConstants.EXO_TITLE),
+                            getTitle(node),
                             byteArrayOutputStream,
                             mimeType);
   }
@@ -1049,11 +1041,7 @@ public class JCRDocumentsUtil {
 
   public static void retrieveTrashElementProperties(Node node, TrashElementNode trashElementNode) throws RepositoryException {
     trashElementNode.setId(((NodeImpl) node).getIdentifier());
-    if (node.hasProperty(NodeTypeConstants.EXO_TITLE)) {
-      trashElementNode.setName(node.getProperty(NodeTypeConstants.EXO_TITLE).getString());
-    } else {
-      trashElementNode.setName(node.getName());
-    }
+    trashElementNode.setName(getTitle(node));
     trashElementNode.setPath(node.getPath());
     if (node.hasProperty(NodeTypeConstants.EXO_LAST_MODIFIED_DATE)) {
       Node nodeToModify = node;
@@ -1088,4 +1076,17 @@ public class JCRDocumentsUtil {
       }
     }
   }
+
+  public static String getTitle(Node node) throws RepositoryException {
+    String title = null;
+    if (node.hasProperty(NodeTypeConstants.EXO_TITLE)) {
+      title = node.getProperty(NodeTypeConstants.EXO_TITLE).getString();
+    }
+    if (StringUtils.isBlank(title)) {
+      return node.getName();
+    } else {
+      return title;
+    }
+  }
+
 }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -1050,6 +1050,8 @@ public class JCRDocumentFileStorageTest {
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toNodes(any(), any(), any(), any(), any(), anyBoolean(), any()))
                       .thenCallRealMethod();
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toFolderNode(any(), any(), any(), any(), any())).thenCallRealMethod();
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getTitle(any()))
+                      .thenCallRealMethod();
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.retrieveFileProperties(any(), any(), any(), any(), any()))
                       .thenCallRealMethod();
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toFileNode(any(IdentityManager.class),
@@ -1174,6 +1176,7 @@ public class JCRDocumentFileStorageTest {
     Property createdDateProperty = mock(Property.class);
     when(createdDateProperty.getDate()).thenReturn(createdDate);
     when(folderMock.getProperty(NodeTypeConstants.EXO_DATE_CREATED)).thenReturn(createdDateProperty);
+    when(folderMock.getName()).thenReturn(name);
     when(getNodeByIdentifier(session, name + "Identifier")).thenReturn(folderMock);
     when(getNodeByIdentifier(null, name + "Identifier")).thenReturn(folderMock);
     return folderMock;

--- a/documents-webapp/src/main/webapp/WEB-INF/jsp/download_document.jsp
+++ b/documents-webapp/src/main/webapp/WEB-INF/jsp/download_document.jsp
@@ -30,7 +30,7 @@
     response.setCharacterEncoding("UTF-8");
     response.setContentType("text/html; charset=UTF-8");
 
-    String contextPath = request.getContextPath();
+    String contextPath = "/portal";
 
     // Styles
     List<String> skinUrls = (List<String>) request.getAttribute("skinUrls");

--- a/documents-webapp/src/main/webapp/vue-app/attachment-integration/main.js
+++ b/documents-webapp/src/main/webapp/vue-app/attachment-integration/main.js
@@ -9,7 +9,7 @@ const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
 
 // should expose the locale resources as REST API
 
-const url = `/portal/rest/i18n/bundle/locale.portlet.attachments-${lang}.json`;
+const url = `/documents-portlet/i18n/locale.portlet.attachments?lang=${lang}`;
 
 // get overridden components if exist
 if (extensionRegistry) {

--- a/documents-webapp/src/main/webapp/vue-app/attachment/main.js
+++ b/documents-webapp/src/main/webapp/vue-app/attachment/main.js
@@ -18,7 +18,7 @@ const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
 
 // should expose the locale resources as REST API
 
-const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.attachments-${lang}.json`;
+const url = `/documents-portlet/i18n/locale.portlet.attachments?lang=${lang}`;
 
 // get overridden components if exist
 if (extensionRegistry) {

--- a/documents-webapp/src/main/webapp/vue-app/document-info-drawer/main.js
+++ b/documents-webapp/src/main/webapp/vue-app/document-info-drawer/main.js
@@ -50,8 +50,7 @@ const appId = 'documentInfoDrawer';
 const lang = eXo?.env?.portal?.language || 'en';
 
 //should expose the locale ressources as REST API
-const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Documents-${lang}.json`;
-
+const url = `/documents-portlet/i18n/locale.portlet.Documents?lang=${lang}`;
 
 export function init(event) {
   if (!document.querySelector(`#${appId}`)) {

--- a/documents-webapp/src/main/webapp/vue-app/documents-size-gadget/main.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents-size-gadget/main.js
@@ -41,7 +41,7 @@ const appId = 'DocumentsSizeGadget';
 const lang = eXo?.env?.portal?.language || 'en';
 
 //should expose the locale ressources as REST API
-const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Documents-${lang}.json`;
+const url = `/documents-portlet/i18n/locale.portlet.Documents?lang=${lang}`;
 
 export function init() {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {

--- a/documents-webapp/src/main/webapp/vue-app/download-document/main.js
+++ b/documents-webapp/src/main/webapp/vue-app/download-document/main.js
@@ -44,9 +44,9 @@ const lang = eXo?.env?.portal?.language || 'en';
 
 //should expose the locale ressources as REST API
 const urls = [
-  `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Documents-${lang}.json`,
-  `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Login-${lang}.json`,
-  `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portal.login-${lang}.json`
+  `/documents-portlet/i18n/locale.portlet.Documents?lang=${lang}`,
+  `/social/i18n/locale.portlet.Login?lang=${lang}`,
+  `/social/i18n/locale.portal.login?lang=${lang}`
 ];
 
 export function init(params) {

--- a/documents-webapp/src/main/webapp/vue-app/legacy-composer-attachments/main.js
+++ b/documents-webapp/src/main/webapp/vue-app/legacy-composer-attachments/main.js
@@ -9,7 +9,7 @@ const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
 
 // should expose the locale resources as REST API
 
-const url = `/portal/rest/i18n/bundle/locale.portlet.attachments-${lang}.json`;
+const url = `/documents-portlet/i18n/locale.portlet.attachments?lang=${lang}`;
 
 // get overridden components if exist
 if (extensionRegistry) {

--- a/documents-webapp/src/main/webapp/vue-app/notification-extension/main.js
+++ b/documents-webapp/src/main/webapp/vue-app/notification-extension/main.js
@@ -19,7 +19,7 @@ import './initComponents.js';
 import './extensions.js';
 
 const lang = eXo.env.portal.language;
-const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.notification.DocumentsNotification-${lang}.json`;
+const url = `/documents-portlet/i18n/locale.notification.DocumentsNotification?lang=${lang}`;
 
 export function init() {
   return exoi18n.loadLanguageAsync(lang, url)

--- a/documents-webapp/src/main/webapp/vue-app/trash-management/main.js
+++ b/documents-webapp/src/main/webapp/vue-app/trash-management/main.js
@@ -46,7 +46,7 @@ const appId = 'TrashManagement';
 const lang = eXo?.env?.portal?.language || 'en';
 
 //should expose the locale resources as REST API
-const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.TrashManagement-${lang}.json`;
+const url = `/documents-portlet/i18n/locale.portlet.TrashManagement?lang=${lang}`;
 
 export function init() {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {


### PR DESCRIPTION
Prior to this change, when attempting to display the Public Download UI, an error is thrown by spring Filters about 'Different' context path from originating request ('/portal' to '/documents-portlet'). This change will wrap the request to change the context path before including the jsp which displays the download page.