### PR TITLE
fix: Folder must not be listed as shared item in document list - EXO-81850

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentList.vue
+++ b/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentList.vue
@@ -206,7 +206,7 @@ export default {
         parentFolderId: this.selectedFoldersId,
       };
       return this.$documentFileService.getDocumentItems(filter, this.selectedCategoryIds, this.excludedCategoryIds, 0, this.maxDocumentsToList, null).then(files => {
-        this.files = files;
+        this.files = files.filter(file => !file.folder);
       }).finally(() => this.loading = false);
     },
     settingsUpdated(settings, headerTitle, refreshList) {


### PR DESCRIPTION
Prior to this, when a folder is shared with someone else, it appears in the documents list gadget.
This change filters the list of shared items to only show files.