### PR TITLE
fix: Fix opening document with edit permission from unified search - EXO-85244

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/files-search/components/FileSearchCard.vue
+++ b/documents-webapp/src/main/webapp/vue-app/files-search/components/FileSearchCard.vue
@@ -194,11 +194,7 @@ export default {
     openFilePreview() {
       this.result.path = this.result.nodePath;
       if (this.isFileEditable)  {
-        if (this.result?.acl?.canEdit){
-          window.open(this.$documentsUtils.getEditorUrl(this.result,''), '_blank');
-        } else {
-          window.open(this.$documentsUtils.getEditorUrl(this.result,'view'), '_blank');
-        }
+        window.open(this.$documentsUtils.getEditorUrl(this.result,''), '_blank');
       } else if (this.isFileReadable)  {
         window.open(this.$documentsUtils.getEditorUrl(this.result,'view'), '_blank');
       } else {


### PR DESCRIPTION
Prior to this change, when opening a searched document from unified search, the OO url of the document have always the view mode param regardless the user permission (view or edit) on this document.
This is caused by the check this.result?.acl?.canEdit which is not available since the canEdit value is not provided on the search result entity so the mode added to the url is always 'view' even if the user has edit rights on the document.
After this commit, we removed this frontend check since from backend, the DocumentModeRedirectHandler already filters the OO url and adds the mode to the url according to the user permission on the document.