### PR TITLE
fix: Documents in Recent document portlet are considered as images without alt - EXO-85772

### DIFF
--- a/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
+++ b/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
@@ -480,3 +480,4 @@ documents.label.viewType.cards=Cards
 documents.bulk.categories.summary1=Add categories to simplify access to documents.
 documents.bulk.categories.summary2=Note: Some may limit user access
 documents.bulk.categories.summary3=
+documents.attach.image.alt=Open document: {0}

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentItemCard.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentItemCard.vue
@@ -44,6 +44,7 @@
           v-else-if="fileImage"
           :src="fileImage"
           class="ma-auto"
+          :alt="$t('documents.attach.image.alt', { 0:fileName})"
           @load="loading = false"
           @error="fileImage = fileImage !== downloadUrl ? downloadUrl : null">
         <v-icon


### PR DESCRIPTION
Before this change, when add some documents in document application then add Recent document portlet to a page, The documents in Recent document portlet are considered as images without alt. After this change, For all documents in Recent document portlet, add alt= Open document: [file name].