### PR TITLE
fix: Cannot drop doc while recent view - EXO-81960 (#1745)

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -1526,7 +1526,7 @@ export default {
         document.dispatchEvent(new CustomEvent('open-attachments-app-drawer', { detail: {
           'sourceApp': 'NEW.APP',
           defaultDrive: this.$root.selectedDrive,
-          defaultFolder: this.$root.selectedPath.indexOf(this.$root.selectedDrive.path) !== -1 ? this.$root.selectedPath.split(this.$root.selectedDrive.path)[1] : this.$root.selectedPath,
+          defaultFolder: this.$root.selectedPath.indexOf(this.$root.selectedDrive?.path) !== -1 ? this.$root.selectedPath.split(this.$root.selectedDrive?.path)[1] : this.$root.selectedPath,
           files,
         }}));
       }


### PR DESCRIPTION
Prior to this it's nor possible to drop files in the recent view because the selected drive is net set. This change fix it by ignoring the selected path if not defined when computing the default folder for the attachments drawer.