### PR TITLE
fix: Cannot move files/folders by D&D - EXO-81478

### DIFF
--- a/documents-webapp/src/main/webapp/js/DocumentsDraggable.js
+++ b/documents-webapp/src/main/webapp/js/DocumentsDraggable.js
@@ -320,15 +320,15 @@
     }
 
     function getParentDragElement() {
-        return getBreadCrumbListElement().querySelector('div.documents-tree-item:last-child').cloneNode(true);
+        return getBreadCrumbListElement().querySelector('div.document-breadcrumb-item:last-child').cloneNode(true);
     }
 
     function getRootFolder() {
-        return getBreadCrumbListElement().querySelector('div.documents-tree-item:first-child').cloneNode(true);
+        return getBreadCrumbListElement().querySelector('div.document-breadcrumb-item:first-child').cloneNode(true);
     }
 
     function isRootFolder() {
-        return getBreadCrumbListElement().querySelectorAll('div.documents-tree-item')?.length === 1;
+        return getBreadCrumbListElement().querySelectorAll('div.document-breadcrumb-item')?.length === 1;
     }
 
     function canDropOnListFiles() {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -33,7 +33,8 @@
             v-if="document.isBreadcrumbItem && !document.isEllipsis"
             :key="index"
             :data-fileId="document.id"
-            :class="document.class">
+            :class="document.class"
+            class="document-breadcrumb-item">
             <v-tooltip max-width="300" bottom>
               <template #activator="{ on, attrs }">
                 <a


### PR DESCRIPTION
Prior to this it's not possible to D&D a folder or a file to move it from a folder to another, this is a regression caused by the remove a specific class used to get the element to drag. This commit adds a new class to be used as a selector for the element to drag.