### PR TITLE
fix: Fix Tomcat security warning by explicitly handling OPTIONS method in webdav web.xml

### DIFF
--- a/documents-webdav-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/documents-webdav-webapp/src/main/webapp/WEB-INF/web.xml
@@ -63,6 +63,7 @@
     <url-pattern>/drives/*</url-pattern>
   </filter-mapping>
 
+  <!-- Secure all methods except OPTIONS -->
   <security-constraint>
     <web-resource-collection>
       <web-resource-name>rest</web-resource-name>
@@ -75,6 +76,15 @@
     <user-data-constraint>
       <transport-guarantee>NONE</transport-guarantee>
     </user-data-constraint>
+  </security-constraint>
+
+  <!-- Explicitly allow OPTIONS requests (WebDAV discovery) -->
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>options</web-resource-name>
+      <url-pattern>/*</url-pattern>
+      <http-method>OPTIONS</http-method>
+    </web-resource-collection>
   </security-constraint>
 
   <login-config>


### PR DESCRIPTION
Tomcat logs a startup warning indicating that the HTTP method OPTIONS is not
covered by any security constraint for the URL pattern `/*`.

This occurs because the existing constraint excludes OPTIONS using `<http-method-omission>OPTIONS</http-method-omission>`, but no separate constraint is defined to handle OPTIONS requests. Newer Tomcat versions validate that all HTTP methods are explicitly covered by at least one security constraint.

This change adds a dedicated `security-constraint` for the OPTIONS method
without an authentication requirement. This preserves the intended behavior
while eliminating the warning.

Result:

* Removes Tomcat startup warning about uncovered HTTP methods
* Maintains authentication requirements for all WebDAV operations
* Allows unauthenticated OPTIONS requests required for WebDAV capability discovery
