### PR TITLE
fix: Non OO docs cannot be opened from document list  - EXO-81837

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentList.vue
+++ b/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentList.vue
@@ -222,11 +222,12 @@ export default {
         this.getFiles();
       }
     },
-    previewDocument(file) {
+    previewDocument(file,files) {
       const attachments = [];
-      this.files.forEach((item) => {
+      files = files && files.length > 0 ? files : this.files;
+      files.forEach((item) => {
         if (!item.folder && Vue.prototype?.$supportedDocuments.filter(doc =>doc.mimeType === item.mimeType).length === 0){
-          attachments.push({'id': item.id,'filename': item.name,'mimetype': item.mimeType,'source': 'documents','downloadUrl': `/rest/v1/documents/content/${item.id}`, 'icon': this.$root.getFileIcon(item)});}
+          attachments.push({'id': item.id,'filename': item.name,'mimetype': item.mimeType || item.mimetype,'source': 'documents','downloadUrl': `/rest/v1/documents/content/${item.id}`, 'icon': this.$root.getFileIcon(item)});}
       });
       document.dispatchEvent(new CustomEvent('open-attachments-preview', {detail: {'attachments': attachments,'id': file.id }}));
     },

--- a/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentListWidgetItem.vue
+++ b/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentListWidgetItem.vue
@@ -116,7 +116,7 @@ export default {
       } else if (this.isFileOnlyReadable) {
         this.$root.openInReadOnlyMode(this.file);
       } else {
-        this.$root.$emit('documents-preview', this.files, this.file);
+        this.$root.$emit('documents-preview', this.file, this.files);
       }
       this.loading = false;
       this.$root.$emit('mark-document-as-viewed', this.file);


### PR DESCRIPTION
Prior to this commit non O0 docs are not opened from the document list gadget. This commit fixes this by sending the good file object list to the attachments preview component.