### PR TITLE
fix: Open doc location is KO when doc opened from favorite - EXO-81992 (#1785)

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents-favorite-drawer-extensions/components/DocumentsFavoriteItem.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents-favorite-drawer-extensions/components/DocumentsFavoriteItem.vue
@@ -142,8 +142,14 @@ export default {
       }
     },
     url() {
-      if (this.isFileEditable || this.isFileReadable) {
-        return `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/oeditor?docId=${this.file?.id}${this.isFileReadable && !this.isFileEditable && '&mode=view' || ''}&backTo=${window.location.pathname}`;
+      if (this.isFileEditable)  {
+        if (this.file?.acl?.canEdit){
+          return this.$documentsUtils.getEditorUrl(this.file,'');
+        } else {
+          return this.$documentsUtils.getEditorUrl(this.file,'view');
+        }
+      } else if (this.isFileReadable)  {
+        return this.$documentsUtils.getEditorUrl(this.file,'view');
       } else {
         return null;
       }


### PR DESCRIPTION
Prior to this, when opening a doc from the favorite drawer, the link to go back from OO opens the home page instead of the documents. 
This change resolves this by changing the link.