### PR TITLE
fix: Fix copied links truncation by URL-encoding folder paths - EXO-83734

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/CopyLinkMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/CopyLinkMenuAction.vue
@@ -45,6 +45,7 @@ export default {
       } else {
         path = `${window.location.origin}${this.$documentsUtils.getParentFolderUrl(this.file)}?documentPreviewId=${this.file.id}`;
       }
+      path = encodeURI(path);
       if (navigator?.clipboard?.writeText) {
         navigator.clipboard.writeText(path).catch(() => {
           this.copy(path);


### PR DESCRIPTION
Prior to this change, copied document and folder links were truncated when folder names contained spaces, because the generated URLs were not properly encoded.

This PR fixes the issue by applying URL encoding to the generated paths before copying them to the clipboard, ensuring valid, browser-safe URLs and reliable link sharing regardless of folder naming.