### PR TITLE
fix: Fix accessing a space drive using webdav - EXO-85437

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents-user-setting/components/drawers/DocumentsWebdavMapDrivesDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents-user-setting/components/drawers/DocumentsWebdavMapDrivesDrawer.vue
@@ -265,7 +265,7 @@ export default {
       } else if (this.driveType === 'PERSONAL') {
         return `${window.location.origin}/webdav/drives/d/(${eXo.env.portal.userIdentityId})`;
       } else if (this.driveType === 'SPACE' && this.spaceIdentityId) {
-        return `${window.location.origin}/webdav/drives/d/(${this.spaceIdentityId})`;
+        return `${window.location.origin}/webdav/drives/d/${this.spaceIdentity.displayName} (${this.spaceIdentityId})`;
       } else {
         return null;
       }


### PR DESCRIPTION
Prior to this change ,space drives could not be accessed via WebDAV. When users attempted to mount or browse a space drive, the server returned HTML error pages or directory listings that were incompatible with WebDAV clients. This fix will improve path handling so that space drives behave consistently with other drive types.