### PR TITLE
fix: Group actions button not displayed - EXO-80244 

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsAddNewFile.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/header/actions/DocumentsAddNewFile.vue
@@ -84,6 +84,7 @@ export default {
     },
   },
   created() {
+    this.showSelectionsMenu = this.selectedDocuments.length;
     this.$root.$on('show-mobile-filter', data => {
       this.showFilter= data;
     });


### PR DESCRIPTION
Before this change, when click on filter icon in doc app and click on their checkboxes, +new button displayed instead of x elements selected. To fix this problem, initialize showSelectionsMenu in the created method. After this change, miss actions button is displayed.