### PR TITLE
fix: Unable to add extension in DocumentsHeaderLeft extension point - EXO-85544

### DIFF
--- a/documents-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -27,6 +27,30 @@
     <overwrite>true</overwrite>
   </portlet-skin>
 
+  <module>
+    <name>DocumentsLeftHeaderExtension</name>
+    <load-group>documentLeftHeaderGRP</load-group>
+    <script>
+      <minify>false</minify>
+      <path>/js/documentLeftHeader.js</path>
+    </script>
+    <depends>
+      <module>extensionRegistry</module>
+    </depends>
+    <depends>
+      <module>eXoVueI18n</module>
+    </depends>
+    <depends>
+      <module>vue</module>
+    </depends>
+    <depends>
+      <module>vuetify</module>
+    </depends>
+    <depends>
+      <module>commonVueComponents</module>
+    </depends>
+  </module>
+
   <portlet>
     <name>Documents</name>
     <module>
@@ -66,6 +90,9 @@
       </depends>
       <depends>
         <module>DocumentsDraggable</module>
+      </depends>
+      <depends>
+        <module>DocumentsLeftHeaderExtension</module>
       </depends>
       <depends>
         <module>applicationToolbarComponent</module>

--- a/documents-webapp/src/main/webapp/js/documentLeftHeader.js
+++ b/documents-webapp/src/main/webapp/js/documentLeftHeader.js
@@ -1,0 +1,1 @@
+//this file is necessary to initialize the js group documentLeftHeaderGRP to add extensions from other addons

--- a/documents-webapp/src/main/webapp/vue-app/documents/main.js
+++ b/documents-webapp/src/main/webapp/vue-app/documents/main.js
@@ -178,6 +178,7 @@ export async function init(appId, canEdit,  settings, settingsSaveUrl) {
     vuetify: Vue.prototype.vuetifyOptions,
     i18n
   }, `#${appId}`, 'Documents');
+  Vue.prototype.$utils.includeExtensions('LeftHeaderExtension');
 }
 
 async function getSubcategoryIds(categoryIds, depth) {


### PR DESCRIPTION
Before this fix, it is not possible to add an extension in extension point DocumentsHeaderLeft because the js load-group is missing. In addition, the call to Vue.prototype.includeExtensions(...) is missing for the Documents application