### PR TITLE
fix: fix Optimize trash query by scoping to trashHome and exo:restoreLocation - EXO-83976

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -17,8 +17,7 @@
 package org.exoplatform.documents.storage.jcr;
 
 import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.*;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.DOCUMENT_CATEGORY_IDS;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_SYMLINK;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.*;
 import static org.gatein.common.net.URLTools.SLASH;
 
 import java.io.File;
@@ -147,6 +146,10 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
   private final BulkStorageActionService            bulkStorageActionService;
 
   private final String                              EVENT_DOCUMENT_MOVED        = "exo-document-moved";
+
+  private final String                              DEST_PATH                   = "destPath";
+
+  private final String                              SRC_PATH                    = "srcPath";
 
   private final String                              DATE_FORMAT                 = "yyyy-MM-dd";
 
@@ -1052,7 +1055,10 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       node.setProperty(NodeTypeConstants.EXO_TITLE, title);
       node.setProperty(NodeTypeConstants.EXO_NAME, name);
       node.save();
-      listenerService.broadcast(EVENT_DOCUMENT_MOVED, srcPath, destPath);
+      listenerService.broadcast(EVENT_DOCUMENT_MOVED,
+              Map.of(SRC_PATH, srcPath, DEST_PATH, destPath),
+              node.getPrimaryNodeType().getName());
+
     } catch (ObjectAlreadyExistsException e) {
       throw new ObjectAlreadyExistsException(e);
     } catch (Exception e) {
@@ -1244,7 +1250,9 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     } else {
       node.getSession().getWorkspace().move(srcPath, nodeDestinationPath);
       node.save();
-      listenerService.broadcast(EVENT_DOCUMENT_MOVED, srcPath, nodeDestinationPath);
+      listenerService.broadcast(EVENT_DOCUMENT_MOVED,
+                Map.of(SRC_PATH, srcPath, DEST_PATH, nodeDestinationPath),
+                node.getPrimaryNodeType().getName());
     }
   }
 
@@ -1334,7 +1342,10 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         destNode.setProperty(NodeTypeConstants.EXO_TITLE, exoTitle);
       }
       destNode.getSession().save();
-      listenerService.broadcast(EVENT_DOCUMENT_MOVED, srcPath, destPath);
+
+      listenerService.broadcast(EVENT_DOCUMENT_MOVED,
+                Map.of(SRC_PATH, srcPath, DEST_PATH, destPath),
+                node.getPrimaryNodeType().getName());
     } else if (Objects.equals(conflictAction, CREATE_NEW_VERSION)) {
       Node destNode = (Node) session.getItem(destPath + SLASH + name);
       Node scrNode = (Node) session.getItem(srcPath);

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/TrashStorageImpl.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/TrashStorageImpl.java
@@ -647,7 +647,14 @@ public class TrashStorageImpl implements TrashStorage {
     SessionProvider sessionProvider = sessionProviderService.getSystemSessionProvider(null);
     Session session = sessionProvider.getSession(this.trashWorkspace, repositoryService.getCurrentRepository());
 
-    String queryStr = "SELECT * FROM nt:base WHERE exo:restorePath LIKE '" + oldPath.replace("'", "''") + "%'";
+    String safePath = oldPath.startsWith("/") ? oldPath : "/" + oldPath;
+    String queryStr = """
+                        SELECT * FROM exo:restoreLocation
+                        WHERE jcr:path LIKE '%s/%%'
+                        AND exo:restorePath LIKE '%s%%'
+                        """.formatted(
+                          trashHome.replace("'", "''"),
+                          safePath.replace("'", "''"));
     QueryManager queryManager = session.getWorkspace().getQueryManager();
     Query query = queryManager.createQuery(queryStr, Query.SQL);
     QueryResult result = query.execute();

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/listener/MoveNodeListener.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/listener/MoveNodeListener.java
@@ -24,9 +24,13 @@ import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.listener.ListenerService;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.NT_FOLDER;
+
 
 @Component
-public class MoveNodeListener extends Listener<String, String> {
+public class MoveNodeListener extends Listener<Map<String, String>, String> {
 
     private final TrashStorage trashStorage;
     private final ListenerService listenerService;
@@ -42,9 +46,13 @@ public class MoveNodeListener extends Listener<String, String> {
     }
 
     @Override
-    public void onEvent(Event<String, String> event) throws Exception {
-        String oldPath = event.getSource();
-        String newPath = event.getData();
-        trashStorage.updateRestorePath(oldPath, newPath);
+    public void onEvent(Event<Map<String, String>, String> event) throws Exception {
+        Map<String, String> source = event.getSource();
+        String newPath = source.get("destPath");
+        String oldPath = source.get("srcPath");
+        boolean isFolder = event.getData().equals(NT_FOLDER);
+        if (isFolder) {
+            trashStorage.updateRestorePath(oldPath, newPath);
+        }
     }
 }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -1306,6 +1306,9 @@ public class JCRDocumentFileStorageTest {
     when(node.canAddMixin(NodeTypeConstants.EXO_MODIFY)).thenReturn(true);
     when(node.getPath()).thenReturn("path");
     when(node.getName()).thenReturn("test.docx");
+    NodeType nodeType = mock(NodeType.class);
+    when(nodeType.getName()).thenReturn("nt:file");
+    when(node.getPrimaryNodeType()).thenReturn(nodeType);
     when(session.itemExists(anyString())).thenReturn(false);
     when(node.getSession()).thenReturn(session);
     Workspace workspace = mock(Workspace.class);

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/listener/MoveNodeListenerTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/listener/MoveNodeListenerTest.java
@@ -26,6 +26,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Map;
+
 @RunWith(MockitoJUnitRunner.class)
 public class MoveNodeListenerTest {
 
@@ -52,11 +54,15 @@ public class MoveNodeListenerTest {
         String oldPath = "/old/folder";
         String newPath = "/new/folder";
 
-        @SuppressWarnings("unchecked")
-        Event<String, String> event = mock(Event.class);
+        String nodeTypeName = "nt:folder";
 
-        when(event.getSource()).thenReturn(oldPath);
-        when(event.getData()).thenReturn(newPath);
+        Map<String, String> source = Map.of("srcPath", oldPath, "destPath", newPath);
+
+        @SuppressWarnings("unchecked")
+        Event<Map<String, String>, String> event = mock(Event.class);
+
+        when(event.getSource()).thenReturn(source);
+        when(event.getData()).thenReturn(nodeTypeName);
 
         moveNodeListener.onEvent(event);
         verify(trashStorage, times(1))


### PR DESCRIPTION
- Scope JCR-SQL query to the Trash subtree using dynamic trashHome path
- Replace global repository scanning with path-restricted lookup
- Use exo:restoreLocation instead of nt:base to limit results to nodes that actually contain exo:restorePath metadata
- Prevent unnecessary traversal of non-trash documents

This change ensures the query only targets restore metadata nodes inside the Trash folder, avoiding full-repository scans and improving execution time on large repositories.