### PR TITLE
fix: Webdav displays folders/files names unlike on eXo Platform - EXO-85020

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandler.java
@@ -17,6 +17,7 @@
 package org.exoplatform.documents.storage.jcr.webdav.plugin;
 
 import static org.exoplatform.documents.storage.jcr.util.ACLProperties.getReadOnlyACL;
+import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.getPathWithTitles;
 import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.getTitle;
 import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.*;
 import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_CONTENT;
@@ -697,7 +698,13 @@ public class WebdavReadCommandHandler {
 
   @SneakyThrows
   private String getNodeUri(Node node, String identityBaseJcrPath, String identityBaseUri) {
-    String nodeRelativePath = node.getPath().replaceFirst(identityBaseJcrPath, "");
+    String jcrPath = node.getPath();
+    if (node.hasProperty(EXO_TITLE)) {
+      String[] parts = jcrPath.split("/");
+      parts[parts.length - 1] = node.getProperty(EXO_TITLE).getString();
+      jcrPath = Arrays.stream(parts).collect(Collectors.joining("/"));
+    }
+    String nodeRelativePath = jcrPath.replaceFirst(identityBaseJcrPath, "");
     if (StringUtils.isBlank(nodeRelativePath)) {
       return identityBaseUri;
     } else {
@@ -715,7 +722,8 @@ public class WebdavReadCommandHandler {
                                     String identityBaseJcrPath,
                                     long identityId,
                                     String displayName) {
-    String nodeRelativePath = node.getPath().replaceFirst(identityBaseJcrPath, "");
+
+    String nodeRelativePath = getPathWithTitles(node).replaceFirst(identityBaseJcrPath, "");
     if (StringUtils.isBlank(nodeRelativePath)) {
       return String.format("/%s%s%s%s",
                            encodeUrlString(displayName),
@@ -785,25 +793,25 @@ public class WebdavReadCommandHandler {
     }
   }
 
-  private String checkResourceExists(Session session, String jcrPath) throws RepositoryException, WebDavException {
-    if (!session.itemExists(jcrPath)) {
-      String[] parts = jcrPath.split("/");
-      String fileTitle = parts[parts.length - 1];
-      String cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(fileTitle.toLowerCase(),NodeTypeConstants.NT_FILE));
-      parts[parts.length - 1] = cleanName;
-      jcrPath =  Arrays.stream(parts).collect(Collectors.joining("/"));
-      if (!session.itemExists(jcrPath)) {
-        cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanName(fileTitle.toLowerCase()));
-        parts[parts.length - 1] = cleanName;
-        jcrPath =  Arrays.stream(parts).collect(Collectors.joining("/"));
+  private String checkResourceExists(Session session, String path) throws RepositoryException, WebDavException {
+    String[] parts = path.split("/");
+    String jcrPath = "";
+    for (int i = 1; i < parts.length; i++) {
+      String parentPath = jcrPath + "/" + parts[i];
+      if (!session.itemExists(parentPath)) {
+        String cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(parts[i].toLowerCase(), NodeTypeConstants.NT_FILE));
+        parentPath = jcrPath + "/" + cleanName;
+        if (!session.itemExists(parentPath)) {
+          cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanName(parts[i].toLowerCase()));
+          parentPath = jcrPath + "/" + cleanName;
+        }
+        if (!session.itemExists(parentPath)) {
+          throw new WebDavException(HttpStatus.SC_NOT_FOUND,
+                  String.format("Resource with path '%s' not found", jcrPath));
+        }
       }
-      if (!session.itemExists(jcrPath)) {
-        throw new WebDavException(HttpStatus.SC_NOT_FOUND,
-                String.format("Resource with path '%s' not found", jcrPath));
-      }
+      jcrPath = parentPath;
     }
     return jcrPath;
   }
-
-
 }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavWriteCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavWriteCommandHandler.java
@@ -24,7 +24,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 import javax.jcr.*;
 import javax.jcr.lock.Lock;
@@ -134,6 +133,10 @@ public class WebdavWriteCommandHandler {
                            List<String> mixinTypes) {
     checkNotRoot(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
+    String folderName = jcrPath.substring(jcrPath.lastIndexOf("/") + 1);
+    jcrPath = jcrPath.substring(0, jcrPath.lastIndexOf("/"));
+    jcrPath = checkResourceExists(session, jcrPath);
+    jcrPath = jcrPath + "/" + folderName;
     Node node = addNode(session, jcrPath, NT_FOLDER);
     addMixins(node, mixinTypes);
     session.save();
@@ -147,13 +150,10 @@ public class WebdavWriteCommandHandler {
                        InputStream inputStream) {
     checkNotRoot(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    if (!session.itemExists(jcrPath)) {
-      String[] parts = jcrPath.split("/");
-      String fileTitle = parts[parts.length - 1];
-      fileTitle = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(fileTitle.toLowerCase(), NodeTypeConstants.NT_FILE));
-      parts[parts.length - 1] = fileTitle;
-      jcrPath = Arrays.stream(parts).collect(Collectors.joining("/"));
-    }
+    String fileName = jcrPath.substring(jcrPath.lastIndexOf("/") + 1);
+    jcrPath = jcrPath.substring(0, jcrPath.lastIndexOf("/"));
+    jcrPath = checkResourceExists(session, jcrPath);
+    jcrPath = jcrPath + "/" + fileName;
     Node node = session.itemExists(jcrPath) ? (Node) session.getItem(jcrPath) : null;
     Calendar now = Calendar.getInstance();
     if (node == null) {
@@ -284,6 +284,10 @@ public class WebdavWriteCommandHandler {
       }
     }
     forceUnlock((Node) session.getItem(sourceJcrPath));
+    String fileName = targetJcrPath.substring(targetJcrPath.lastIndexOf("/") + 1);
+    targetJcrPath = targetJcrPath.substring(0, targetJcrPath.lastIndexOf("/"));
+    targetJcrPath = checkResourceExists(session, targetJcrPath);
+    targetJcrPath = targetJcrPath + "/" + fileName;
     session.move(sourceJcrPath, targetJcrPath);
     session.save();
     Node targetNode = (Node) session.getItem(targetJcrPath);
@@ -516,21 +520,24 @@ public class WebdavWriteCommandHandler {
     }
   }
 
-  private String checkResourceExists(Session session, String jcrPath) throws RepositoryException, WebDavException {
-    if (!session.itemExists(jcrPath)) {
-      String[] parts = jcrPath.split("/");
-      String fileTitle = parts[parts.length - 1];
-      String cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(fileTitle.toLowerCase(),NodeTypeConstants.NT_FILE));
-      parts[parts.length - 1] = cleanName;
-      jcrPath =  Arrays.stream(parts).collect(Collectors.joining("/"));
-      if (!session.itemExists(jcrPath)) {
-        cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(fileTitle.toLowerCase(), NT_FOLDER));
-        parts[parts.length - 1] = cleanName;
-        jcrPath =  Arrays.stream(parts).collect(Collectors.joining("/"));
+  private String checkResourceExists(Session session, String path) throws RepositoryException, WebDavException {
+    String[] parts = path.split("/");
+    String jcrPath = "";
+    for (int i = 1; i < parts.length; i++) {
+      String parentPath = jcrPath + "/" + parts[i];
+      if (!session.itemExists(parentPath)) {
+        String cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(parts[i].toLowerCase(), NodeTypeConstants.NT_FILE));
+        parentPath = jcrPath + "/" + cleanName;
+        if (!session.itemExists(parentPath)) {
+          cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanName(parts[i].toLowerCase()));
+          parentPath = jcrPath + "/" + cleanName;
+        }
+        if (!session.itemExists(parentPath)) {
+          throw new WebDavException(HttpStatus.SC_NOT_FOUND,
+                  String.format("Resource with path '%s' not found", jcrPath));
+        }
       }
-      if (!session.itemExists(jcrPath)) {
-        throw new WebDavException(HttpStatus.SC_NOT_FOUND, String.format(RESOURCE_WITH_PATH_S_NOT_FOUND, jcrPath));
-      }
+      jcrPath = parentPath;
     }
     return jcrPath;
   }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandlerTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandlerTest.java
@@ -17,12 +17,10 @@
 package org.exoplatform.documents.storage.jcr.webdav.plugin;
 
 import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.DISPLAYNAME;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
@@ -40,13 +38,16 @@ import javax.jcr.version.VersionHistory;
 import javax.jcr.version.VersionIterator;
 import javax.xml.namespace.QName;
 
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil;
 import org.exoplatform.documents.storage.jcr.util.NodeTypeConstants;
 import org.exoplatform.documents.webdav.model.WebDavFileDownload;
 import org.exoplatform.documents.webdav.model.WebDavItem;
@@ -118,6 +119,12 @@ public class WebdavReadCommandHandlerTest {
   private ListAccess<Space>        memberSpacesListAccess;
 
   private WebdavReadCommandHandler handler;
+  private static final MockedStatic<JCRDocumentsUtil> JCR_DOCUMENTS_UTIL = mockStatic(JCRDocumentsUtil.class);
+
+  @AfterClass
+  public static void afterRunBare() throws Exception { // NOSONAR
+    JCR_DOCUMENTS_UTIL.close();
+  }
 
   @Before
   @SneakyThrows
@@ -149,6 +156,7 @@ public class WebdavReadCommandHandlerTest {
     when(spaceService.getMemberSpaces(USERNAME)).thenReturn(memberSpacesListAccess);
     when(node.getPath()).thenReturn(JCR_PATH);
     when(pathCommandHandler.getIdentityBaseJcrPath(WEBDAV_PATH)).thenReturn(IDENTITY_PATH);
+    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getPathWithTitles(node)).thenReturn(JCR_PATH);
   }
 
   @Test


### PR DESCRIPTION
Prior to this commit, Folders and documents are displayed in lowercase and without accents when opened in webdav, this fix allow the use of file's title in the path instead of JCR name.