### PR TITLE
fix: Option "Move to" is missing when multiselecting documents - EXO-80676

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsTreeSelectorDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsTreeSelectorDrawer.vue
@@ -224,9 +224,9 @@ export default {
           return breadCrumbs;
         });
     },
-    retrieveDocumentTree() {
+    retrieveDocumentTree(ownerId) {
       this.$documentFileService
-        .getFullTreeData(this.$root.ownerId).then(data => {
+        .getFullTreeData(ownerId ? ownerId : this.$root.ownerId).then(data => {
           if (data) {
             this.items = [];
             this.items = data;


### PR DESCRIPTION
Prior to this fix move action is no more available on multisection.

This commit fix this by fixing the filtering of actions extension for multiselection.