### PR TITLE
fix: Option "Move to" is missing when multiselecting documents - EXO-80676

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionMenu.vue
@@ -96,7 +96,7 @@ export default {
         });
       }
 
-      if (!this.isMobile) {
+      if (!this.isMobile && !this.isMultiSelection) {
         const groupingExtensions =  extensions.filter(extension => extension.type === 'group');
         groupingExtensions.forEach(extension => {
           if (!extensions.some(ext => ext.parent === extension.id)) {


### PR DESCRIPTION
Prior to this fix, move action is no more available on multisection.

This commit fixes the filtering of the actions extensions for multiselection.