### PR TITLE
fix: Folder must not be listed as shared item in document list - EXO-81850 

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -2262,15 +2262,9 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
           node.setProperty(NodeTypeConstants.EXO_LAST_MODIFIED_DATE, Calendar.getInstance());
         }
         node.save();
-        if (!node.isCheckedOut()) {
-          node.checkout();
-        }
-        Version version = node.checkin();
-        node.checkout();
-        node.getSession().save();
-        fileVersion = JCRDocumentsUtil.toFileVersion(version, node, identityManager);
+        VersionHistoryUtils.createVersion(node);
       }
-    } catch (RepositoryException e) {
+    } catch (Exception e) {
       throw new IllegalStateException("Error while creating new version", e);
     }
     return fileVersion;

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -1254,7 +1254,7 @@ public class JCRDocumentFileStorageTest {
   }
   
   @Test
-  public void createNewVersion() throws RepositoryException {
+  public void createNewVersion() throws Exception {
     org.exoplatform.services.security.Identity identity = mock(org.exoplatform.services.security.Identity.class);
     when(identityRegistry.getIdentity("user")).thenReturn(identity);
     ManageableRepository manageableRepository = mock(ManageableRepository.class);
@@ -1277,7 +1277,8 @@ public class JCRDocumentFileStorageTest {
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.toFileVersion(version, node, identityManager)).thenReturn(new FileVersion());
     jcrDocumentFileStorage.createNewVersion("123", "user", new ByteArrayInputStream("test".getBytes()));
     verify(node, times(1)).save();
-    verify(session, times(1)).save();
+    VERSION_HISTORY_UTILS.verify(() -> VersionHistoryUtils.createVersion(node), times(1));
+
   }
 
   @Test

--- a/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentList.vue
+++ b/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentList.vue
@@ -206,7 +206,7 @@ export default {
         parentFolderId: this.selectedFoldersId,
       };
       return this.$documentFileService.getDocumentItems(filter, this.selectedCategoryIds, this.excludedCategoryIds, 0, this.maxDocumentsToList, null).then(files => {
-        this.files = files;
+        this.files = files.filter(file => !file.folder);
       }).finally(() => this.loading = false);
     },
     settingsUpdated(settings, headerTitle, refreshList) {


### PR DESCRIPTION
Prior to this, when a folder is shared with someone else, it appears in the documents list gadget
This change filters the list of shared items to only show files.