### PR TITLE
Fix: change of path for documents in shortcut folder - EXO-83178

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -728,6 +728,16 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         }
         while (node != null && (!node.getPath().equals(homePath) || node.getName().equals(USER_PUBLIC_ROOT_NODE))) {
           try {
+            if (node.isNodeType(NodeTypeConstants.EXO_SYMLINK) && node.getPath().contains(SPACE_PATH_PREFIX)) {
+              String[] pathParts = node.getPath().split(SPACE_PATH_PREFIX)[1].split("/");
+              String homePathSymlink = SPACE_PATH_PREFIX + pathParts[0] + "/" + pathParts[1];
+              for (int i = 0; i < parents.size(); i++) {
+                String pathActuel = parents.get(i).getPath();
+                pathActuel = pathActuel.replace(homePath,homePathSymlink);
+                parents.get(i).setPath(pathActuel);
+              }
+              homePath = homePathSymlink;
+            }
             if(node.getName().equals(USER_PUBLIC_ROOT_NODE)){
               node = getIdentityRootNode(spaceService, nodeHierarchyCreator, username, ownerIdentity, sessionProvider);
               if (node != null) {


### PR DESCRIPTION
Before this change, when go to doc app of spacex and create folder2 sub-folder in folder1 then create a shortcut of folder1 in spacey and open folder2 in doc app of spacey then upload some files, the files are added in a new created folder. To fix this problem, correct the breadcrumb path to be added to file correctly. After this change, the files are uploaded to the current location.