### PR TITLE
fix: Document name hidden in comments drawer - EXO-81363

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachment.vue
+++ b/documents-webapp/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachment.vue
@@ -67,7 +67,7 @@
             </v-avatar>
             <v-card             
               max-width="198px"
-              class="d-flex  px-1 my-auto  no-border elevation-0">
+              class="d-flex  px-1 my-auto transparent no-border elevation-0">
               <v-card-text
                 :title="attachment.name"
                 class="pa-0  my-auto white--text text-wrap text-break text-truncate"


### PR DESCRIPTION
 Prior to this change, the attachment name was hidden in the comment drawer due to the default card background, which concealed the white text. This update applies a transparent class to the card, resolving the issue