### PR TITLE
fix: prevent XSS vulnerability in document description field - EXO-84920 (#1882)

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -35,6 +35,7 @@ import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.file.model.FileInfo;
 import org.exoplatform.commons.file.model.FileItem;
 import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.commons.utils.HTMLSanitizer;
 import org.exoplatform.documents.constant.DocumentSortField;
 import org.exoplatform.documents.constant.FileListingType;
 import org.exoplatform.documents.model.*;
@@ -419,6 +420,7 @@ public class DocumentFileServiceImpl implements DocumentFileService {
                                         String documentID,
                                         String description,
                                         long aclIdentity) throws IllegalStateException, IllegalAccessException, RepositoryException {
+    description = HTMLSanitizer.sanitize(description);
     documentFileStorage.updateDocumentDescription(ownerId, documentID, description, getAclUserIdentity(aclIdentity));
   }
 

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -39,6 +39,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.ibm.icu.text.Transliterator;
 
 import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.commons.utils.HTMLSanitizer;
 import org.exoplatform.documents.constant.DocumentSortField;
 import org.exoplatform.documents.legacy.search.data.SearchResult;
 import org.exoplatform.documents.model.*;
@@ -508,7 +509,8 @@ public class JCRDocumentsUtil {
   public static void retrieveFileContentProperties(Node content, FileNode fileNode) throws RepositoryException {
     if (content.hasProperty(NodeTypeConstants.DC_DESCRIPTION)
         && content.getProperty(NodeTypeConstants.DC_DESCRIPTION).getValues().length > 0) {
-      fileNode.setDescription(content.getProperty(NodeTypeConstants.DC_DESCRIPTION).getValues()[0].getString());
+      String description = HTMLSanitizer.sanitize(content.getProperty(NodeTypeConstants.DC_DESCRIPTION).getValues()[0].getString());
+      fileNode.setDescription(description);
     }
     if (content.hasProperty(NodeTypeConstants.JCR_MIME_TYPE)) {
       fileNode.setMimeType(content.getProperty(NodeTypeConstants.JCR_MIME_TYPE).getString());


### PR DESCRIPTION
Before this change, the document description field was vulnerable to XSS attacks. This update introduces sanitization to prevent such vulnerabilities

(cherry picked from commit c2489c850fe576c7c09fae86aeb8abed5be2a688)