### PR TITLE
fix: Document uploaded not displayed in shared folder - EXO-80427. 

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -237,6 +237,11 @@ export default {
     },
   },
   watch: {
+    recentViewSelected() {
+      if (this.recentViewSelected) {
+        this.$root.selectedPath = '/';
+      }
+    },
     selectedCategoryIds() {
       if (this.initialized) {
         this.refreshFiles();
@@ -1508,39 +1513,13 @@ export default {
             document.dispatchEvent(new CustomEvent('open-attachments-app-drawer', {detail: attachmentAppConfiguration}));
           }
         }
-      }
-      else {
-        if (eXo.env.portal.spaceName) {
-          attachmentAppConfiguration.defaultDrive = {
-            isSelected: true,
-            name: `.spaces.${eXo.env.portal.spaceGroup}`,
-            title: eXo.env.portal.spaceDisplayName,
-          };
-          const pathparts = window.location.pathname.toLowerCase().split(`${eXo.env.portal.selectedNodeUri.toLowerCase()}/`);
-          const currentUrlSearchParams = window.location.search;
-          const queryParams = new URLSearchParams(currentUrlSearchParams);
-          if (pathparts.length > 1 || queryParams.has('folderId')) {
-            attachmentAppConfiguration.defaultFolder = this.extractDefaultFolder();
-          }
-        }  else  {
-          attachmentAppConfiguration.defaultDrive = {
-            isSelected: true,
-            name: 'Personal Documents',
-            title: 'Personal Documents'
-          };
-          attachmentAppConfiguration.defaultFolder = '/';
-          let pathparts = window.location.pathname.split(`${eXo.env.portal.selectedNodeUri}/`);
-          if (pathparts.length > 1 && pathparts[1].startsWith('Private/')){
-            pathparts = pathparts[1].split('Private/');
-          }
-          if (pathparts.length > 1) {
-            attachmentAppConfiguration.defaultFolder = `${this.extractDefaultFolder(true)}`;
-          }
-        }
-        if (files){
-          attachmentAppConfiguration.files=files;
-        }
-        document.dispatchEvent(new CustomEvent('open-attachments-app-drawer', {detail: attachmentAppConfiguration}));
+      } else {
+        document.dispatchEvent(new CustomEvent('open-attachments-app-drawer', { detail: {
+          'sourceApp': 'NEW.APP',
+          defaultDrive: this.$root.selectedDrive,
+          defaultFolder: this.$root.selectedPath,
+          files,
+        }}));
       }
     },
     extractDefaultFolder(isPersonalDrive) {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -135,6 +135,18 @@ export default {
       }
     },
   },
+  watch: {
+    documentsBreadcrumb() {
+      const drive = { ... this.documentsBreadcrumb[0]};
+      if (drive.path?.startsWith?.('/Groups/spaces')) {
+        drive.name = `.spaces.${drive.path.split('/').filter(s => s?.length)[2]}`;
+      } else {
+        drive.name='Personal Documents';
+      }
+      this.$root.selectedDrive = drive;
+      this.$root.selectedPath = this.documentsBreadcrumb[this.documentsBreadcrumb.length-1].path.replace(`${drive.path}/`,'');
+    },
+  },
   created() {
     this.$root.$on('set-breadcrumb', this.setBreadcrumb);
     this.$root.$on('update-breadcrumb', this.updateBreadcrumb);

--- a/documents-webapp/src/main/webapp/vue-app/documents/main.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/main.js
@@ -86,6 +86,8 @@ export async function init(appId, canEdit,  settings, settingsSaveUrl) {
       ownerId: eXo.env.portal.spaceIdentityId || eXo.env.portal.userIdentityId,
       driveView: false,
       spaceId: null,
+      selectedDrive: null,
+      selectedPath: null,
     },
     computed: {
       categoryIds() {


### PR DESCRIPTION
Before this change, when open documents App from a folder's collaborator notification and create a new file, successful upload message displayed but document uploaded not displayed neither can be found. To fix this problem, change the creation of the drive and the path from breadcrumb. After this change, uploaded documents are displayed.