### PR TITLE
fix: Category filters are no more listed in recent view - EXO-84876

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/plugins/DocumentCategoryPlugin.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/plugins/DocumentCategoryPlugin.java
@@ -55,8 +55,8 @@ public class DocumentCategoryPlugin implements CategoryPlugin {
   }
 
   @Override
-  public List<Long> getCategoryIds(long spaceId) {
-    return documentFileService.getDocumentCategoryIds(spaceId, userAcl.getSuperUser());
+  public List<Long> getCategoryIds(long spaceId, String username) {
+    return documentFileService.getDocumentCategoryIds(spaceId, username);
   }
 
 }


### PR DESCRIPTION
Prior to this change, when accessing the Space Drive recent view, if categories were linked to a document, the category filter was not displayed and an `UnsupportedOperationException` was thrown by the default implementation. This was due to the update of the `getCategoryIds` method signature in `CategoryPluginService`, which now includes the username parameter.

This change updates the `DocumentCategoryPlugin` to align with the new method signature.