### PR TITLE
fix: Cannot access subfolders from treeview - EXO-81063 (#1649)

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
@@ -434,6 +434,7 @@ public class DocumentFileRest implements ResourceContainer {
     }
     long userIdentityId = RestUtils.getCurrentUserIdentityId(identityManager);
     try {
+        ownerId = ownerId == null ? 0 :ownerId;
         return Response.ok(EntityBuilder.toFullTreeItemEntities(documentFileService.getFullTreeData(ownerId, folderId,destinationFolderPath, userIdentityId, withChildren,showHidden),ownerId))
               .build();
     } catch (IllegalAccessException e) {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/TreeView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/TreeView.vue
@@ -189,8 +189,7 @@ export default {
     },
     fetchChildren (item) {
       this.$root.$emit('tree-loading', true);
-      let folderId = item.id;
-      folderId = null;
+      const folderId = item.identityId ? null : item.id;
       this.$documentFileService
         .getFullTreeData(item.identityId,folderId).then(data => {
           if (data) {


### PR DESCRIPTION
Prior to this change suvfolders are not retreived in treeview, this commit fixes this by setting the folder ID on the rest call