### PR TITLE
fix: Folder view: table display UI to fix - EXO-81378

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderCardsView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderCardsView.vue
@@ -23,7 +23,7 @@
       :folder-path="folderPath" />
     <v-card
       flat
-      class="col-lg-8 col-md-7">
+      :class="treeViewExpended ? 'col-9':'col-12'">
       <documents-breadcrumb
         :is-mobile="isMobile"
         :tree-view-expended="treeViewExpended" />

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderListView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderListView.vue
@@ -23,7 +23,7 @@
       :folder-path="folderPath" />
     <v-card
       flat
-      class="col-lg-8 col-md-7">
+      :class="treeViewExpended ? 'col-9':'col-12'">
       <documents-breadcrumb
         class="width-min-content"
         :is-mobile="isMobile"


### PR DESCRIPTION
Prior to this, when the tree view is collapsed the documents table isn't displayed on full page width, this change fix that.