### PR TITLE
fix: TranslationService API with Object Id of Type String instead of Long - MEED-9632 - Meeds-io/meeds#3608

### DIFF
--- a/documents-webapp/src/main/java/org/exoplatform/documents/portlet/DocumentGadgetPortlet.java
+++ b/documents-webapp/src/main/java/org/exoplatform/documents/portlet/DocumentGadgetPortlet.java
@@ -24,19 +24,41 @@ import javax.portlet.ActionResponse;
 import javax.portlet.PortletConfig;
 import javax.portlet.PortletException;
 import javax.portlet.PortletPreferences;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
 
 import org.apache.commons.lang3.StringUtils;
 
+import org.exoplatform.container.ExoContainerContext;
+
 import io.meeds.social.portlet.CMSPortlet;
+import io.meeds.social.translation.service.TranslationService;
 
 public class DocumentGadgetPortlet extends CMSPortlet {
 
-  private static final String OBJECT_TYPE = "documentGadget";
+  private static final String HEADER_FIELD_NAME = "headerTitle";
+
+  private static final String OBJECT_TYPE       = "documentGadget";
+
+  private TranslationService  translationService;
 
   @Override
   public void init(PortletConfig config) throws PortletException {
     super.init(config);
     this.contentType = OBJECT_TYPE;
+  }
+
+  @Override
+  public void doView(RenderRequest request, RenderResponse response) throws PortletException, IOException {
+    String name = request.getPreferences().getValue(NAME, null);
+    String headerTitle = getTranslationService().getTranslationLabelOrDefault(OBJECT_TYPE,
+                                                                              name,
+                                                                              HEADER_FIELD_NAME,
+                                                                              request.getLocale());
+    if (headerTitle != null) {
+      request.setAttribute(HEADER_FIELD_NAME, headerTitle);
+    }
+    super.doView(request, response);
   }
 
   @Override
@@ -52,5 +74,12 @@ public class DocumentGadgetPortlet extends CMSPortlet {
       preferences.setValue(name, value);
     }
     preferences.store();
+  }
+
+  public TranslationService getTranslationService() {
+    if (translationService == null) {
+      translationService = ExoContainerContext.getService(TranslationService.class);
+    }
+    return translationService;
   }
 }

--- a/documents-webapp/src/main/webapp/WEB-INF/jsp/documentGadget.jsp
+++ b/documents-webapp/src/main/webapp/WEB-INF/jsp/documentGadget.jsp
@@ -17,17 +17,15 @@
    */
 %>
 <%@ page import="javax.portlet.PortletPreferences" %>
-<%@ page import="org.exoplatform.commons.utils.CommonsUtils" %>
-<%@ page import="io.meeds.social.translation.service.TranslationService" %>
 <%@ page import="org.exoplatform.portal.localization.LocaleContextInfoUtils" %>
 <%@ page import="org.apache.commons.text.StringEscapeUtils" %>
-
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 <portlet:defineObjects/>
 <portlet:actionURL var="saveSettingsUrl" />
 <%
   String settingName = (String) request.getAttribute("settingName");
+  String headerTitle = (String) request.getAttribute("headerTitle");
   boolean canEdit = (boolean) request.getAttribute("canEdit");
   String id = "DocumentGadget-" + renderRequest.getWindowID();
 
@@ -41,8 +39,6 @@
   String categoryIds = preferences.getValue("categoryIds", "[]").replace("\"", "`");
   String excludeCategoryIds = preferences.getValue("excludeCategoryIds", "[]").replace("\"", "`");
   String selectedFoldersId = preferences.getValue("selectedFoldersId", "");
-  String headerTitle = CommonsUtils.getService(TranslationService.class).getTranslationLabelOrDefault("documentGadget",
-          Long.parseLong(settingName), "headerTitle", LocaleContextInfoUtils.getUserLocale(request.getRemoteUser()));
 %>
 
 <div class="VuetifyApp">


### PR DESCRIPTION
This change will fix the usage of `TranslationService` API which uses Id of Type `String` instead of `Long`.

Resolves Meeds-io/meeds#3608