### PR TITLE
feat: Allow to search in Audio Transcription Metadata of Media Files - EXO-85069

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/service/DocumentFileService.java
@@ -360,6 +360,16 @@ public interface DocumentFileService {
   }
 
   /**
+   * A previously saved media Text transcription content
+   *
+   * @param documentId Video or Audio UUID
+   * @return the transcription text
+   */
+  default String getAudioTranscription(String documentId) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Creates a shortcut for a document
    *
    * @param documentId     document id

--- a/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/storage/DocumentFileStorage.java
@@ -305,6 +305,16 @@ public interface DocumentFileStorage {
   }
 
   /**
+   * A previously saved media Text transcription content
+   *
+   * @param documentId Video or Audio UUID
+   * @return the transcription text
+   */
+  default String getAudioTranscription(String documentId) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Creates a shortcut for a document
    *
    * @param documentId     document id

--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -474,6 +474,11 @@ public class DocumentFileServiceImpl implements DocumentFileService {
   }
 
   @Override
+  public String getAudioTranscription(String documentId) {
+    return documentFileStorage.getAudioTranscription(documentId);
+  }
+
+  @Override
   public void createShortcut(String documentId, String destPath, String aclIdentity, String conflictAction) throws IllegalAccessException, ObjectAlreadyExistsException {
     documentFileStorage.createShortcut(documentId, destPath, aclIdentity, conflictAction);
   }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -2038,6 +2038,29 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
   }
 
   @Override
+  public String getAudioTranscription(String documentId) {
+    SessionProvider sessionProvider = null;
+    try {
+      sessionProvider = SessionProvider.createSystemProvider();
+      Session session = sessionProvider.getSession(COLLABORATION, repositoryService.getCurrentRepository());
+      Node node = getNodeByIdentifier(session, documentId);
+      if (node.isNodeType(NodeTypeConstants.EXO_TRANSCRIPTION)
+          && node.hasProperty(NodeTypeConstants.EXO_TRANSCRIPTION)) {
+        InputStream stream = node.getProperty(NodeTypeConstants.EXO_TRANSCRIPTION).getStream();
+        return IOUtil.getStreamContentAsString(stream);
+      } else {
+        return null;
+      }
+    } catch (Exception e) {
+      throw new IllegalStateException("Error renaming document'" + documentId, e);
+    } finally {
+      if (sessionProvider != null) {
+        sessionProvider.close();
+      }
+    }
+  }
+
+  @Override
   public void updateAudioTranscription(String documentId,
                                        String transcription,
                                        Identity aclIdentity) throws IllegalAccessException {

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
@@ -75,7 +75,7 @@ public class DocumentSearchServiceConnector {
 
   public static final String           EXTENDED_SEARCH_QUERY_TERM   = "\"must\":{"
           + "    \"query_string\":{"
-          + "    \"fields\": [\"title\",\"attachment.content\",\"dc:description\"],"
+          + "    \"fields\": [\"title\",\"attachment.content\",\"dc:description\",\"transcription\"],"
           + "    \"query\": \"*@term@*\""
           + "  }" + "},";
 


### PR DESCRIPTION
This change will allow to search in ES 'transcription' field which is mapped from JCR '`exo:transcription`' property from '`exo:transcription`' mixin type.