### PR TITLE
fix: Cards view: Not all options available - EXO-81754

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentListWidgetItem.vue
+++ b/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentListWidgetItem.vue
@@ -85,7 +85,7 @@ export default {
       return this.file?.icon?.color || 'secondary';
     },
     mimeType() {
-      return this.file?.mimetype;
+      return this.file?.mimeType;
     },
     isFileEditable() {
       const type = this.mimeType || '';

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentItemCard.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentItemCard.vue
@@ -286,7 +286,7 @@ export default {
       return this.file?.folder;
     },
     mimeType() {
-      return this.file?.mimetype;
+      return this.file?.mimeType;
     },
     isMediaFile() {
       return this.mimeType?.startsWith('video/') || this.mimeType?.startsWith('audio/');

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsCardsView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsCardsView.vue
@@ -126,7 +126,7 @@ export default {
           filename: decodedName,
           modifiedDate: file?.modifiedDate,
           createdDate: file?.createdDate,
-          mimetype: file?.mimeType,
+          mimeType: file?.mimeType,
           sourceID: file?.sourceID,
           acl: file?.acl,
           image: this.$root.getImageUrl(file),

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderCardsView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderCardsView.vue
@@ -169,7 +169,7 @@ export default {
           filename: decodedName,
           modifiedDate: file?.modifiedDate,
           createdDate: file?.createdDate,
-          mimetype: file?.mimeType,
+          mimeType: file?.mimeType,
           sourceID: file?.sourceID,
           acl: file?.acl,
           image: this.$root.getImageUrl(file),


### PR DESCRIPTION
Prior to this, some actions are not listed in the card view; this is due to missing properties in the item object.
This change fixes it by adding missing information and setting the current view.