### PR TITLE
fix: change the permissions of the root node based on space permissions - EXO-84115

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/listener/RestrictContentCreationSpaceListener.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/listener/RestrictContentCreationSpaceListener.java
@@ -1,0 +1,98 @@
+package org.exoplatform.documents.storage.jcr.listener;
+
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.access.AccessControlEntry;
+import org.exoplatform.services.jcr.access.PermissionType;
+import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.social.core.space.SpaceListenerPlugin;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceLifeCycleEvent;
+
+import javax.jcr.Node;
+import javax.jcr.Session;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.getGroupNode;
+
+public class RestrictContentCreationSpaceListener extends SpaceListenerPlugin {
+  private static final Log       LOG = ExoLogger.getExoLogger(RestrictContentCreationSpaceListener.class);
+
+  private RepositoryService      repositoryService;
+
+  private NodeHierarchyCreator   nodeHierarchyCreator;
+
+  private SessionProviderService sessionProviderService;
+
+  public RestrictContentCreationSpaceListener(RepositoryService repositoryService,
+                                              NodeHierarchyCreator nodeHierarchyCreator,
+                                              SessionProviderService sessionProviderService) {
+    this.repositoryService = repositoryService;
+    this.nodeHierarchyCreator = nodeHierarchyCreator;
+    this.sessionProviderService = sessionProviderService;
+  }
+
+  @Override
+  public void addRedactorUser(SpaceLifeCycleEvent event) {
+    Space space = event.getSpace();
+    if (space.getRedactors() != null && space.getRedactors().length == 1) {
+      changePermissionsForSpaceMembers(space, true);
+    }
+  }
+
+  @Override
+  public void removeRedactorUser(SpaceLifeCycleEvent event) {
+    Space space = event.getSpace();
+    if (space.getRedactors() == null || space.getRedactors().length == 0) {
+      changePermissionsForSpaceMembers(space, false);
+    }
+  }
+
+  private void changePermissionsForSpaceMembers(Space space, boolean readOnlyForMembers) {
+    SessionProvider sessionProvider = null;
+    try {
+      ManageableRepository repository = repositoryService.getCurrentRepository();
+      sessionProvider = sessionProviderService.getSystemSessionProvider(null);
+      Session session = sessionProvider.getSession("collaboration", repository);
+      Node spaceRootNode = getGroupNode(nodeHierarchyCreator, session, space.getGroupId());
+      Map<String, String[]> permissions = new HashMap<>();
+      if (spaceRootNode != null) {
+        for (AccessControlEntry accessEntry : ((ExtendedNode) spaceRootNode).getACL().getPermissionEntries()) {
+          if (!accessEntry.getIdentity().endsWith(":" + space.getGroupId())) {
+            if (permissions.get(accessEntry.getIdentity()) == null) {
+              permissions.put(accessEntry.getIdentity(), new String[] { accessEntry.getPermission() });
+            } else {
+              List<String> existingPermissions = new ArrayList<>(List.of(permissions.get(accessEntry.getIdentity())));
+              existingPermissions.add(accessEntry.getPermission());
+              permissions.put(accessEntry.getIdentity(), existingPermissions.toArray(new String[0]));
+            }
+          }
+        }
+        if (readOnlyForMembers) {
+          permissions.put("*:" + space.getGroupId(), new String[] { PermissionType.READ });
+          permissions.put("manager:" + space.getGroupId(), PermissionType.ALL);
+          permissions.put("redactor:" + space.getGroupId(), PermissionType.ALL);
+        } else {
+          permissions.put("*:" + space.getGroupId(), PermissionType.ALL);
+        }
+        ((ExtendedNode) spaceRootNode).setPermissions(permissions);
+        session.save();
+      }
+    } catch (Exception e) {
+      LOG.error("Error updating permissions of the root Node of the space {}", space.getPrettyName(), e);
+    } finally {
+      if (sessionProvider != null) {
+        sessionProvider.close();
+      }
+    }
+  }
+}

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/listener/RestrictContentCreationSpaceListenerTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/listener/RestrictContentCreationSpaceListenerTest.java
@@ -1,0 +1,128 @@
+package org.exoplatform.documents.storage.jcr.listener;
+
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.access.AccessControlEntry;
+import org.exoplatform.services.jcr.access.AccessControlList;
+import org.exoplatform.services.jcr.access.PermissionType;
+import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceLifeCycleEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+class RestrictContentCreationSpaceListenerTest {
+
+  RestrictContentCreationSpaceListener restrictContentCreationSpaceListener;
+
+  String                               userId      = "userOne";
+
+  RepositoryService                    repositoryService;
+
+  NodeHierarchyCreator                 nodeHierarchyCreator;
+
+  ManageableRepository                 repository;
+
+  SessionProviderService               sessionProviderService;
+
+  SessionProvider                      systemSessionProvider;
+
+  ExtendedNode                         groupNode   = Mockito.mock(ExtendedNode.class);
+
+  AccessControlList                    acl         = mock(AccessControlList.class);
+
+  String                               memberShip1 = "member:/spaces/groupOne";
+
+  String                               memberShip2 = "*:/platform/users";
+
+  String                               memberShip3 = "member:/organization/board";
+
+  String                               groupId     = "/spaces/groupOne";
+
+  @BeforeEach
+  void setUp() throws RepositoryException {
+    repositoryService = mock(RepositoryService.class);
+    nodeHierarchyCreator = mock(NodeHierarchyCreator.class);
+    repository = mock(ManageableRepository.class);
+    systemSessionProvider = mock(SessionProvider.class);
+    sessionProviderService = mock(SessionProviderService.class);
+
+    when(sessionProviderService.getSystemSessionProvider(null)).thenReturn(systemSessionProvider);
+    Session session = mock(Session.class);
+
+    when(repositoryService.getCurrentRepository()).thenReturn(repository);
+    when(session.itemExists(anyString())).thenReturn(true);
+    when(session.getItem(anyString())).thenReturn(groupNode);
+    when(systemSessionProvider.getSession(anyString(), any())).thenReturn(session);
+    this.restrictContentCreationSpaceListener = new RestrictContentCreationSpaceListener(repositoryService,
+                                                                                         nodeHierarchyCreator,
+                                                                                         sessionProviderService);
+
+    List<AccessControlEntry> permissionEntries = new ArrayList<>();
+    permissionEntries.add(new AccessControlEntry("root", "read"));
+    permissionEntries.add(new AccessControlEntry("root", "add_node"));
+    permissionEntries.add(new AccessControlEntry("root", "set_property"));
+    permissionEntries.add(new AccessControlEntry("root", "remove"));
+    permissionEntries.add(new AccessControlEntry(memberShip1, "read"));
+    permissionEntries.add(new AccessControlEntry(memberShip1, "add_node"));
+    permissionEntries.add(new AccessControlEntry(memberShip1, "set_property"));
+    permissionEntries.add(new AccessControlEntry(memberShip1, "remove"));
+    permissionEntries.add(new AccessControlEntry(memberShip2, "read"));
+    permissionEntries.add(new AccessControlEntry(memberShip3, "read"));
+    permissionEntries.add(new AccessControlEntry(memberShip3, "add_node"));
+    permissionEntries.add(new AccessControlEntry(memberShip3, "set_property"));
+    permissionEntries.add(new AccessControlEntry(memberShip3, "remove"));
+    when(acl.getPermissionEntries()).thenReturn(permissionEntries);
+  }
+
+  @Test
+  void addRedactorUser() throws RepositoryException {
+    Space space = new Space();
+    space.setGroupId(groupId);
+    space.setRedactors(new String[] { "root" });
+    when(groupNode.getACL()).thenReturn(acl);
+
+    SpaceLifeCycleEvent event = new SpaceLifeCycleEvent(space, userId, SpaceLifeCycleEvent.Type.ADD_REDACTOR_USER);
+    restrictContentCreationSpaceListener.addRedactorUser(event);
+    ArgumentCaptor<Map<String, String[]>> argumentCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(groupNode).setPermissions(argumentCaptor.capture());
+    Map<String, String[]> capturedArgument = argumentCaptor.getValue();
+    assertNotNull(capturedArgument);
+    assertArrayEquals(new String[]{"read"}, capturedArgument.get("*:/spaces/groupOne"));
+  }
+
+  @Test
+  void removeRedactorUser() throws RepositoryException {
+    Space space = new Space();
+    space.setGroupId(groupId);
+
+    when(groupNode.getACL()).thenReturn(acl);
+
+    SpaceLifeCycleEvent event = new SpaceLifeCycleEvent(space, userId, SpaceLifeCycleEvent.Type.REMOVE_REDACTOR_USER);
+    restrictContentCreationSpaceListener.removeRedactorUser(event);
+    ArgumentCaptor<Map<String, String[]>> argumentCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(groupNode).setPermissions(argumentCaptor.capture());
+    Map<String, String[]> capturedArgument = argumentCaptor.getValue();
+    assertNotNull(capturedArgument);
+    assertArrayEquals(PermissionType.ALL, capturedArgument.get("*:/spaces/groupOne"));
+  }
+}

--- a/documents-webapp/src/main/webapp/WEB-INF/conf/documents/documents-service-configuration.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/conf/documents/documents-service-configuration.xml
@@ -71,6 +71,15 @@
   </external-component-plugins>
 
   <external-component-plugins>
+    <target-component>org.exoplatform.social.core.space.spi.SpaceService</target-component>
+    <component-plugin>
+      <name>SpaceIndexingListenerImpl</name>
+      <set-method>addSpaceListener</set-method>
+      <type>org.exoplatform.documents.storage.jcr.listener.RestrictContentCreationSpaceListener</type>
+    </component-plugin>
+  </external-component-plugins>
+
+  <external-component-plugins>
     <target-component>org.exoplatform.web.filter.ExtensibleFilter</target-component>
     <component-plugin>
       <name>Documents preview filter</name>

--- a/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentListDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/document-gadget/components/DocumentListDrawer.vue
@@ -37,19 +37,6 @@
         </v-icon>
       </v-btn> 
     </template>
-    <template #titleIcons>
-      <v-btn
-        :title="$t('documents.documentGadget.seeMore')"
-        v-if="$root.settings.displayAccessDrive"
-        link
-        icon
-        @click="openDrive">
-        <v-icon
-          size="20px">
-          fas fa-external-link-alt
-        </v-icon>
-      </v-btn> 
-    </template>
     <template #content>
       <document-list-empty-message v-if="!hasDocuments && !loading" :title="noDocumentMessage" />
       <document-list-widget-item


### PR DESCRIPTION
When the restrict Con,tent creation is enabled, only redactors are able to edit/add content to the space.
This restriction was not set since all space members are still able to add files and folders on the root Node of the space.
This change will disable adding contents on the space root node when redactors are enabled