### PR TITLE
fix: Misaligned cancel option in file upload - EXO-76185

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
+++ b/documents-webapp/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
@@ -68,8 +68,8 @@
         </v-icon>
         <v-btn
           v-if="attachmentInProgress"
-          class="d-flex align-end"
-          outlined
+          class="d-flex align-end me-1"
+          icon
           x-small
           height="18"
           width="18"
@@ -84,7 +84,7 @@
           <v-btn
             :disabled="!canDetachAttachment"
             class="d-flex"
-            outlined
+            icon
             x-small
             height="24"
             width="24"


### PR DESCRIPTION
Prior to this change the file upload cancel option icon was misaligned, this change is going to align this icon.