### PR TITLE
feat: Include Documents Extensions when Attachment JS Module is loaded - EXO-83601

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/document-info-drawer/main.js
+++ b/documents-webapp/src/main/webapp/vue-app/document-info-drawer/main.js
@@ -78,6 +78,7 @@ export function init(event) {
             const registration = await navigator?.serviceWorker?.getRegistration?.();
             this.pwaEnabled = !!registration;
             this.isFavoritesSynchronized = this.pwaEnabled && (await this.$documentOfflineService.isOfflineDocumentsEnabled());
+            this.$utils.includeExtensions('DocumentsExtension');
           },
         },
         template: `<document-info-drawer id="${appId}"/>`,


### PR DESCRIPTION
This change will allow to initialize the Modules having the Prefix (or suffix) 'DocumentsExtension' when Attachments Info Drawer is displayed.