### PR TITLE
fix: Cards view: Not all options available - EXO-81754

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentListWidgetItem.vue
+++ b/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentListWidgetItem.vue
@@ -85,7 +85,7 @@ export default {
       return this.file?.icon?.color || 'secondary';
     },
     mimeType() {
-      return this.file?.mimeType;
+      return this.file?.mimeType || this.file?.mimetype;
     },
     isFileEditable() {
       const type = this.mimeType || '';

--- a/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentListWidgetItem.vue
+++ b/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentListWidgetItem.vue
@@ -85,7 +85,7 @@ export default {
       return this.file?.icon?.color || 'secondary';
     },
     mimeType() {
-      return this.file?.mimetype;
+      return this.file?.mimeType;
     },
     isFileEditable() {
       const type = this.mimeType || '';

--- a/documents-webapp/src/main/webapp/vue-app/documents-favorite-drawer-extensions/components/DocumentsFavoriteItem.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents-favorite-drawer-extensions/components/DocumentsFavoriteItem.vue
@@ -96,7 +96,7 @@ export default {
       return this.expanded ? 34 : 24;
     },
     fileType() {
-      return this.file?.mimetype || '';
+      return  this.file?.mimeType || this.file?.mimetype || '';
     },
     isFileEditable() {
       return this.$supportedDocuments?.filter?.(doc => doc.edit && doc.mimeType === this.fileType && !this.file?.cloudDrive)?.length;

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentItemCard.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentItemCard.vue
@@ -286,7 +286,7 @@ export default {
       return this.file?.folder;
     },
     mimeType() {
-      return this.file?.mimetype;
+      return this.file?.mimeType;
     },
     isMediaFile() {
       return this.mimeType?.startsWith('video/') || this.mimeType?.startsWith('audio/');

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentItemCard.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentItemCard.vue
@@ -286,7 +286,7 @@ export default {
       return this.file?.folder;
     },
     mimeType() {
-      return this.file?.mimeType;
+      return this.file?.mimeType || this.file?.mimetype;
     },
     isMediaFile() {
       return this.mimeType?.startsWith('video/') || this.mimeType?.startsWith('audio/');

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsCardsView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsCardsView.vue
@@ -126,7 +126,7 @@ export default {
           filename: decodedName,
           modifiedDate: file?.modifiedDate,
           createdDate: file?.createdDate,
-          mimetype: file?.mimeType,
+          mimeType: file?.mimeType,
           sourceID: file?.sourceID,
           acl: file?.acl,
           image: this.$root.getImageUrl(file),

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsCardsView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsCardsView.vue
@@ -58,6 +58,7 @@
             :key="file.id"
             :file="file"
             :files="files"
+            :current-view="currentView"
             :select-all-checked="selectAll"
             :selected-documents="selectedDocuments"
             @document-selected="handleDocumentSelection"
@@ -103,6 +104,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    currentView: {
+      type: String,
+      default: ''
+    },
   },
   data: () => ({
     sortMenu: false,
@@ -130,6 +135,11 @@ export default {
           editable: this.$root.isFileEditable(file),
           readable: this.$root.isFileReadable(file),
           path: file?.path,
+          versionable: file?.versionable,
+          cloudDriveFolder: file?.cloudDriveFolder,
+          creatorUserName: file?.creatorUserName,
+          folder: file?.folder,
+          canAdd: file?.canAdd,
           source: 'documents',
         };
       });

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderCardsView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderCardsView.vue
@@ -70,6 +70,7 @@
             <documents-folder-card
               :folder="folder"
               :files="folderToDisplay"
+              current-view="folder"
               :select-all-checked="selectAll"
               :selected-documents="selectedDocuments"
               @document-selected="handleDocumentSelection"
@@ -94,6 +95,7 @@
                 :key="file.id"
                 :file="file"
                 :files="files"
+                current-view="folder"
                 :select-all-checked="selectAll"
                 :selected-documents="selectedDocuments"
                 @document-selected="handleDocumentSelection"
@@ -178,6 +180,10 @@ export default {
           path: file?.path,
           source: 'documents',
           folder: file.folder,
+          versionable: file?.versionable,
+          cloudDriveFolder: file?.cloudDriveFolder,
+          creatorUserName: file?.creatorUserName,
+          canAdd: file?.canAdd,
         };
       });
     },

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderCardsView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderCardsView.vue
@@ -169,7 +169,7 @@ export default {
           filename: decodedName,
           modifiedDate: file?.modifiedDate,
           createdDate: file?.createdDate,
-          mimetype: file?.mimeType,
+          mimeType: file?.mimeType,
           sourceID: file?.sourceID,
           acl: file?.acl,
           image: this.$root.getImageUrl(file),

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsTimelineView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsTimelineView.vue
@@ -21,6 +21,7 @@
       :files="files"
       :has-more="hasMore"
       :loading="loading"
+      current-view="timeline"
       :selected-documents="selectedDocuments" />
     <documents-list-view
       v-else


### PR DESCRIPTION
Prior to this, some actions are not listed in the card view.
 This is due to missing properties in the item object.
This change fixes it by adding missing information and setting the current view.