### PR TITLE
fix: Attachments to a note are not listed when editing the note - EXO-83533 (#1819)

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/attachment/components/notes/NotesAttachment.vue
+++ b/documents-webapp/src/main/webapp/vue-app/attachment/components/notes/NotesAttachment.vue
@@ -115,7 +115,7 @@ export default {
     openAttachmentDrawer() {
       this.originalAttachmentsList = [];
       this.attachments = [];
-      if (this.entityId > 0 && this.entityType && this.spaceId && !this.isEmptyNoteTranslation) {
+      if (this.entityId > 0 && this.entityType && !this.isEmptyNoteTranslation) {
         this.initDone = false;
         this.waitInit();
         this.initEntityAttachmentsList().then(() => {


### PR DESCRIPTION
Before this change, when editing the note, adding an attachment, and reopening the attachment drawer, the attachment drawer was empty. To fix this problem, remove the  check in the  method, as the necessary check for  already exists in the  method within the  event, where  is required. After this change, the list of attachments is displayed correctly.

(cherry picked from commit 910aaec84618d68162f884fc34ba09b238579d04)