### PR TITLE
fix: Attached documents are considered as images without alt - EXO-85787

### DIFF
--- a/documents-webapp/src/main/resources/locale/portlet/attachments_en.properties
+++ b/documents-webapp/src/main/resources/locale/portlet/attachments_en.properties
@@ -115,6 +115,7 @@ attachments.label.download=Download
 
 activity.attach.file.reminder.title=New way to attach documents to a message
 activity.attach.file.reminder.description=Attach documents to your message directly using the attach icon
+activity.attach.image.alt=Open the attachment: {0}
 
 #####################################################################################
 #                                    notes attachments                              #

--- a/documents-webapp/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachment.vue
+++ b/documents-webapp/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachment.vue
@@ -29,6 +29,7 @@
           v-else-if="image"
           :src="image"
           class="ma-auto"
+          :alt="$t('activity.attach.image.alt', { 0:attachment.name })"
           @load="loading = false"
           @error="image = image!==attachment.downloadUrl?attachment.downloadUrl:null">
         <v-icon


### PR DESCRIPTION
Before this change, when adding a post with an attached document or image, the attachment was treated as an image without an alt attribute. After this change, all attached documents and images include an alt attribute in the following format: alt=Open the attachment: [document name].