### PR TITLE
feat: Make WebDav OS System files hiddenable - EXO-80922

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/webdav/model/constant/FileConstants.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/webdav/model/constant/FileConstants.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2025 eXo Platform SAS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <gnu.org/licenses>.
+ */
+package org.exoplatform.documents.webdav.model.constant;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class FileConstants {
+
+  private FileConstants() {
+    // Utils class
+  }
+
+  public static final List<String> BLOCKED_FILES         = Arrays.asList("\\.DS_Store",                                                   // NOSONAR
+                                                                         "\\._.*",
+                                                                         "\\.Spotlight-V100",
+                                                                         "\\.Trashes",
+                                                                         "\\.fseventsd",
+                                                                         "\\.TemporaryItems",
+                                                                         "\\.VolumeIcon\\.icns",
+                                                                         "\\.DocumentRevisions-V100",
+                                                                         "Thumbs\\.db",
+                                                                         "ehthumbs\\.db",
+                                                                         "desktop\\.ini",
+                                                                         "\\.Trash-.*",
+                                                                         "\\.lnk",
+                                                                         "\\.localized",
+                                                                         "\\.directory",
+                                                                         "\\.hidden",
+                                                                         "\\.cache",
+                                                                         "\\.config",
+                                                                         "lost\\+found",
+                                                                         "pagefile.sys",
+                                                                         "hiberfil.sys",
+                                                                         "\\$Recycle\\.[Bb]in",
+                                                                         "System Volume Information",
+                                                                         "\\.nfs.*",
+                                                                         "\\.X0-lock",
+                                                                         "\\.Xauthority",
+                                                                         "\\.gvfs",
+                                                                         "\\.bash_history",
+                                                                         "\\.zsh_history");
+
+  public static final Pattern      BLOCKED_FILES_PATTERN = Pattern.compile(String.format("(?i)(?:^|/)(?:%s)$",
+                                                                                         BLOCKED_FILES.stream()
+                                                                                                      .collect(Collectors.joining("|"))));
+
+}

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandler.java
@@ -108,8 +108,10 @@ import org.exoplatform.documents.webdav.model.WebDavException;
 import org.exoplatform.documents.webdav.model.WebDavFileDownload;
 import org.exoplatform.documents.webdav.model.WebDavItem;
 import org.exoplatform.documents.webdav.model.WebDavItemProperty;
+import org.exoplatform.documents.webdav.model.constant.FileConstants;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
@@ -119,18 +121,22 @@ import lombok.SneakyThrows;
 @Component
 public class WebdavReadCommandHandler {
 
-  private static final String     VERSION_QUERY_PARAM = "?version=";
+  private static final String     VERSION_QUERY_PARAM     = "?version=";
 
-  private static final String     IDENTITY_ID_PREFIX  = "%20(";
+  private static final String     IDENTITY_ID_PREFIX      = "%20(";
 
-  private static final String     IDENTITY_ID_SUFFIX  = ")";
+  private static final String     IDENTITY_ID_SUFFIX      = ")";
 
-  private static final Set<QName> SEARCH_PROPERTIES   = new HashSet<>(Arrays.asList(DISPLAYNAME,
-                                                                                    RESOURCETYPE,
-                                                                                    CREATIONDATE,
-                                                                                    GETLASTMODIFIED,
-                                                                                    GETCONTENTLENGTH,
-                                                                                    GETCONTENTTYPE));
+  private static final String     EXO_HIDDEN_PROPERTY     = "exo:hidden";
+
+  private static final String     WINDOWS_HIDDEN_PROPERTY = "lp1:win32FileAttributes";
+
+  private static final Set<QName> SEARCH_PROPERTIES       = new HashSet<>(Arrays.asList(DISPLAYNAME,
+                                                                                        RESOURCETYPE,
+                                                                                        CREATIONDATE,
+                                                                                        GETLASTMODIFIED,
+                                                                                        GETCONTENTLENGTH,
+                                                                                        GETCONTENTTYPE));
 
   private PathCommandHandler      pathCommandHandler;
 
@@ -368,6 +374,9 @@ public class WebdavReadCommandHandler {
                          boolean requestPropertyNamesOnly,
                          int depth,
                          String identityBaseUri) {
+    if (FileConstants.BLOCKED_FILES_PATTERN.matcher(node.getName()).find()) {
+      return null;
+    }
     WebDavItem result = new WebDavItem();
     result.setFile(isFile(node));
     result.setIdentifier(new URI(getNodeUri(node, identityBaseJcrPath, identityBaseUri)));
@@ -413,6 +422,7 @@ public class WebdavReadCommandHandler {
                                          requestPropertyNamesOnly,
                                          depth - 1,
                                          identityBaseUri))
+                   .filter(Objects::nonNull)
                    .forEach(webDavItem::addChild);
     }
   }
@@ -638,8 +648,11 @@ public class WebdavReadCommandHandler {
       List<String> memberSpacesIds = spaceService.getMemberSpacesIds(username, 0, memberSpacesSize);
       for (String spaceId : memberSpacesIds) {
         Space space = spaceService.getSpaceById(spaceId);
+        Identity spaceIdentity = identityManager.getOrCreateSpaceIdentity(space.getPrettyName());
+        // Ensure that old Spaces considers using the Space Display Name
+        spaceIdentity.getProfile().setProperty(Profile.FULL_NAME, space.getDisplayName());
         WebDavItem webDavIdentityItem = getWebDavIdentityItem(session,
-                                                              identityManager.getOrCreateSpaceIdentity(space.getPrettyName()),
+                                                              spaceIdentity,
                                                               requestedPropertyNames,
                                                               requestPropertyNamesOnly,
                                                               depth,
@@ -675,6 +688,9 @@ public class WebdavReadCommandHandler {
                                            boolean requestPropertyNamesOnly,
                                            int depth,
                                            String baseUri) {
+    if (StringUtils.isBlank(displayName)) {
+      displayName = getDisplayName(identityId);
+    }
     WebDavItem identityWebDavItem = new WebDavItem();
     String identityBaseUri = String.format(IDENTITY_PATHS_FORMAT,
                                            baseUri,
@@ -714,6 +730,7 @@ public class WebdavReadCommandHandler {
     }
   }
 
+  @SneakyThrows
   private void addProperties(WebDavItem result,
                              Node node,
                              Set<QName> requestedPropertyNames,
@@ -726,6 +743,12 @@ public class WebdavReadCommandHandler {
                                                        getWebDavPropertyNoException(node, result.getIdentifier(), null, name))
                  .filter(Objects::nonNull)
                  .forEach(result::addProperty);
+    if (node.isNodeType(EXO_HIDDENABLE)) {
+      // Windows
+      result.addProperty(new WebDavItemProperty(WINDOWS_HIDDEN_PROPERTY, "2"));
+      // Custom Property
+      result.addProperty(new WebDavItemProperty(EXO_HIDDEN_PROPERTY, "1"));
+    }
   }
 
   @SneakyThrows
@@ -806,6 +829,16 @@ public class WebdavReadCommandHandler {
   private String encodeUrlString(String s) {
     return URLEncoder.encode(s, StandardCharsets.UTF_8)
                      .replace("+", "%20");
+  }
+
+  private String getDisplayName(long identityId) {
+    Identity identity = identityManager.getIdentity(identityId);
+    if (identity.isSpace()) {
+      Space space = spaceService.getSpaceByPrettyName(identity.getRemoteId());
+      return space.getDisplayName();
+    } else {
+      return identity.getProfile().getFullName();
+    }
   }
 
 }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavWriteCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavWriteCommandHandler.java
@@ -179,7 +179,7 @@ public class WebdavWriteCommandHandler {
       if (node.canAddMixin(VersionHistoryUtils.MIX_VERSIONABLE)) {
         node.addMixin(VersionHistoryUtils.MIX_VERSIONABLE);
       }
-      if(node.canAddMixin(EXO_SORTABLE)) {
+      if (node.canAddMixin(EXO_SORTABLE)) {
         node.addMixin(EXO_SORTABLE);
       }
       node.setProperty(EXO_NAME, node.getName());

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandlerTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandlerTest.java
@@ -129,6 +129,7 @@ public class WebdavReadCommandHandlerTest {
     when(session.getItem("/jcr/path")).thenReturn(node);
 
     when(node.isNodeType(anyString())).thenReturn(false); // default
+    when(node.getName()).thenReturn("path");
     when(node.getNode("jcr:content")).thenReturn(contentNode);
     when(contentNode.hasProperty(anyString())).thenReturn(true);
     when(contentNode.getProperty(anyString())).thenReturn(property);

--- a/documents-webdav-webapp/src/main/java/org/exoplatform/documents/webdav/plugin/impl/GetWebDavHandler.java
+++ b/documents-webdav-webapp/src/main/java/org/exoplatform/documents/webdav/plugin/impl/GetWebDavHandler.java
@@ -135,8 +135,8 @@ public class GetWebDavHandler extends WebDavHttpMethodPlugin implements ServletC
           setAcceptRangesHeader(httpResponse);
           setContentTypeHeader(httpResponse, contentType);
           setCacheHeaders(httpResponse, lastModifiedDate);
-          writeResponseRange(httpResponse, fileDownload, range);
           httpResponse.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
+          writeResponseRange(httpResponse, fileDownload, range);
         }
       } else {
         // Requested a set of ranges
@@ -144,7 +144,6 @@ public class GetWebDavHandler extends WebDavHttpMethodPlugin implements ServletC
         httpResponse.setDateHeader(HttpHeaders.LAST_MODIFIED, lastModifiedDate);
         setAcceptRangesHeader(httpResponse);
         writeResponseRanges(httpResponse, fileDownload, ranges);
-        httpResponse.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
       }
     } else {
       // Folder listing
@@ -199,6 +198,7 @@ public class GetWebDavHandler extends WebDavHttpMethodPlugin implements ServletC
         httpResponse.setHeader(ExtHttpHeaders.CONTENTRANGE, "bytes */" + contentLength);
         httpResponse.setStatus(HttpServletResponse.SC_REQUESTED_RANGE_NOT_SATISFIABLE);
       } else {
+        httpResponse.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
         writeResponseRanges(inputStream, outputStream, contentLength, contentType, ranges);
       }
     }
@@ -249,9 +249,7 @@ public class GetWebDavHandler extends WebDavHttpMethodPlugin implements ServletC
     httpResponse.setHeader("Access-Control-Allow-Origin", "*");
     httpResponse.setHeader("Access-Control-Allow-Credentials", "true");
     httpResponse.setHeader("Access-Control-Allow-Methods", ALLOW_METHODS);
-    httpResponse.setHeader("Access-Control-Allow-Headers",
-                           "Overwrite, Destination, Content-Type, Depth, User-Agent, Translate, Range, Content-Range," +
-                               " Timeout, X-File-Size, X-Requested-With, If-Modified-Since, X-File-Name, Cache-Control, Location, Lock-Token, If");
+    httpResponse.setHeader("Access-Control-Allow-Headers", "*");
     httpResponse.setHeader("Access-Control-Expose-Header", "DAV, content-length, Allow");
     httpResponse.setHeader("Access-Control-Max-Age", "3600");
   }

--- a/documents-webdav-webapp/src/main/java/org/exoplatform/documents/webdav/plugin/impl/PropFindWebDavHandler.java
+++ b/documents-webdav-webapp/src/main/java/org/exoplatform/documents/webdav/plugin/impl/PropFindWebDavHandler.java
@@ -66,6 +66,7 @@ public class PropFindWebDavHandler extends WebDavHttpMethodPlugin {
     String propRequestType = getRequestPropertyType(body);
     if (!ALLOWED_REQUEST_PROP_TYPES.contains(propRequestType)) {
       httpResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      return;
     }
 
     boolean requestPropertyNamesOnly = REQUEST_SINGLE_PROP_NAME.equals(propRequestType);

--- a/documents-webdav-webapp/src/main/java/org/exoplatform/documents/webdav/rest/WebDavRest.java
+++ b/documents-webdav-webapp/src/main/java/org/exoplatform/documents/webdav/rest/WebDavRest.java
@@ -16,16 +16,13 @@
 */
 package org.exoplatform.documents.webdav.rest;
 
+import static org.exoplatform.documents.webdav.model.constant.FileConstants.BLOCKED_FILES_PATTERN;
 import static org.exoplatform.documents.webdav.plugin.WebDavHttpMethodPlugin.CONTEXT_PATH;
 import static org.exoplatform.documents.webdav.plugin.WebDavHttpMethodPlugin.CONTEXT_PATH_ROOT;
 import static org.exoplatform.documents.webdav.plugin.WebDavHttpMethodPlugin.CONTEXT_PATH_SINGLE_DRIVE;
 import static org.exoplatform.documents.webdav.plugin.WebDavHttpMethodPlugin.CONTEXT_PATH_SINGLE_DRIVE_ROOT;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -54,29 +51,6 @@ import lombok.SneakyThrows;
 public class WebDavRest {
 
   protected static final Log         LOG                   = ExoLogger.getLogger(WebDavRest.class);
-
-  private static final List<String>  BLOCKED_FILES         = Arrays.asList("\\.DS_Store",
-                                                                           "\\._.*",
-                                                                           "\\.Spotlight-V100",
-                                                                           "\\.Trashes",
-                                                                           "\\.fseventsd",
-                                                                           "\\.TemporaryItems",
-                                                                           "\\.VolumeIcon\\.icns",
-                                                                           "\\.DocumentRevisions-V100",
-                                                                           "Thumbs\\.db",
-                                                                           "ehthumbs\\.db",
-                                                                           "desktop\\.ini",
-                                                                           "\\.Trash-.*",
-                                                                           "\\.nfs.*",
-                                                                           "\\.X0-lock",
-                                                                           "\\.Xauthority",
-                                                                           "\\.gvfs",
-                                                                           "\\.bash_history",
-                                                                           "\\.zsh_history");
-
-  private static final Pattern       BLOCKED_FILES_PATTERN = Pattern.compile(String.format("(?i)(?:^|/)(?:%s)$",
-                                                                                           BLOCKED_FILES.stream()
-                                                                                                        .collect(Collectors.joining("|"))));
 
   @Autowired
   private PortalContainer            container;


### PR DESCRIPTION
Prior to this change, the Hidden JCR files wasn't hidden when mounting a WebDav folder in Windows OS. This change will allow to hide items in mounted WebDav Drive when it's hidden in JCR as well.