### PR TITLE
fix: Fix accessing a space drive using webdav - EXO-85437

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents-user-setting/components/drawers/DocumentsWebdavMapDrivesDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents-user-setting/components/drawers/DocumentsWebdavMapDrivesDrawer.vue
@@ -265,7 +265,7 @@ export default {
       } else if (this.driveType === 'PERSONAL') {
         return `${window.location.origin}/webdav/drives/d/(${eXo.env.portal.userIdentityId})`;
       } else if (this.driveType === 'SPACE' && this.spaceIdentityId) {
-        return `${window.location.origin}/webdav/drives/d/${this.spaceIdentity.remoteId} (${this.spaceIdentityId})`;
+        return `${window.location.origin}/webdav/drives/d/${this.spaceIdentity.displayName} (${this.spaceIdentityId})`;
       } else {
         return null;
       }


### PR DESCRIPTION
Prior to this change, space drives whose names contained spaces or special characters could not be accessed correctly via WebDAV. The generated URLs were not properly encoded, which led to invalid paths and errors when trying to browse these drives in WebDAV clients.
This fix will  ensure that paths for space drives are correctly handled when names include spaces or special characters.