### PR TITLE
fix: Empty post in stream for a shortcut file - EXO-85240 (#1861)

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/PostMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/PostMenuAction.vue
@@ -36,7 +36,7 @@ export default {
       }
       const attachment = {
         eXoDrive: true,
-        id: this.file.id,
+        id: this.file?.sourceID || this.file?.id,
         name: this.file.name,
         isCloudFile: this.file.cloudDriveFile,
         isSelectedFromDrives: true,


### PR DESCRIPTION
Empty post in stream for a shortcut file

(cherry picked from commit 7291738470da2f0e9feecd2923427ad787e4c257)