### PR TITLE
fix: Update download-document pages margin and size - MEED-9838 - meeds-io/meeds#3779

### DIFF
--- a/documents-webapp/src/main/webapp/WEB-INF/conf/documents/portal/portal/global/pages.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/conf/documents/portal/portal/global/pages.xml
@@ -187,7 +187,7 @@
                 <title>Platform Name</title>
                 <height>150</height>
                 <css-style>
-                  <margin-top>60</margin-top>
+                  <margin-top>20</margin-top>
                   <margin-bottom>0</margin-bottom>
                   <margin-right>20</margin-right>
                   <margin-left>20</margin-left>
@@ -217,7 +217,7 @@
                 </portlet>
                 <title>Download Document</title>
                 <css-style>
-                  <margin-top>0</margin-top>
+                  <margin-top>-40</margin-top>
                   <margin-bottom>20</margin-bottom>
                   <margin-right>20</margin-right>
                   <margin-left>20</margin-left>
@@ -236,7 +236,7 @@
                   </preferences>
                 </portlet>
                 <title>Platform Logo</title>
-                <height>100</height>
+                <height>50</height>
                 <css-style>
                   <margin-top>20</margin-top>
                   <margin-bottom>40</margin-bottom>


### PR DESCRIPTION
This commit update the size of platformLogo for pages related to download-document It also update margins for differents portlets on pages related to download-document

Resolves meeds-io/meeds#3779