### PR TITLE
fix: files displayed in lowercase and without accents when opened from webdav - EXO-84286

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandler.java
@@ -17,81 +17,25 @@
 package org.exoplatform.documents.storage.jcr.webdav.plugin;
 
 import static org.exoplatform.documents.storage.jcr.util.ACLProperties.getReadOnlyACL;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_DATE_CREATED;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_DATE_MODIFIED;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_HIDDENABLE;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_LAST_MODIFIED_DATE;
+import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.getTitle;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.*;
 import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_CONTENT;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_CREATED_DATE;
 import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_DATA;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_ENCODING;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_FROZEN_NODE;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_LAST_MODIFIED;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_MIME_TYPE;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_ROOT_VERSION;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.MIX_LOCKABLE;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.MIX_VERSIONABLE;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.NT_FOLDER;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.NT_UNSTRUCTURED;
 import static org.exoplatform.documents.storage.jcr.util.Utils.decodeString;
 import static org.exoplatform.documents.storage.jcr.util.Utils.getStringProperty;
-import static org.exoplatform.documents.storage.jcr.webdav.plugin.PathCommandHandler.IDENTITY_PATHS_FORMAT;
-import static org.exoplatform.documents.storage.jcr.webdav.plugin.PathCommandHandler.LOG;
-import static org.exoplatform.documents.storage.jcr.webdav.plugin.PathCommandHandler.PATHS_CONCAT_FORMAT;
-import static org.exoplatform.documents.storage.jcr.webdav.plugin.PathCommandHandler.PROPERTY_NAMES;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.CHECKEDIN;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.CHECKEDOUT;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.CHILDCOUNT;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.CREATIONDATE;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.CREATION_PATTERN;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.DISPLAYNAME;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.GETCONTENTLENGTH;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.GETCONTENTTYPE;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.GETLASTMODIFIED;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.GET_ETAG;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.HASCHILDREN;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.HREF;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.ISCOLLECTION;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.ISFOLDER;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.ISROOT;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.ISVERSIONED;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.LOCKDISCOVERY;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.MODIFICATION_PATTERN;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.OWNER;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.PARENTNAME;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.PREDECESSORSET;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.RESOURCETYPE;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.SUCCESSORSET;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.SUPPORTEDLOCK;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.SUPPORTEDMETHODSET;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.VERSIONHISTORY;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.VERSIONNAME;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.getIsFolderItemProperty;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.getLockDiscovery;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.getSupportedLock;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.getSupportedMethodSet;
+import static org.exoplatform.documents.storage.jcr.webdav.plugin.PathCommandHandler.*;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.*;
 
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import javax.jcr.Item;
-import javax.jcr.Node;
-import javax.jcr.NodeIterator;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
+import javax.jcr.*;
 import javax.jcr.version.Version;
 import javax.jcr.version.VersionIterator;
 import javax.xml.namespace.QName;
@@ -102,6 +46,7 @@ import org.springframework.stereotype.Component;
 
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.documents.storage.jcr.util.ACLProperties;
+import org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil;
 import org.exoplatform.documents.storage.jcr.util.NodeTypeConstants;
 import org.exoplatform.documents.storage.jcr.webdav.model.JcrNamespaceContext;
 import org.exoplatform.documents.webdav.model.WebDavException;
@@ -110,6 +55,7 @@ import org.exoplatform.documents.webdav.model.WebDavItem;
 import org.exoplatform.documents.webdav.model.WebDavItemProperty;
 import org.exoplatform.documents.webdav.model.constant.FileConstants;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
+import org.exoplatform.services.jcr.util.Text;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.manager.IdentityManager;
@@ -211,7 +157,7 @@ public class WebdavReadCommandHandler {
     String mimeType = node.getNode(JCR_CONTENT).getProperty(JCR_MIME_TYPE).getString();
     InputStream inputStream = node.getNode(JCR_CONTENT).getProperty(JCR_DATA).getStream();
 
-    return new WebDavFileDownload(node.getName(),
+    return new WebDavFileDownload(getTitle(node),
                                   inputStream.available(),
                                   lastModifiedDate == null ? 0l : lastModifiedDate.getTimeInMillis(),
                                   mimeType,
@@ -269,6 +215,7 @@ public class WebdavReadCommandHandler {
   @SneakyThrows
   public boolean isFile(Session session, String webDavPath) {
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
+    jcrPath = checkResourceExists(session, jcrPath);
     if (session.itemExists(jcrPath)) {
       Item item = session.getItem(jcrPath);
       if (item instanceof Node node) {
@@ -328,10 +275,7 @@ public class WebdavReadCommandHandler {
       version = jcrPath.substring(jcrPath.indexOf(VERSION_QUERY_PARAM) + VERSION_QUERY_PARAM.length());
       jcrPath = jcrPath.substring(0, jcrPath.indexOf(VERSION_QUERY_PARAM));
     }
-    if (!session.itemExists(jcrPath)) {
-      throw new WebDavException(HttpStatus.SC_NOT_FOUND,
-                                String.format("Resource with path '%s' not found", jcrPath));
-    }
+    jcrPath = checkResourceExists(session, jcrPath);
     Item item = session.getItem(jcrPath);
     if (!(item instanceof Node node)) {
       throw new WebDavException(HttpStatus.SC_BAD_REQUEST,
@@ -452,7 +396,7 @@ public class WebdavReadCommandHandler {
     if (name.equals(DISPLAYNAME)) {
       return version == null ? new WebDavItemProperty(name,
                                                       String.format("%s%s",
-                                                                    decodeString(node.getName()),
+                                                                    decodeString(getTitle(node)),
                                                                     getNodeIndexSuffix(node))) :
                              new WebDavItemProperty(name, decodeString(version.getName()));
     } else if (VERSIONNAME.equals(name)) {
@@ -840,5 +784,26 @@ public class WebdavReadCommandHandler {
       return identity.getProfile().getFullName();
     }
   }
+
+  private String checkResourceExists(Session session, String jcrPath) throws RepositoryException, WebDavException {
+    if (!session.itemExists(jcrPath)) {
+      String[] parts = jcrPath.split("/");
+      String fileTitle = parts[parts.length - 1];
+      String cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(fileTitle.toLowerCase(),NodeTypeConstants.NT_FILE));
+      parts[parts.length - 1] = cleanName;
+      jcrPath =  Arrays.stream(parts).collect(Collectors.joining("/"));
+      if (!session.itemExists(jcrPath)) {
+        cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanName(fileTitle.toLowerCase()));
+        parts[parts.length - 1] = cleanName;
+        jcrPath =  Arrays.stream(parts).collect(Collectors.joining("/"));
+      }
+      if (!session.itemExists(jcrPath)) {
+        throw new WebDavException(HttpStatus.SC_NOT_FOUND,
+                String.format("Resource with path '%s' not found", jcrPath));
+      }
+    }
+    return jcrPath;
+  }
+
 
 }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavWriteCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavWriteCommandHandler.java
@@ -17,40 +17,16 @@
 package org.exoplatform.documents.storage.jcr.webdav.plugin;
 
 import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.*;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_DATA;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_ENCODING;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_LAST_MODIFIED;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_MIME_TYPE;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.MIX_LOCKABLE;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.MIX_VERSIONABLE;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.NT_FILE;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.NT_FOLDER;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.NT_RESOURCE;
 import static org.exoplatform.documents.storage.jcr.util.Utils.encodeNodeName;
 import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.getStatusDescription;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
+import java.util.stream.Collectors;
 
-import javax.jcr.AccessDeniedException;
-import javax.jcr.Item;
-import javax.jcr.ItemNotFoundException;
-import javax.jcr.Node;
-import javax.jcr.NodeIterator;
-import javax.jcr.PathNotFoundException;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.Workspace;
+import javax.jcr.*;
 import javax.jcr.lock.Lock;
 import javax.jcr.lock.LockException;
 import javax.jcr.version.Version;
@@ -70,6 +46,8 @@ import org.exoplatform.commons.api.settings.data.Context;
 import org.exoplatform.commons.api.settings.data.Scope;
 import org.exoplatform.commons.utils.MimeTypeResolver;
 import org.exoplatform.documents.storage.TrashStorage;
+import org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil;
+import org.exoplatform.documents.storage.jcr.util.NodeTypeConstants;
 import org.exoplatform.documents.webdav.model.WebDavException;
 import org.exoplatform.documents.webdav.model.WebDavItemOrder;
 import org.exoplatform.documents.webdav.model.WebDavItemProperty;
@@ -89,6 +67,7 @@ import org.exoplatform.services.jcr.ext.utils.VersionHistoryUtils;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.jcr.impl.core.SessionImpl;
 import org.exoplatform.services.jcr.impl.core.WorkspaceImpl;
+import org.exoplatform.services.jcr.util.Text;
 import org.exoplatform.services.jcr.webdav.util.InitParamsDefaults;
 import org.exoplatform.services.jcr.webdav.util.PropertyConstants;
 import org.exoplatform.services.jcr.webdav.util.TextUtil;
@@ -168,6 +147,13 @@ public class WebdavWriteCommandHandler {
                        InputStream inputStream) {
     checkNotRoot(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
+    if (!session.itemExists(jcrPath)) {
+      String[] parts = jcrPath.split("/");
+      String fileTitle = parts[parts.length - 1];
+      fileTitle = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(fileTitle.toLowerCase(), NodeTypeConstants.NT_FILE));
+      parts[parts.length - 1] = fileTitle;
+      jcrPath = Arrays.stream(parts).collect(Collectors.joining("/"));
+    }
     Node node = session.itemExists(jcrPath) ? (Node) session.getItem(jcrPath) : null;
     Calendar now = Calendar.getInstance();
     if (node == null) {
@@ -200,7 +186,7 @@ public class WebdavWriteCommandHandler {
                                                                     List<WebDavItemProperty> propertiesToRemove) throws WebDavException {
     checkNotReadOnly(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    checkResourceExists(session, jcrPath);
+    jcrPath = checkResourceExists(session, jcrPath);
     Node node = (Node) session.getItem(jcrPath);
     Map<String, Collection<WebDavItemProperty>> result = new HashMap<>();
     for (int i = 0; i < propertiesToSave.size(); i++) {
@@ -264,7 +250,7 @@ public class WebdavWriteCommandHandler {
                      String webDavPath) throws WebDavException {
     checkNotReadOnly(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    checkResourceExists(session, jcrPath);
+    jcrPath = checkResourceExists(session, jcrPath);
 
     Node node = (Node) session.getItem(jcrPath);
     forceUnlock(node);
@@ -286,7 +272,7 @@ public class WebdavWriteCommandHandler {
     checkNotRoot(webDavTargetPath);
     String sourceJcrPath = pathCommandHandler.transformToJcrPath(webDavSourcePath);
     String targetJcrPath = pathCommandHandler.transformToJcrPath(webDavTargetPath);
-    checkResourceExists(session, sourceJcrPath);
+    sourceJcrPath = checkResourceExists(session, sourceJcrPath);
     boolean itemExists = session.itemExists(targetJcrPath);
     if (itemExists) {
       if (overwrite) {
@@ -319,7 +305,7 @@ public class WebdavWriteCommandHandler {
     checkNotRoot(webDavTargetPath);
     String sourceJcrPath = pathCommandHandler.transformToJcrPath(webDavSourcePath);
     String targetJcrPath = pathCommandHandler.transformToJcrPath(webDavTargetPath);
-    checkResourceExists(session, sourceJcrPath);
+    sourceJcrPath = checkResourceExists(session, sourceJcrPath);
     boolean itemExists = session.itemExists(targetJcrPath);
     if (itemExists && removeDestination) {
       Item destItem = session.getItem(targetJcrPath);
@@ -337,7 +323,7 @@ public class WebdavWriteCommandHandler {
                                String webDavPath) {
     checkNotReadOnly(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    checkResourceExists(session, jcrPath);
+    jcrPath = checkResourceExists(session, jcrPath);
     Node node = (Node) session.getItem(jcrPath);
     forceUnlock(node);
     if (!node.isNodeType(MIX_VERSIONABLE)) {
@@ -351,7 +337,7 @@ public class WebdavWriteCommandHandler {
                       String webDavPath) {
     checkNotReadOnly(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    checkResourceExists(session, jcrPath);
+    jcrPath = checkResourceExists(session, jcrPath);
     Node node = session.getRootNode().getNode(TextUtil.relativizePath(jcrPath));
     forceUnlock(node);
     node.checkin();
@@ -362,7 +348,7 @@ public class WebdavWriteCommandHandler {
                        String webDavPath) throws WebDavException {
     checkNotReadOnly(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    checkResourceExists(session, jcrPath);
+    jcrPath = checkResourceExists(session, jcrPath);
     Node node = session.getRootNode().getNode(TextUtil.relativizePath(jcrPath));
     node.checkout();
   }
@@ -372,7 +358,7 @@ public class WebdavWriteCommandHandler {
                          String webDavPath) throws WebDavException {
     checkNotReadOnly(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    checkResourceExists(session, jcrPath);
+    jcrPath = checkResourceExists(session, jcrPath);
     Node node = session.getRootNode().getNode(TextUtil.relativizePath(jcrPath));
     Version restoreVersion = node.getBaseVersion();
     node.restore(restoreVersion, true);
@@ -387,7 +373,7 @@ public class WebdavWriteCommandHandler {
                                  String username) {
     checkNotReadOnly(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    checkResourceExists(session, jcrPath);
+    jcrPath = checkResourceExists(session, jcrPath);
     Node node = (Node) session.getItem(jcrPath);
     if (!node.isNodeType(MIX_LOCKABLE) && node.canAddMixin(MIX_LOCKABLE)) {
       node.addMixin(MIX_LOCKABLE);
@@ -417,8 +403,7 @@ public class WebdavWriteCommandHandler {
   @SneakyThrows
   public void unlock(Session session, String webDavPath, List<String> lockTokens) {
     checkNotReadOnly(webDavPath);
-    String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    checkResourceExists(session, jcrPath);
+    String jcrPath = checkResourceExists(session, pathCommandHandler.transformToJcrPath(webDavPath));
     try {
       unlockNode(session, jcrPath);
     } catch (Exception e) {
@@ -430,12 +415,11 @@ public class WebdavWriteCommandHandler {
 
   @SneakyThrows
   public void unlockNode(Session session, String jcrPath) {
-    if (session.itemExists(jcrPath)) {
-      Node node = (Node) session.getItem(jcrPath);
-      if (node.isLocked()) {
-        node.unlock();
-        session.save();
-      }
+    jcrPath = checkResourceExists(session, jcrPath);
+    Node node = (Node) session.getItem(jcrPath);
+    if (node.isLocked()) {
+      node.unlock();
+      session.save();
     }
     removeLockTimeout(jcrPath);
   }
@@ -446,7 +430,7 @@ public class WebdavWriteCommandHandler {
                        List<WebDavItemOrder> members) throws WebDavException {
     checkNotReadOnly(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    checkResourceExists(session, jcrPath);
+    jcrPath = checkResourceExists(session, jcrPath);
     Node node = (Node) session.getItem(jcrPath);
 
     for (int i = 0; i < members.size(); i++) {
@@ -532,11 +516,25 @@ public class WebdavWriteCommandHandler {
     }
   }
 
-  private void checkResourceExists(Session session, String jcrPath) throws RepositoryException, WebDavException {
+  private String checkResourceExists(Session session, String jcrPath) throws RepositoryException, WebDavException {
     if (!session.itemExists(jcrPath)) {
-      throw new WebDavException(HttpStatus.SC_NOT_FOUND, String.format(RESOURCE_WITH_PATH_S_NOT_FOUND, jcrPath));
+      String[] parts = jcrPath.split("/");
+      String fileTitle = parts[parts.length - 1];
+      String cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(fileTitle.toLowerCase(),NodeTypeConstants.NT_FILE));
+      parts[parts.length - 1] = cleanName;
+      jcrPath =  Arrays.stream(parts).collect(Collectors.joining("/"));
+      if (!session.itemExists(jcrPath)) {
+        cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(fileTitle.toLowerCase(), NT_FOLDER));
+        parts[parts.length - 1] = cleanName;
+        jcrPath =  Arrays.stream(parts).collect(Collectors.joining("/"));
+      }
+      if (!session.itemExists(jcrPath)) {
+        throw new WebDavException(HttpStatus.SC_NOT_FOUND, String.format(RESOURCE_WITH_PATH_S_NOT_FOUND, jcrPath));
+      }
     }
+    return jcrPath;
   }
+
 
   @SneakyThrows
   private void updateContent(Node node,

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/OpenInDesktopMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/OpenInDesktopMenuAction.vue
@@ -42,8 +42,10 @@ export default {
     },
   },
   methods: {
-    openDialog() {
-      this.$root.$emit('open-in-desktop-dialog', this.protocol, this.file.path);
+    openDialog() {    
+      const pathParts = this.file.path.split('/');
+      pathParts.pop();
+      this.$root.$emit('open-in-desktop-dialog', this.protocol, `${pathParts.join('/')}/${this.file.name}`);
     },
   },
 };


### PR DESCRIPTION
Prior to this commit, files displayed in lowercase and without accents when opened from webdav, this fix allow the use of file's title in the path instead of JCR name.