### PR TITLE
fix: prevent group admins from being automatically added as collaborators in personal drive - EXO-81752

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1631,7 +1631,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     return null;
   }
 
-  public void updatePermissions(String documentID, NodePermission nodePermissionEntity, Identity aclIdentity){
+  public void updatePermissions(String documentID, NodePermission nodePermissionEntity, Identity aclIdentity) {
     SessionProvider sessionProvider = null;
     try {
       ManageableRepository manageableRepository = repositoryService.getCurrentRepository();
@@ -1644,7 +1644,9 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         String owner = node.getProperty(NodeTypeConstants.EXO_OWNER).getString();
         permissions.put(owner, PermissionType.ALL);
       }
-      permissions.put(GROUP_ADMINISTRATORS, PermissionType.ALL);
+      if (!isPersonalDrive(node)) {
+        permissions.put(GROUP_ADMINISTRATORS, PermissionType.ALL);
+      }
       if (nodePermissionEntity.isPublic()) {
         permissions.put("any", new String[] {PermissionType.READ});
       }
@@ -2577,4 +2579,8 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     symlinksNavHistory.clear();
   }
 
+  public boolean isPersonalDrive(Node node) throws RepositoryException {
+    String nodePath = node.getPath();
+    return StringUtils.startsWith(nodePath, "/Users") && StringUtils.contains(nodePath, "/Private");
+  }
 }


### PR DESCRIPTION
Prior to this change, the group admins was automatically added as collaborators in personal drive, this change is going to prevent this group from being automatically added as collaborators in personal drive.