### PR TITLE
fix: Cannot open a shared doc if view permission only - EXO-80934

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -16,6 +16,8 @@
  */
 package org.exoplatform.documents.storage.jcr.util;
 
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.DOCUMENT_CATEGORY_IDS;
+
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -67,8 +69,6 @@ import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.service.LinkProvider;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
-
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.DOCUMENT_CATEGORY_IDS;
 
 public class JCRDocumentsUtil {
   private static final Log                              LOG                           =
@@ -218,7 +218,7 @@ public class JCRDocumentsUtil {
           FolderNode folderNode = toFolderNode(identityManager, aclIdentity, node, sourceID, spaceService);
           fileNodes.add(folderNode);
         }
-        if ((sourceNode.isNodeType(NodeTypeConstants.NT_FILE))
+        if ((sourceNode.isNodeType(NodeTypeConstants.NT_FILE) || node.isNodeType(NodeTypeConstants.EXO_SYMLINK))
             && (!node.isNodeType(NodeTypeConstants.EXO_HIDDENABLE) || includeHiddenFiles)) {
           FileNode fileNode = toFileNode(identityManager, aclIdentity, node, sourceID, spaceService);
           fileNode.setMimeType(getMimeType(sourceNode));
@@ -340,15 +340,24 @@ public class JCRDocumentsUtil {
       fileNode.setDatasource(JCR_DATASOURCE_NAME);
       fileNode.setCloudDriveFile(node.hasProperty("ecd:driveUUID"));
       retrieveFileProperties(identityManager, node, aclIdentity, fileNode, spaceService);
-      if (node.isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
-        retrieveSymlinkSize(node, fileNode);
-      }
-      retrieveViewsProperty(node, fileNode);
-      retrieveCategoryIdsProperty(node, fileNode);
       if (node.hasNode(NodeTypeConstants.JCR_CONTENT)) {
         Node content = node.getNode(NodeTypeConstants.JCR_CONTENT);
         retrieveFileContentProperties(content, fileNode);
+      } else if (node.isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
+        if (StringUtils.isEmpty(fileNode.getSourceID())) {
+          String sourceID = node.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString();
+          fileNode.setSourceID(sourceID);
+        }
+        Node source = getNodeByIdentifier(node.getSession(), fileNode.getSourceID());
+        if (source != null) {
+          if (source.hasNode(NodeTypeConstants.JCR_CONTENT)) {
+            Node content = source.getNode(NodeTypeConstants.JCR_CONTENT);
+            retrieveFileContentProperties(content, fileNode);
+          }
+        }
       }
+      retrieveViewsProperty(node, fileNode);
+      retrieveCategoryIdsProperty(node, fileNode);
     } catch (Exception e) {
       try {
         LOG.warn("Error computing File Node for search result with path {}", node.getPath(), e);
@@ -382,16 +391,6 @@ public class JCRDocumentsUtil {
       }).filter(Objects::nonNull).collect(Collectors.toList());
     }
     fileNode.setCategoryIds(idsList);
-  }
-  
-  private static void retrieveSymlinkSize(Node node, FileNode fileNode) throws RepositoryException {
-    Node source = getNodeByIdentifier(node.getSession(), fileNode.getSourceID());
-    if (source != null && source.getNode(NodeTypeConstants.JCR_CONTENT) != null) {
-      Node content = source.getNode(NodeTypeConstants.JCR_CONTENT);
-      if (content.hasProperty(NodeTypeConstants.JCR_DATA)) {
-        fileNode.setSize(content.getProperty(NodeTypeConstants.JCR_DATA).getLength());
-      }
-    }
   }
 
   public static Node getNode(Session session,

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -218,7 +218,7 @@ public class JCRDocumentsUtil {
           FolderNode folderNode = toFolderNode(identityManager, aclIdentity, node, sourceID, spaceService);
           fileNodes.add(folderNode);
         }
-        if ((sourceNode.isNodeType(NodeTypeConstants.NT_FILE) || node.isNodeType(NodeTypeConstants.EXO_SYMLINK))
+        if ((sourceNode.isNodeType(NodeTypeConstants.NT_FILE))
             && (!node.isNodeType(NodeTypeConstants.EXO_HIDDENABLE) || includeHiddenFiles)) {
           FileNode fileNode = toFileNode(identityManager, aclIdentity, node, sourceID, spaceService);
           fileNode.setMimeType(getMimeType(sourceNode));

--- a/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentListWidgetItem.vue
+++ b/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentListWidgetItem.vue
@@ -107,8 +107,12 @@ export default {
       this.loading = true;
       if (this.file?.folder) {
         this.$root.$emit('document-open-folder', this.file);
-      } else if (this.isFileEditable && this.canEdit) {
-        this.$root.openInEditMode(this.file);
+      } else if (this.isFileEditable)  {
+        if (this.canEdit) {
+          this.openInEditMode(this.file);
+        } else {
+          this.openInReadOnlyMode(this.file);
+        }        
       } else if (this.isFileOnlyReadable) {
         this.$root.openInReadOnlyMode(this.file);
       } else {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileNameCell.vue
@@ -209,12 +209,12 @@ export default {
   }),
   computed: {
     isFileEditable() {
-      const type = this.file && this.file.mimeType || '';
-      return this.$supportedDocuments && this.$supportedDocuments.filter(doc => doc.edit && doc.mimeType === type && !this.file.cloudDriveFile).length > 0;
+      const fileType = this.file && this.file.mimeType || '';
+      return this.$supportedDocuments && this.$supportedDocuments.filter(doc => doc.edit && doc.mimeType === fileType && !this.file.cloudDriveFile).length > 0;
     },
     isFileOnlyReadable() {
-      const type = this.file && this.file.mimeType || '';
-      return this.$supportedDocuments && this.$supportedDocuments.filter(doc => !doc.edit && doc.mimeType === type && !this.file.cloudDriveFile).length > 0;
+      const fileType = this.file && this.file.mimeType || '';
+      return this.$supportedDocuments && this.$supportedDocuments.filter(doc => !doc.edit && doc.mimeType === fileType && !this.file.cloudDriveFile).length > 0;
     },
     documentMultiSelectionActive() {
       return this.$vuetify.breakpoint.width >= 600 && !this.file.drive;
@@ -337,8 +337,12 @@ export default {
         this.$root.ownerId = this.file.identityId;
         this.$root.spaceId = this.file.spaceId;
         this.$root.$emit('document-open-folder', this.file);
-      } else if (this.isFileEditable && this.canEdit)  {
-        this.openInEditMode(this.file);
+      } else if (this.isFileEditable)  {
+        if (this.canEdit) {
+          this.openInEditMode(this.file);
+        } else {
+          this.openInReadOnlyMode(this.file);
+        }        
       } else if (this.isFileOnlyReadable) {
         this.openInReadOnlyMode(this.file);
       } else {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentItemCard.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentItemCard.vue
@@ -377,8 +377,12 @@ export default {
       this.loading = true;
       if (this.isFolder) {
         this.$root.$emit('document-open-folder', this.file);
-      } else if (this.isFileEditable && this.canEdit) {
-        this.$root.openInEditMode(this.file);
+      } else if (this.isFileEditable)  {
+        if (this.canEdit) {
+          this.openInEditMode(this.file);
+        } else {
+          this.openInReadOnlyMode(this.file);
+        }        
       } else if (this.isFileOnlyReadable) {
         this.$root.openInReadOnlyMode(this.file);
       } else {


### PR DESCRIPTION
Prior to this commit shared office documents cannot be opened in the editor according to the permissions.
This commit fixes this by checking the permissions and file type to open the document properly, 
This also fixes opening this kind of document from the info drawer.