### PR TITLE
fix: Fix trash restore path when parent folder is renamed - EXO-83976

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/storage/TrashStorage.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/storage/TrashStorage.java
@@ -136,4 +136,19 @@ public interface TrashStorage {
    * @return the total count of deleted documents
    */
   int countDeletedDocuments();
+
+
+  /**
+   * Updates the restore paths of nodes in the trash workspace when a parent folder has been renamed.
+   * <p>
+   * This method searches for all nodes whose {@code exo:restoreWorkspace} property starts with the given
+   * {@code oldPath}, and replaces that prefix with {@code newPath}. This ensures that nodes in the trash
+   * can be restored correctly even after the original folder has been moved or renamed.
+   * </p>
+   *
+   * @param oldPath the old path prefix to look for in the {@code exo:restoreWorkspace} property
+   * @param newPath the new path prefix to replace the old path with
+   * @throws RepositoryException if an error occurs while accessing or updating nodes in the repository
+   */
+  void updateRestorePath(String oldPath, String newPath) throws RepositoryException;
 }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -146,6 +146,8 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
 
   private final BulkStorageActionService            bulkStorageActionService;
 
+  private final String                              EVENT_DOCUMENT_MOVED        = "exo-document-moved";
+
   private final String                              DATE_FORMAT                 = "yyyy-MM-dd";
 
   private final String                              SPACE_PATH_PREFIX           = "/Groups/spaces/";
@@ -1050,6 +1052,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       node.setProperty(NodeTypeConstants.EXO_TITLE, title);
       node.setProperty(NodeTypeConstants.EXO_NAME, name);
       node.save();
+      listenerService.broadcast(EVENT_DOCUMENT_MOVED, srcPath, destPath);
     } catch (ObjectAlreadyExistsException e) {
       throw new ObjectAlreadyExistsException(e);
     } catch (Exception e) {
@@ -1235,11 +1238,13 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     node.save();
 
     String srcPath = node.getPath();
-    if (session.itemExists(destPath + SLASH + node.getName())) {
+    String nodeDestinationPath = destPath + SLASH + node.getName();
+    if (session.itemExists(nodeDestinationPath)) {
       handleMoveDocConflict(session, node, srcPath, destPath, conflictAction);
     } else {
-      node.getSession().getWorkspace().move(srcPath, destPath + SLASH + node.getName());
+      node.getSession().getWorkspace().move(srcPath, nodeDestinationPath);
       node.save();
+      listenerService.broadcast(EVENT_DOCUMENT_MOVED, srcPath, nodeDestinationPath);
     }
   }
 
@@ -1329,6 +1334,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         destNode.setProperty(NodeTypeConstants.EXO_TITLE, exoTitle);
       }
       destNode.getSession().save();
+      listenerService.broadcast(EVENT_DOCUMENT_MOVED, srcPath, destPath);
     } else if (Objects.equals(conflictAction, CREATE_NEW_VERSION)) {
       Node destNode = (Node) session.getItem(destPath + SLASH + name);
       Node scrNode = (Node) session.getItem(srcPath);

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/TrashStorageImpl.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/TrashStorageImpl.java
@@ -48,8 +48,7 @@ import javax.jcr.query.QueryResult;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_DATE_MODIFIED;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_TITLE;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.*;
 
 public class TrashStorageImpl implements TrashStorage {
 
@@ -641,6 +640,30 @@ public class TrashStorageImpl implements TrashStorage {
 
     trashNodeSession.save();
     restoreSession.save();
+  }
+
+  @Override
+  public void updateRestorePath(String oldPath, String newPath) throws RepositoryException {
+    SessionProvider sessionProvider = sessionProviderService.getSystemSessionProvider(null);
+    Session session = sessionProvider.getSession(this.trashWorkspace, repositoryService.getCurrentRepository());
+
+    String queryStr = "SELECT * FROM nt:base WHERE exo:restorePath LIKE '" + oldPath.replace("'", "''") + "%'";
+    QueryManager queryManager = session.getWorkspace().getQueryManager();
+    Query query = queryManager.createQuery(queryStr, Query.SQL);
+    QueryResult result = query.execute();
+
+    NodeIterator nodes = result.getNodes();
+    while (nodes.hasNext()) {
+      Node node = nodes.nextNode();
+      if (node.hasProperty(RESTORE_PATH)) {
+        String restorePath = node.getProperty(RESTORE_PATH).getString();
+
+        //Update path prefix
+        String updatedPath = restorePath.replaceFirst("^" + oldPath, newPath);
+        node.setProperty(RESTORE_PATH, updatedPath);
+      }
+    }
+    session.save();
   }
 
 }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/listener/MoveNodeListener.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/listener/MoveNodeListener.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.exoplatform.documents.storage.jcr.listener;
+
+import jakarta.annotation.PostConstruct;
+import org.exoplatform.documents.storage.TrashStorage;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.services.listener.ListenerService;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class MoveNodeListener extends Listener<String, String> {
+
+    private final TrashStorage trashStorage;
+    private final ListenerService listenerService;
+
+    public MoveNodeListener(TrashStorage trashStorage, ListenerService listenerService) {
+        this.trashStorage = trashStorage;
+        this.listenerService = listenerService;
+    }
+
+    @PostConstruct
+    public void init() {
+        listenerService.addListener("exo-document-moved", this);
+    }
+
+    @Override
+    public void onEvent(Event<String, String> event) throws Exception {
+        String oldPath = event.getSource();
+        String newPath = event.getData();
+        trashStorage.updateRestorePath(oldPath, newPath);
+    }
+}

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/TrashStorageImplTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/TrashStorageImplTest.java
@@ -16,6 +16,7 @@
 */
 package org.exoplatform.documents.storage.jcr;
 
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.RESTORE_PATH;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -187,8 +188,8 @@ public class TrashStorageImplTest {
     Property pathProperty = Mockito.mock(Property.class);
     lenient().when(((Node) sessionProviderService.getSystemSessionProvider(any()).getSession("trashWorkspace", repository).getItem(anyString())).getProperty(NodeTypeConstants.RESTORE_WORKSPACE)).thenReturn(property);
     lenient().when(((Node) sessionProviderService.getSystemSessionProvider(any()).getSession("trashWorkspace", repository).getItem(anyString())).getProperty(NodeTypeConstants.RESTORE_WORKSPACE).getString()).thenReturn(currentRepository);
-    lenient().when(((Node) sessionProviderService.getSystemSessionProvider(any()).getSession("trashWorkspace", repository).getItem(anyString())).getProperty(NodeTypeConstants.RESTORE_PATH)).thenReturn(pathProperty);
-    lenient().when(((Node) sessionProviderService.getSystemSessionProvider(any()).getSession("trashWorkspace", repository).getItem(anyString())).getProperty(NodeTypeConstants.RESTORE_PATH).getString()).thenReturn(path);
+    lenient().when(((Node) sessionProviderService.getSystemSessionProvider(any()).getSession("trashWorkspace", repository).getItem(anyString())).getProperty(RESTORE_PATH)).thenReturn(pathProperty);
+    lenient().when(((Node) sessionProviderService.getSystemSessionProvider(any()).getSession("trashWorkspace", repository).getItem(anyString())).getProperty(RESTORE_PATH).getString()).thenReturn(path);
     lenient().when(sessionProviderService.getSystemSessionProvider(any()).getSession("trashWorkspace", repository).getWorkspace().getName()).thenReturn(currentRepository);
     lenient().when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     lenient().when(repositoryService.getCurrentRepository()).thenReturn(repository);
@@ -208,7 +209,7 @@ public class TrashStorageImplTest {
     lenient().when(session.itemExists(anyString())).thenReturn(true);
     lenient().when(session.getItem(anyString())).thenReturn(node);
     lenient().when(node.isNodeType(NodeTypeConstants.RESTORE_WORKSPACE)).thenReturn(true);
-    lenient().when(node.isNodeType(NodeTypeConstants.RESTORE_PATH)).thenReturn(true);
+    lenient().when(node.isNodeType(RESTORE_PATH)).thenReturn(true);
     lenient().when(node.isNodeType(NodeTypeConstants.MIX_REFERENCEABLE)).thenReturn(true);
     lenient().when(node.isNodeType(NodeTypeConstants.EXO_RESTORE_LOCATION)).thenReturn(true);
     lenient().when(node.getNodes()).thenReturn(nodeIterator);
@@ -296,4 +297,63 @@ public class TrashStorageImplTest {
     assertNotNull(result);
     assertEquals(2, result.size());
   }
+
+    @Test
+    public void testUpdateRestorePath() throws Exception {
+        String oldPath = "/old/folder";
+        String newPath = "/new/folder";
+
+        Workspace workspace = mock(Workspace.class);
+        QueryManager queryManager = mock(QueryManager.class);
+        Query query = mock(Query.class);
+        QueryResult queryResult = mock(QueryResult.class);
+        NodeIterator nodeIterator = mock(NodeIterator.class);
+        Node node1 = mock(Node.class);
+        Node node2 = mock(Node.class);
+        Property property1 = mock(Property.class);
+        Property property2 = mock(Property.class);
+
+        when(repositoryService.getCurrentRepository()).thenReturn(repository);
+        when(sessionProviderService.getSystemSessionProvider(null)).thenReturn(sessionProvider);
+        when(sessionProvider.getSession(anyString(), eq(repository))).thenReturn(session);
+        when(session.getWorkspace()).thenReturn(workspace);
+        when(workspace.getQueryManager()).thenReturn(queryManager);
+
+        when(queryManager.createQuery(anyString(), eq(Query.SQL))).thenReturn(query);
+        when(query.execute()).thenReturn(queryResult);
+        when(queryResult.getNodes()).thenReturn(nodeIterator);
+
+        // Iterator behavior (2 nodes)
+        when(nodeIterator.hasNext()).thenReturn(true, true, false);
+        when(nodeIterator.nextNode()).thenReturn(node1, node2);
+
+        // Node 1 has restore path
+        when(node1.hasProperty(RESTORE_PATH)).thenReturn(true);
+        when(node1.getProperty(RESTORE_PATH)).thenReturn(property1);
+        when(property1.getString()).thenReturn("/old/folder/doc1");
+
+        // Node 2 has restore path
+        when(node2.hasProperty(RESTORE_PATH)).thenReturn(true);
+        when(node2.getProperty(RESTORE_PATH)).thenReturn(property2);
+        when(property2.getString()).thenReturn("/old/folder/sub/doc2");
+
+        // Execute
+        trashStorage.updateRestorePath(oldPath, newPath);
+
+        // Verify query execution
+        verify(queryManager).createQuery(anyString(), eq(Query.SQL));
+        verify(query).execute();
+        verify(queryResult).getNodes();
+
+        // Verify iteration
+        verify(nodeIterator, times(3)).hasNext();
+        verify(nodeIterator, times(2)).nextNode();
+
+        // Verify updates
+        verify(node1).setProperty(RESTORE_PATH, "/new/folder/doc1");
+        verify(node2).setProperty(RESTORE_PATH, "/new/folder/sub/doc2");
+
+        // Verify save
+        verify(session).save();
+    }
 }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/listener/MoveNodeListenerTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/listener/MoveNodeListenerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.documents.storage.jcr.listener;
+
+import static org.mockito.Mockito.*;
+
+import org.exoplatform.documents.storage.TrashStorage;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.ListenerService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MoveNodeListenerTest {
+
+    private TrashStorage trashStorage;
+    private ListenerService listenerService;
+    private MoveNodeListener moveNodeListener;
+
+    @Before
+    public void setUp() {
+        trashStorage = mock(TrashStorage.class);
+        listenerService = mock(ListenerService.class);
+        moveNodeListener = new MoveNodeListener(trashStorage, listenerService);
+    }
+
+    @Test
+    public void testInitRegistersListener() {
+        moveNodeListener.init();
+        verify(listenerService, times(1))
+                .addListener(eq("exo-document-moved"), eq(moveNodeListener));
+    }
+
+    @Test
+    public void testOnEventCallsUpdateRestorePath() throws Exception {
+        String oldPath = "/old/folder";
+        String newPath = "/new/folder";
+
+        @SuppressWarnings("unchecked")
+        Event<String, String> event = mock(Event.class);
+
+        when(event.getSource()).thenReturn(oldPath);
+        when(event.getData()).thenReturn(newPath);
+
+        moveNodeListener.onEvent(event);
+        verify(trashStorage, times(1))
+                .updateRestorePath(oldPath, newPath);
+    }
+}


### PR DESCRIPTION
Prior to this change, documents in the trash could not be restored if a parent folder was renamed or moved.

The restore mechanism relies on the `exo:restorePath` property, which becomes invalid when a parent folder path changes. As a result, restore operations failed because the stored path no longer matched the real structure.

This PR fixes the issue by creating a listener that tracks the move document event and update the restore path of trashed nodes accordingly to prevent the reference loss.