### PR TITLE
feat: move document access control to service layer - EXO-83521 - exoplatform/eXIP#33

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/plugin/DocumentsImageThumbnailPlugin.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/plugin/DocumentsImageThumbnailPlugin.java
@@ -23,6 +23,9 @@ import org.exoplatform.documents.service.DocumentFileService;
 
 import io.meeds.portal.thumbnail.model.FileContent;
 import io.meeds.portal.thumbnail.plugin.ImageThumbnailPlugin;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.services.security.IdentityConstants;
 
 public class DocumentsImageThumbnailPlugin extends ImageThumbnailPlugin {
 
@@ -37,5 +40,15 @@ public class DocumentsImageThumbnailPlugin extends ImageThumbnailPlugin {
   public FileContent getImage(String fileId, String userName) throws ObjectNotFoundException {
     DocumentFileService documentFileService = CommonsUtils.getService(DocumentFileService.class);
     return documentFileService.getDocumentContent(fileId, userName);
+  }
+
+  @Override
+  public boolean hasAccessPermission(String fileId, String username) {
+    DocumentFileService documentFileService = CommonsUtils.getService(DocumentFileService.class);
+    Identity identityAcl = CommonsUtils.getService(UserACL.class).getUserIdentity(username);
+    if (identityAcl == null) {
+      identityAcl = new Identity(IdentityConstants.ANONIM);
+    }
+    return documentFileService.canAccess(fileId, identityAcl);
   }
 }

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/DocumentFileRest.java
@@ -1552,7 +1552,6 @@ public class DocumentFileRest implements ResourceContainer {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  @RolesAllowed("users")
   @Path("/{documentId}")
   @Operation(summary = "Get all details of a given document", method = "GET", description = "Get versions list of a a given document")
   @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"),
@@ -1572,9 +1571,6 @@ public class DocumentFileRest implements ResourceContainer {
       return Response.status(Status.BAD_REQUEST).entity("document id is mandatory").build();
     }
     long userIdentityId = RestUtils.getCurrentUserIdentityId(identityManager);
-    if (userIdentityId == 0) {
-      return Response.status(Response.Status.UNAUTHORIZED).build();
-    }
     try {
       AbstractNodeEntity abstractNodeEntity =
                                             EntityBuilder.toDocumentItemEntity(documentFileService,
@@ -1602,7 +1598,6 @@ public class DocumentFileRest implements ResourceContainer {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  @RolesAllowed("users")
   @Path("/{fileType}/{documentId}")
   @Operation(summary = "Get content of a given document", method = "GET", description = "Get content a a given document")
   @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"),

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1864,19 +1864,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       sessionProvider = getUserSessionProvider(repositoryService, aclIdentity);
       Session session = sessionProvider.getSession(COLLABORATION, manageableRepository);
       Node node = getNodeByIdentifier(session, documentID);
-      if(node == null) return false;
-
-      String userId = aclIdentity.getUserId();
-      List<AccessControlEntry> permsList = ((ExtendedNode) node).getACL().getPermissionEntries();
-      boolean canAccess = false;
-      for (AccessControlEntry accessControlEntry : permsList) {
-        String nodeAclIdentity = accessControlEntry.getIdentity();
-        MembershipEntry membershipEntry = accessControlEntry.getMembershipEntry();
-        if (StringUtils.equals(nodeAclIdentity, userId) || StringUtils.equals(IdentityConstants.ANY, userId) || (membershipEntry != null && aclIdentity.isMemberOf(membershipEntry) && !StringUtils.equals(membershipEntry.toString(), GROUP_ADMINISTRATORS))) {
-          canAccess = true;
-        }
-      }
-      return canAccess;
+      return node != null;
     } catch (AccessDeniedException | ItemNotFoundException e) {
       return false;
     } catch (Exception e) {


### PR DESCRIPTION
This change updates the document access control mechanism by removing role-based restrictions at the REST level and delegating authorization controls to the document access service.