### PR TITLE
fix: folder issue when its name has "." using webdav - EXO-85435

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandler.java
@@ -802,6 +802,9 @@ public class WebdavReadCommandHandler {
         String cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(parts[i].toLowerCase(), NodeTypeConstants.NT_FILE));
         parentPath = jcrPath + "/" + cleanName;
         if (!session.itemExists(parentPath)) {
+          cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanName(parts[i].toLowerCase(), NodeTypeConstants.NT_FOLDER ));
+          parentPath = jcrPath + "/" + cleanName;
+        }if (!session.itemExists(parentPath)) {
           cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanName(parts[i].toLowerCase()));
           parentPath = jcrPath + "/" + cleanName;
         }


### PR DESCRIPTION
Prior to this commit, content of folders with names containing a '.' cannot be displayed using webdav. This is caused by a wrong folder "JCR" name. this commit fix the problem by getting the good jcr name for the folder.