### PR TITLE
fix: Cannot open a shared doc if view permission only - EXO-80934

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentListWidgetItem.vue
+++ b/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentListWidgetItem.vue
@@ -109,9 +109,9 @@ export default {
         this.$root.$emit('document-open-folder', this.file);
       } else if (this.isFileEditable)  {
         if (this.canEdit) {
-          this.openInEditMode(this.file);
+          this.$root.openInEditMode(this.file);
         } else {
-          this.openInReadOnlyMode(this.file);
+          this.$root.openInReadOnlyMode(this.file);
         }        
       } else if (this.isFileOnlyReadable) {
         this.$root.openInReadOnlyMode(this.file);


### PR DESCRIPTION
Prior to this commit shared office documents cannot be opened in the editor according to the permissions This commit fixes this by checking the permission and file type to open the document properly, this fixes also opening this kind of documents from the info drawer.