### PR TITLE
fix: OnlyOffice document link shows blank page when session expires EXO-82725

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/filter/DocumentModeRedirectHandler.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/filter/DocumentModeRedirectHandler.java
@@ -40,6 +40,9 @@ public class DocumentModeRedirectHandler implements Filter {
     String documentPreviewId = httpServletRequest.getParameter("documentPreviewId");
     String documentEditId = httpServletRequest.getParameter("docId");
     String viewer = httpServletRequest.getRemoteUser();
+    if (viewer == null) {
+      chain.doFilter(request, response);
+    }
 
     String documentId = documentPreviewId != null ? documentPreviewId : documentEditId;
 


### PR DESCRIPTION
Prior to this change, opening an editable document displayed a blank page if the user was not logged in. This issue was caused by a null pointer exception thrown in `documentModeRedirectHandler` when checking the authenticated user’s permissions for the opened document. This change handles the exception, allows the filter process to continue.