### PR TITLE
fix: Unable to access the space drives when using mobile (personal drive) - EXO-81085

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/FolderTreeViewDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/FolderTreeViewDrawer.vue
@@ -69,7 +69,7 @@ export default {
       try {
         const promises = [
           this.$documentFileService.getFullTreeData(
-            this.$root.ownerId,
+            this.$root.ownerId && this.$root.ownerId !== '0' ? this.$root.ownerId : eXo.env.portal.spaceIdentityId || eXo.env.portal.userIdentityId,
             null,
             this.folderPath,
             this.showHidden

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/TreeView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/TreeView.vue
@@ -169,6 +169,9 @@ export default {
       return items;
     },
     openFolder(folder){
+      if (this.currentFolderPathTab[this.currentFolderPathTab.length - 1] === folder.id) {
+        return;
+      }
       this.currentFolderPathTab.push(folder.id);
       if (folder.drives) {
         this.$root.$emit('document-show-drives', this.getNodeChildrenById('space_drives'));


### PR DESCRIPTION
Prior to this change, drives are not listed in the treeview in mobile; this commit adds the space drives to the treeview