### PR TITLE
fix: Link to open location from OO - EXO-80476

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -1657,10 +1657,7 @@ export default {
     },
     openFileInEditor(attachment,mode,tab) {
       if (attachment && attachment.id) {
-        let url = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/oeditor?docId=${attachment.id}&backTo=${window.location.pathname}`;
-        if (mode) {
-          url += `&mode=${mode}`;
-        }
+        const url = this.$documentsUtils.getEditorUrl(attachment,mode);
         window.open(url,tab ? tab:'_blank');
       }
     },

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderCardsView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderCardsView.vue
@@ -23,7 +23,7 @@
       :folder-path="folderPath" />
     <v-card
       flat
-      :class="!isMobile && treeViewExpended ? 'col-9':''">
+      :class="!isMobile && treeViewExpended ? 'col-9':'col-12'">
       <documents-breadcrumb
         :is-mobile="isMobile"
         :tree-view-expended="treeViewExpended" />

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderListView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderListView.vue
@@ -23,7 +23,7 @@
       :folder-path="folderPath" />
     <v-card
       flat
-      :class="!isMobile && treeViewExpended ? 'col-9':''">
+      :class="!isMobile && treeViewExpended ? 'col-9':'col-12'">
       <documents-breadcrumb
         class="width-min-content"
         :is-mobile="isMobile"


### PR DESCRIPTION
This commit fixes the back to documents link for documents opened from links (article, notes...).