### PR TITLE
feat: eXIP19: Display of the breadcrumb when browsing space drives - EXO-80858

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/model/FullTreeItem.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/model/FullTreeItem.java
@@ -31,4 +31,5 @@ public class FullTreeItem {
   private String                                path;
   private List<FullTreeItem>                    children;
   private boolean                               hidden;
+  private String                                ownerId;
 }

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -230,7 +230,18 @@ public class EntityBuilder {
 
   public static List<FullTreeItemEntity> toFullTreeItemEntities(List<FullTreeItem> folders, long ownerId) {
     List<FullTreeItemEntity>  brList = new ArrayList<>();
-    brList = folders.stream().map(document -> new FullTreeItemEntity(document.getId(), document.getName(), document.getPath(), ownerId,document.getChildren())).collect(Collectors.toList());
+    brList = folders.stream()
+            .map(document -> {
+              document.getChildren().forEach(child -> child.setOwnerId(String.valueOf(ownerId)));
+              return new FullTreeItemEntity(
+                      document.getId(),
+                      document.getName(),
+                      document.getPath(),
+                      ownerId,
+                      document.getChildren()
+              );
+            })
+            .collect(Collectors.toList());
     Collections.reverse(brList);
     return brList;
   }

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/DocumentFileRestTest.java
@@ -800,7 +800,7 @@ public class DocumentFileRestTest {
     mockRestUtils().when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(currentOwnerId);
 
     List<FullTreeItem> children = new ArrayList<>();
-    FullTreeItem fullTreeItem = new FullTreeItem("11111222", "test", "path", null,false);
+    FullTreeItem fullTreeItem = new FullTreeItem("11111222", "test", "path", null,false,null);
     children.add(fullTreeItem);
 
     org.exoplatform.services.security.Identity userID = new org.exoplatform.services.security.Identity(username);

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -731,7 +731,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         String nodeName = node.hasProperty(NodeTypeConstants.EXO_TITLE) ? node.getProperty(NodeTypeConstants.EXO_TITLE).getString() : node.getName();
         List<FullTreeItem> children = getAllFolderInNode(node, session, destinationNode, withChildren, showHidden);
 
-        parents.add(new FullTreeItem(((NodeImpl) node).getIdentifier(), nodeName, node.getPath(), children, showHidden && node.isNodeType(NodeTypeConstants.EXO_HIDDENABLE)));
+        parents.add(new FullTreeItem(((NodeImpl) node).getIdentifier(), nodeName, node.getPath(), children, showHidden && node.isNodeType(NodeTypeConstants.EXO_HIDDENABLE), null));
       }
     } catch (Exception e) {
       throw new IllegalStateException("Error retrieving tree folder'" + folderId, e);
@@ -774,7 +774,8 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
                                                nodeName,
                                                childNode.getPath(),
                                                folderChildListNodes,
-                                               showHidden && childNode.isNodeType(NodeTypeConstants.EXO_HIDDENABLE)));
+                                               showHidden && childNode.isNodeType(NodeTypeConstants.EXO_HIDDENABLE),
+                                               null));
         }
 
       }

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -114,6 +114,7 @@ export default {
     folderPath: '',
     currentFolderPath: '',
     showHidden: false,
+    drives: [],
   }),
   computed: {
     documentsBreadcrumbToDisplay() {
@@ -143,6 +144,9 @@ export default {
     this.$root.$on('document-show-drives', this.showDrives);
     this.$root.$on('set-advanced-filter', advancedFilter => {
       this.showHidden = advancedFilter.showHidden;
+    });
+    this.$root.$on('add-drives', drives => {
+      this.drives.push(...drives);
     });
   },
   beforeDestroy() {
@@ -221,7 +225,13 @@ export default {
       if (name==='Private'){
         return this.$t('documents.label.userHomeDocuments');
       } else if (name==='Documents'){
-        return this.driveName && this.$root.ownerId !== eXo.env.portal.userIdentityId ? this.driveName : this.$t('documents.label.spaceHomeDocuments');
+        if (this.$root.ownerId !== eXo.env.portal.userIdentityId){
+          const drive = this.drives.find(drive => drive.identityId === this.$root.ownerId);
+          if (drive) {
+            return drive.name;
+          }
+        }
+        return this.$t('documents.label.spaceHomeDocuments');
       }
       return name;
     },

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/FolderTreeView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/FolderTreeView.vue
@@ -151,6 +151,7 @@ export default {
             drive: true,
             children: [],
           }));
+          this.$root.$emit('add-drives', spacesList);
           if (data.size > this.drivesLimit) {
             spacesList.push({
               id: 'load_more',

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/TreeView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/TreeView.vue
@@ -181,19 +181,18 @@ export default {
           this.$root.ownerId = eXo.env.portal.userIdentityId;
           this.$root.spaceId = null;
           this.$root.driveView = false;
-        } 
+        } else if (folder.ownerId) {
+          this.$root.ownerId = folder.ownerId;
+        }
         this.$root.$emit('open-folder', folder);
       }
     },
     fetchChildren (item) {
       this.$root.$emit('tree-loading', true);
       let folderId = item.id;
-      if (item.identityId) {
-        this.$root.ownerId = item.identityId;
-        folderId = null;
-      }
+      folderId = null;
       this.$documentFileService
-        .getFullTreeData(this.$root.ownerId,folderId).then(data => {
+        .getFullTreeData(item.identityId,folderId).then(data => {
           if (data) {
             const newItems = data.map(obj => {
               return JSON.parse(JSON.stringify(obj, (key, value) => 
@@ -251,6 +250,7 @@ export default {
             drive: true,
             children: [],
           }));
+          this.$root.$emit('add-drives', newChildren);
           if (data.size > this.limit) {
             newChildren.push({
               id: 'load_more',
@@ -260,7 +260,7 @@ export default {
               limit: this.limit,
             });
           }  
-          this.addChildren(this.items, 'space_drives', newChildren);  
+          this.addChildren(this.items, 'space_drives', newChildren);
         }
         this.$root.$emit('document-show-drives', this.getNodeChildrenById('space_drives'));
       });    
@@ -297,8 +297,16 @@ export default {
       }
       return null; // Node not found
     },
-
-
+    
+    getDriveByIdentityId(id, nodes = this.items) {
+      const drivesNode = nodes.find(item => item.drives === true);
+      if (drivesNode) {
+        const drive = drivesNode.children.find(item => item.drive === true && item.identityId === id);
+        return drive || null;
+      } else {
+        return null;
+      }
+    },
   },
 };
 </script>


### PR DESCRIPTION
This commit will fix the home space name on the breadcrumb when browsing using the treeview.