### PR TITLE
fix: empty post in stream if same shortcut or file posted more than once - EXO-85715

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/PostMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/PostMenuAction.vue
@@ -51,7 +51,9 @@ export default {
       this.file=null;
     });
   },
-
+  destroyed() {
+    this.file=null;
+  },
   methods: {
     openComposerDrawer() {
       this.$nextTick().then(() => new Promise(resolve => {

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsGroupMenu.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentsGroupMenu.vue
@@ -34,6 +34,7 @@
           @click="menuDisplayed = true" />
       </template>
       <documents-actions-menu
+        v-if="menuDisplayed"
         :file="file"
         :current-view="currentView"
         :is-search-result="isSearchResult"
@@ -90,7 +91,7 @@ export default {
 
   data: () => ({
     menuDisplayed: false,
-    waitTimeUntilCloseMenu: 100,
+    waitTimeUntilCloseMenu: 200,
   }),
   created() {
     $(document).on('mousedown', () => {      


### PR DESCRIPTION
Before this change, when open action menu of related shortcut > actions > post on feed then post again the same file, empty activity is created. To fix this issue, a conditional rendering directive (v-if) has been added to the <documents-actions-menu> component to ensure it is fully re-created when needed. after this chenge, the document is posted in stream.