### PR TITLE
fix: Exclude documents of public folder from the document insertion -EXO-81878 (#1765)

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/plugin/DocumentContentLinkPlugin.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/plugin/DocumentContentLinkPlugin.java
@@ -35,7 +35,6 @@ import io.meeds.social.cms.model.ContentLinkExtension;
 import io.meeds.social.cms.model.ContentLinkSearchResult;
 import io.meeds.social.cms.plugin.ContentLinkPlugin;
 import io.meeds.social.cms.service.ContentLinkPluginService;
-
 import jakarta.annotation.PostConstruct;
 import lombok.SneakyThrows;
 
@@ -80,7 +79,8 @@ public class DocumentContentLinkPlugin implements ContentLinkPlugin {
                                                           limit);
     return CollectionUtils.isEmpty(documents) ? Collections.emptyList() :
                                               documents.stream()
-                                                       .map(this::toContentLink)
+                                                      .filter(doc -> !doc.getPath().startsWith("/Users"))
+                                                      .map(this::toContentLink)
                                                        .toList();
   }
 


### PR DESCRIPTION
Prior to this, users can insert documents from their private/public folder when writing a message.
This change resolves this by filtering the suggested documents so that private ones will not be listed.