### PR TITLE
fix: Uploaded files are stored in wrong folder if added from folder view - EXO-81346 (#1693)

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -1523,17 +1523,10 @@ export default {
         document.dispatchEvent(new CustomEvent('open-attachments-app-drawer', { detail: {
           'sourceApp': 'NEW.APP',
           defaultDrive: this.$root.selectedDrive,
-          defaultFolder: this.$root.selectedPath,
+          defaultFolder: this.$root.selectedPath.indexOf(this.$root.selectedDrive.path) !== -1 ? this.$root.selectedPath.split(this.$root.selectedDrive.path)[1] : this.$root.selectedPath,
           files,
         }}));
       }
-    },
-    extractDefaultFolder(isPersonalDrive) {
-      const path = this.currentFolder.path;
-      if (isPersonalDrive) {
-        return path.substring(path.indexOf('Private') + '/Private'.length);
-      }
-      return path.substring(path.indexOf('Documents') + '/Documents'.length);
     },
     setCurrentFolder(folder) {
       this.currentFolder = folder;

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -167,6 +167,9 @@ export default {
       }
       this.$root.selectedDrive = drive;
       this.$root.selectedPath = this.documentsBreadcrumb[this.documentsBreadcrumb.length-1]?.path?.replace(`${drive.path}/`,'');
+      if (this.$root.selectedPath.indexOf('Public') !== -1) {
+        this.$root.selectedPath = `Public/${this.$root.selectedPath.split('Public')[1]}` || 'Public';
+      }
       this.initDocumentsBreadcrumb();
       this.$forceUpdate();
       this.isMounted = true;


### PR DESCRIPTION
Prior to this, uploaded documents were not stored in the right location. This commit corrects the path used on the attachment drawer to store files in the right location.