### PR TITLE
fix: Ensure to correctly open the document when clicking on a notification - EXO-81980

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/notification/provider/MailTemplateProvider.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/notification/provider/MailTemplateProvider.java
@@ -95,6 +95,7 @@ public class MailTemplateProvider extends TemplateProvider {
       templateContext.put("PROFILE_URL", encoder.encode(userProfile.getUrl()));
       templateContext.put("AVATAR", encoder.encode(LinkProviderUtils.getUserAvatarUrl(userProfile)));
 
+
       Calendar lastModified = Calendar.getInstance();
       lastModified.setTimeInMillis(notificationInfo.getLastModifiedDate());
       templateContext.put("LAST_UPDATED_TIME",
@@ -111,6 +112,7 @@ public class MailTemplateProvider extends TemplateProvider {
       templateContext.put("FIRST_NAME", encoder.encode(receiver.getProfile().getProperty(Profile.FIRST_NAME).toString()));
       // Footer
       templateContext.put("FOOTER_LINK", LinkProviderUtils.getRedirectUrl("notification_settings", receiver.getRemoteId()));
+      templateContext.put("COMPANY_LINK", LinkProviderUtils.getBaseUrl());
       String subject = TemplateUtils.processSubject(templateContext);
       String body = TemplateUtils.processGroovy(templateContext);
       notificationContext.setException(templateContext.getException());

--- a/documents-webapp/src/main/webapp/js/DocumentsUtils.js
+++ b/documents-webapp/src/main/webapp/js/DocumentsUtils.js
@@ -84,7 +84,7 @@ export function getParentFolderUrl(file) {
             const parentIndex = pathParts.indexOf('Private');
             if (parentIndex !== -1) {
                 folderPath = pathParts.slice(parentIndex, pathParts.length - 1).join('/');
-                folderPath = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/drives/${folderPath}`;
+                folderPath = `${window.location.pathname}/${folderPath}`;
             }
         }
         return folderPath;
@@ -92,7 +92,8 @@ export function getParentFolderUrl(file) {
 }
 
 export function getEditorUrl(file, mode) {
-    let url = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/oeditor?docId=${file.id}&backTo=${getParentFolderUrl(file)}`;
+    const fileId = file.sourceID? file.sourceID: file.id;
+    let url = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/oeditor?docId=${fileId}&backTo=${getParentFolderUrl(file)}`;
     if (mode) {
         url += `&mode=${mode}`;
     }

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -826,7 +826,11 @@ export default {
       } else if (path.includes('Private/')) {
         this.folderPath = path.substring(path.indexOf('Private/') + 'Private/'.length);
         this.selectedView = 'folder';
+      } else if (path !== window.location.pathname){
+        this.folderPath = path;
+        this.selectedView = 'folder';
       }
+
     },
 
     importDocuments(uploadId,overrideMode){
@@ -958,6 +962,11 @@ export default {
       return this.$documentFileService
         .bulkMoveDocuments(actionId,this.selectedDocuments, this.$root.ownerId, destPath)
         .catch(e => console.error(e));
+    },
+    openFile(file) {
+      this.$attachmentService.getDocumentDetails(file.parentFolderId,'').then(folder => {
+        this.openFolder(folder);
+      });
     },
     openFolder(parentFolder) {
       this.$root.driveView = false;
@@ -1549,7 +1558,7 @@ export default {
         return this.showPreview(documentPreviewId)
           .then(attachment => {
             if (attachment?.path) {
-              this.selectFile(attachment.path);
+              this.openFile(attachment);
             }
           });
       }
@@ -1642,10 +1651,12 @@ export default {
             } else {
               this.openFileInEditor(attachment,'view','_self');
 
-            } } else {
+            }
+          } else {
             const file = {'id': attachment.id,'filename': attachment.name,'mimetype': attachment.mimeType,'source': 'documents','downloadUrl': `/rest/v1/documents/content/${attachment.id}`, 'icon': this.getFileIcon(attachment)};
             document.dispatchEvent(new CustomEvent('open-attachments-preview', {detail: {'attachments': [file],'id': documentPreviewId }}));
-            return attachment;}
+            return attachment;
+          }
         })
         .catch(e => console.error(e))
         .finally(() => this.loading = false);


### PR DESCRIPTION
Before this fix, when a user share a file to another user, there are few problems :
- The "context" of the document app is not the folder containing the document
- If the file is "editable" (aka openable with OO), OO generates an error when opening the file
- After fixing the opening of the file, the backButton does not get back to document app in the correct folder
- When generating the share notification, there is an error server log due to missing property