### PR TITLE
fix: Docs app empty when changing view while seeing folders - EXO-81527

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -729,9 +729,9 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       }
       if (node != null) {
         String nodeName = node.hasProperty(NodeTypeConstants.EXO_TITLE) ? node.getProperty(NodeTypeConstants.EXO_TITLE).getString() : node.getName();
-        List<FullTreeItem> children = getAllFolderInNode(node, session, destinationNode, withChildren, showHidden);
+        List<FullTreeItem> children = getAllFolderInNode(node, session, destinationNode, withChildren, showHidden, String.valueOf(ownerId));
 
-        parents.add(new FullTreeItem(((NodeImpl) node).getIdentifier(), nodeName, node.getPath(), children, showHidden && node.isNodeType(NodeTypeConstants.EXO_HIDDENABLE), null));
+        parents.add(new FullTreeItem(((NodeImpl) node).getIdentifier(), nodeName, node.getPath(), children, showHidden && node.isNodeType(NodeTypeConstants.EXO_HIDDENABLE), String.valueOf(ownerId)));
       }
     } catch (Exception e) {
       throw new IllegalStateException("Error retrieving tree folder'" + folderId, e);
@@ -743,7 +743,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     return parents;
   }
 
-  private List<FullTreeItem> getAllFolderInNode(Node node, Session session, Node destinationNode, boolean withChildren, boolean showHidden) throws RepositoryException {
+  private List<FullTreeItem> getAllFolderInNode(Node node, Session session, Node destinationNode, boolean withChildren, boolean showHidden, String ownerId) throws RepositoryException {
     List<FullTreeItem> folderListNodes = new ArrayList<>();
     NodeIterator nodeIter = node.getNodes();
     while (nodeIter.hasNext()) {
@@ -766,7 +766,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         if (childNode != null) {
           List<FullTreeItem> folderChildListNodes = new ArrayList<>();
           if (withChildren || (destinationNode != null && destinationNode.getPath().contains(childNode.getPath()))) {
-            folderChildListNodes = getAllFolderInNode(childNode, session, destinationNode, withChildren, showHidden);
+            folderChildListNodes = getAllFolderInNode(childNode, session, destinationNode, withChildren, showHidden, ownerId);
           } else if (!hasFolderNodes(childNode,showHidden)) {
             folderChildListNodes = null;
           }
@@ -775,7 +775,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
                                                childNode.getPath(),
                                                folderChildListNodes,
                                                showHidden && childNode.isNodeType(NodeTypeConstants.EXO_HIDDENABLE),
-                                               null));
+                                               ownerId));
         }
 
       }

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -1036,7 +1036,10 @@ export default {
     },
     changeView(view) {
       const realPageUrlIndex = window.location.href.toLowerCase().indexOf(location.pathname.toLowerCase()) + location.pathname.length;
-      const url = new URL(window.location.href.substring(0, realPageUrlIndex));
+      let url = new URL(window.location.href.substring(0, realPageUrlIndex));
+      if (view === 'timeline') {
+        url = new URL(window.location.href.split(eXo.env.portal.selectedNodeUri)[0] + eXo.env.portal.selectedNodeUri);
+      }
       const params = new URLSearchParams(document.location.search);
       params.set('view', view);
       if (view !== 'folder'){

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/TreeView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/TreeView.vue
@@ -217,7 +217,7 @@ export default {
           this.$root.ownerId = eXo.env.portal.userIdentityId;
           this.$root.spaceId = null;
           this.$root.driveView = false;
-        } else if (folder.ownerId) {
+        } else if (folder.ownerId && folder.ownerId !== '0') {
           this.$root.ownerId = folder.ownerId;
         }
         this.$root.$emit('open-folder', folder);


### PR DESCRIPTION
Prior to this, after opening some subfolders using the tree, then changing the view, the list of documents is empty. This problem is due to that the owner ID is lost when navigating using the tree view. This commit fixes this by ensuring that the owner ID is never lost.