### PR TITLE
Fix: Allow publisher without being redactor to create/ edit and delete document - EXO-85817

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/model/PermissionRole.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/model/PermissionRole.java
@@ -18,5 +18,5 @@ package org.exoplatform.documents.model;
 
 public enum PermissionRole {
   ALL,
-  MANAGERS_REDACTORS;
+  MANAGERS_REDACTORS_PUBLISHERS;
 }

--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -426,11 +426,11 @@ public class EntityBuilder {
         if(nodePermissionEntity.isAllMembersCanEdit()){
           permissions.add(new PermissionEntry(identity,"edit",PermissionRole.ALL.name()));
         } else {
-          permissions.add(new PermissionEntry(identity,"edit",PermissionRole.MANAGERS_REDACTORS.name()));
+          permissions.add(new PermissionEntry(identity,"edit",PermissionRole.MANAGERS_REDACTORS_PUBLISHERS.name()));
         }
       }
       if (nodePermissionEntity.getVisibilityChoice().equals(Visibility.SPECIFIC_COLLABORATOR.name())) {
-        permissions.add(new PermissionEntry(identity,"edit",PermissionRole.MANAGERS_REDACTORS.name()));
+        permissions.add(new PermissionEntry(identity,"edit",PermissionRole.MANAGERS_REDACTORS_PUBLISHERS.name()));
       }
       return new NodePermission(nodePermissionEntity.isCanAccess(),
                                 nodePermissionEntity.isCanEdit(),

--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -533,8 +533,7 @@ public class DocumentFileServiceImpl implements DocumentFileService {
     Space space = spaceService.getSpaceById(spaceId);
     boolean canAdd = false;
     if (space != null) {
-      canAdd = !spaceService.hasRedactor(space) || spaceService.hasRedactor(space)
-          && (spaceService.isRedactor(space, currentUserName) || spaceService.isManager(space, currentUserName));
+      canAdd = spaceService.canRedactOnSpace(space, currentUserName);
     }
     return canAdd;
   }

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/util/EntityBuilderTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/util/EntityBuilderTest.java
@@ -76,7 +76,7 @@ public class EntityBuilderTest {
         nodePermissionEntity.setAllMembersCanEdit(false);
         NodePermission specificCollabotratorsNodePermission = EntityBuilder.toNodePermission(abstractNodeEntity,documentFileService, spaceService, identityManager);
         assertNotNull(specificCollabotratorsNodePermission);
-        assertEquals(PermissionRole.MANAGERS_REDACTORS.name(), specificCollabotratorsNodePermission.getPermissions().get(0).getRole());
+        assertEquals(PermissionRole.MANAGERS_REDACTORS_PUBLISHERS.name(), specificCollabotratorsNodePermission.getPermissions().get(0).getRole());
         assertEquals(identity.getRemoteId(), specificCollabotratorsNodePermission.getPermissions().get(0).getIdentity().getRemoteId());
         assertEquals("edit", specificCollabotratorsNodePermission.getPermissions().get(0).getPermission());
 

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -1787,18 +1787,21 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
             if (permission.getRole().equals(PermissionRole.ALL.name())) {
               permissions.put("*:" + groupId, PermissionType.ALL);
             }
-            if (permission.getRole().equals(PermissionRole.MANAGERS_REDACTORS.name())) {
+            if (permission.getRole().equals(PermissionRole.MANAGERS_REDACTORS_PUBLISHERS.name())) {
               permissions.put("manager:" + groupId, PermissionType.ALL);
               permissions.put("redactor:" + groupId, PermissionType.ALL);
+              permissions.put("publisher:" + groupId, PermissionType.ALL);
+
             }
           }
           if (permission.getPermission().equals("read")) {
             if (permission.getRole().equals(PermissionRole.ALL.name())) {
               permissions.put("*:" + groupId, new String[] { PermissionType.READ });
             }
-            if (permission.getRole().equals(PermissionRole.MANAGERS_REDACTORS.name())) {
+            if (permission.getRole().equals(PermissionRole.MANAGERS_REDACTORS_PUBLISHERS.name())) {
               permissions.put("manager:" + groupId, new String[] { PermissionType.READ });
               permissions.put("redactor:" + groupId, new String[] { PermissionType.READ });
+              permissions.put("publisher:" + groupId, new String[] { PermissionType.READ });
             }
           }
         } else if (permission.getIdentity().getProviderId().equals("group")) {

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/listener/RestrictContentCreationSpaceListener.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/listener/RestrictContentCreationSpaceListener.java
@@ -15,6 +15,8 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceLifeCycleEvent;
 
 import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
 import java.util.ArrayList;
@@ -73,28 +75,10 @@ public class RestrictContentCreationSpaceListener extends SpaceListenerPlugin {
       sessionProvider = sessionProviderService.getSystemSessionProvider(null);
       Session session = sessionProvider.getSession("collaboration", repository);
       Node spaceRootNode = getGroupNode(nodeHierarchyCreator, session, space.getGroupId());
-      Map<String, String[]> permissions = new HashMap<>();
       if (spaceRootNode != null) {
-        for (AccessControlEntry accessEntry : ((ExtendedNode) spaceRootNode).getACL().getPermissionEntries()) {
-          if (!accessEntry.getIdentity().endsWith(":" + space.getGroupId())) {
-            if (permissions.get(accessEntry.getIdentity()) == null) {
-              permissions.put(accessEntry.getIdentity(), new String[] { accessEntry.getPermission() });
-            } else {
-              List<String> existingPermissions = new ArrayList<>(List.of(permissions.get(accessEntry.getIdentity())));
-              existingPermissions.add(accessEntry.getPermission());
-              permissions.put(accessEntry.getIdentity(), existingPermissions.toArray(new String[0]));
-            }
-          }
-        }
-        if (readOnlyForMembers) {
-          permissions.put("*:" + space.getGroupId(), new String[] { PermissionType.READ });
-          permissions.put("manager:" + space.getGroupId(), PermissionType.ALL);
-          permissions.put("redactor:" + space.getGroupId(), PermissionType.ALL);
-          permissions.put("publisher:" + space.getGroupId(), PermissionType.ALL);
-        } else {
-          permissions.put("*:" + space.getGroupId(), PermissionType.ALL);
-        }
+        Map<String, String[]> permissions = buildPermissions(spaceRootNode, space, readOnlyForMembers);
         ((ExtendedNode) spaceRootNode).setPermissions(permissions);
+        applyPermissionsRecursively(spaceRootNode, space, readOnlyForMembers);
         session.save();
       }
     } catch (Exception e) {
@@ -104,5 +88,41 @@ public class RestrictContentCreationSpaceListener extends SpaceListenerPlugin {
         sessionProvider.close();
       }
     }
+  }
+
+  private void applyPermissionsRecursively(Node parentNode, Space space, boolean readOnlyForMembers) throws RepositoryException {
+    NodeIterator children = parentNode.getNodes();
+    while (children.hasNext()) {
+      Node child = children.nextNode();
+      if (child.isNodeType("exo:privilegeable")) {
+        Map<String, String[]> permissions = buildPermissions(child, space, readOnlyForMembers);
+        ((ExtendedNode) child).setPermissions(permissions);
+      }
+      applyPermissionsRecursively(child, space, readOnlyForMembers);
+    }
+  }
+
+  private Map<String, String[]> buildPermissions(Node node, Space space, boolean readOnlyForMembers) throws RepositoryException {
+    Map<String, String[]> permissions = new HashMap<>();
+    for (AccessControlEntry accessEntry : ((ExtendedNode) node).getACL().getPermissionEntries()) {
+      if (!accessEntry.getIdentity().endsWith(":" + space.getGroupId())) {
+        if (permissions.get(accessEntry.getIdentity()) == null) {
+          permissions.put(accessEntry.getIdentity(), new String[] { accessEntry.getPermission() });
+        } else {
+          List<String> existingPermissions = new ArrayList<>(List.of(permissions.get(accessEntry.getIdentity())));
+          existingPermissions.add(accessEntry.getPermission());
+          permissions.put(accessEntry.getIdentity(), existingPermissions.toArray(new String[0]));
+        }
+      }
+    }
+    if (readOnlyForMembers) {
+      permissions.put("*:" + space.getGroupId(), new String[] { PermissionType.READ });
+      permissions.put("manager:" + space.getGroupId(), PermissionType.ALL);
+      permissions.put("redactor:" + space.getGroupId(), PermissionType.ALL);
+      permissions.put("publisher:" + space.getGroupId(), PermissionType.ALL);
+    } else {
+      permissions.put("*:" + space.getGroupId(), PermissionType.ALL);
+    }
+    return permissions;
   }
 }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/listener/RestrictContentCreationSpaceListener.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/listener/RestrictContentCreationSpaceListener.java
@@ -90,6 +90,7 @@ public class RestrictContentCreationSpaceListener extends SpaceListenerPlugin {
           permissions.put("*:" + space.getGroupId(), new String[] { PermissionType.READ });
           permissions.put("manager:" + space.getGroupId(), PermissionType.ALL);
           permissions.put("redactor:" + space.getGroupId(), PermissionType.ALL);
+          permissions.put("publisher:" + space.getGroupId(), PermissionType.ALL);
         } else {
           permissions.put("*:" + space.getGroupId(), PermissionType.ALL);
         }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/listener/RestrictContentCreationSpaceListener.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/listener/RestrictContentCreationSpaceListener.java
@@ -23,17 +23,21 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.getGroupNode;
 
 public class RestrictContentCreationSpaceListener extends SpaceListenerPlugin {
-  private static final Log       LOG = ExoLogger.getExoLogger(RestrictContentCreationSpaceListener.class);
+  private static final Log                 LOG               = ExoLogger.getExoLogger(RestrictContentCreationSpaceListener.class);
 
-  private RepositoryService      repositoryService;
+  private RepositoryService                repositoryService;
 
-  private NodeHierarchyCreator   nodeHierarchyCreator;
+  private NodeHierarchyCreator             nodeHierarchyCreator;
 
-  private SessionProviderService sessionProviderService;
+  private SessionProviderService           sessionProviderService;
+
+  private final Map<String, AtomicBoolean> pendingOperations = new ConcurrentHashMap<>();
 
   public RestrictContentCreationSpaceListener(RepositoryService repositoryService,
                                               NodeHierarchyCreator nodeHierarchyCreator,
@@ -56,6 +60,11 @@ public class RestrictContentCreationSpaceListener extends SpaceListenerPlugin {
   @Override
   public void removeRedactorUser(SpaceLifeCycleEvent event) {
     Space space = event.getSpace();
+    AtomicBoolean cancelFlag = pendingOperations.get(space.getId());
+    if (cancelFlag != null) {
+      LOG.info("Cancelling in-progress permission restriction for space {}", space.getPrettyName());
+      cancelFlag.set(true);
+    }
     if (space.getRedactors() == null || space.getRedactors().length == 0) {
       changePermissionsForSpaceMembers(space, false);
     }
@@ -76,10 +85,38 @@ public class RestrictContentCreationSpaceListener extends SpaceListenerPlugin {
       Session session = sessionProvider.getSession("collaboration", repository);
       Node spaceRootNode = getGroupNode(nodeHierarchyCreator, session, space.getGroupId());
       if (spaceRootNode != null) {
-        Map<String, String[]> permissions = buildPermissions(spaceRootNode, space, readOnlyForMembers);
-        ((ExtendedNode) spaceRootNode).setPermissions(permissions);
-        applyPermissionsRecursively(spaceRootNode, space, readOnlyForMembers);
-        session.save();
+        boolean spaceIsOpen = isSpaceOpenToAll(spaceRootNode, space.getGroupId());
+        if (readOnlyForMembers && !spaceIsOpen) {
+          LOG.info("Space {} is already restricted, skipping permission update", space.getPrettyName());
+          return;
+        }
+        if (!readOnlyForMembers && spaceIsOpen) {
+          LOG.info("Space {} is already open, skipping permission update", space.getPrettyName());
+          return;
+        }
+
+        AtomicBoolean cancelFlag = null;
+        if (readOnlyForMembers) {
+          cancelFlag = new AtomicBoolean(false);
+          pendingOperations.put(space.getId(), cancelFlag);
+        }
+
+        try {
+          Map<String, String[]> permissions = buildPermissions(spaceRootNode, space, readOnlyForMembers);
+          ((ExtendedNode) spaceRootNode).setPermissions(permissions);
+          applyPermissionsRecursively(spaceRootNode, space, readOnlyForMembers, cancelFlag);
+          if (cancelFlag != null && cancelFlag.get()) {
+            LOG.info("Permission restriction for space {} was cancelled, discarding changes",
+                     space.getPrettyName());
+            session.refresh(false);
+          } else {
+            session.save();
+          }
+        } finally {
+          if (cancelFlag != null) {
+            pendingOperations.remove(space.getId());
+          }
+        }
       }
     } catch (Exception e) {
       LOG.error("Error updating permissions of the root Node of the space {}", space.getPrettyName(), e);
@@ -90,16 +127,42 @@ public class RestrictContentCreationSpaceListener extends SpaceListenerPlugin {
     }
   }
 
-  private void applyPermissionsRecursively(Node parentNode, Space space, boolean readOnlyForMembers) throws RepositoryException {
-    NodeIterator children = parentNode.getNodes();
-    while (children.hasNext()) {
-      Node child = children.nextNode();
-      if (child.isNodeType("exo:privilegeable")) {
-        Map<String, String[]> permissions = buildPermissions(child, space, readOnlyForMembers);
-        ((ExtendedNode) child).setPermissions(permissions);
+  private void applyPermissionsRecursively(Node parentNode,
+                                           Space space,
+                                           boolean readOnlyForMembers,
+                                           AtomicBoolean cancelFlag) {
+    try {
+      NodeIterator children = parentNode.getNodes();
+      while (children.hasNext()) {
+        if (cancelFlag != null && cancelFlag.get()) {
+          LOG.info("Permission restriction cancelled for space {}, stopping recursion",
+                   space.getPrettyName());
+          return;
+        }
+        Node child = children.nextNode();
+        try {
+          if (child.isNodeType("exo:privilegeable")) {
+            Map<String, String[]> permissions = buildPermissions(child, space, readOnlyForMembers);
+            ((ExtendedNode) child).setPermissions(permissions);
+          }
+        } catch (Exception e) {
+          LOG.warn("Error applying permissions to a child node in space {}, continuing",
+                   space.getPrettyName(), e);
+        }
+        applyPermissionsRecursively(child, space, readOnlyForMembers, cancelFlag);
       }
-      applyPermissionsRecursively(child, space, readOnlyForMembers);
+    } catch (RepositoryException e) {
+      LOG.error("Error iterating children for space {}", space.getPrettyName(), e);
     }
+  }
+
+  private boolean isSpaceOpenToAll(Node node, String groupId) throws RepositoryException {
+    for (AccessControlEntry entry : ((ExtendedNode) node).getACL().getPermissionEntries()) {
+      if (entry.getIdentity().equals("*:" + groupId)) {
+        return !PermissionType.READ.equals(entry.getPermission());
+      }
+    }
+    return false;
   }
 
   private Map<String, String[]> buildPermissions(Node node, Space space, boolean readOnlyForMembers) throws RepositoryException {

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -637,8 +637,8 @@ public class JCRDocumentsUtil {
   }
 
   private static String getPermissionRole (String membershipType){
-    if(membershipType.equals("manager") || membershipType.equals("redactor") ){
-      return PermissionRole.MANAGERS_REDACTORS.name();
+    if(membershipType.equals("manager") || membershipType.equals("redactor") || membershipType.equals("publisher") ){
+      return PermissionRole.MANAGERS_REDACTORS_PUBLISHERS.name();
     }
     return PermissionRole.ALL.name();
   }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -1513,7 +1513,7 @@ public class JCRDocumentFileStorageTest {
     permissionsList.add(new PermissionEntry(identity, "read", null));
     permissionsList.add(new PermissionEntry(identity1, "edit", null));
     // permissionsList including space manager and redactor permission
-    permissionsList.add(new PermissionEntry(spaceIdentity, "edit", PermissionRole.MANAGERS_REDACTORS.name()));
+    permissionsList.add(new PermissionEntry(spaceIdentity, "edit", PermissionRole.MANAGERS_REDACTORS_PUBLISHERS.name()));
     nodePermission.setPermissions(permissionsList);
     when(node.getACL()).thenReturn(new AccessControlList("root", new ArrayList<>()));
     //When

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/listener/RestrictContentCreationSpaceListenerTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/listener/RestrictContentCreationSpaceListenerTest.java
@@ -49,15 +49,25 @@ class RestrictContentCreationSpaceListenerTest {
 
   ExtendedNode                         groupNode   = Mockito.mock(ExtendedNode.class);
 
-  AccessControlList                    acl         = mock(AccessControlList.class);
+  AccessControlList                    acl                 = mock(AccessControlList.class);
 
-  String                               memberShip1 = "member:/spaces/groupOne";
+  List<AccessControlEntry>             permissionEntries   = new ArrayList<>();
+
+  String                               memberShip1         = "member:/spaces/groupOne";
 
   String                               memberShip2 = "*:/platform/users";
 
   String                               memberShip3 = "member:/organization/board";
 
   String                               groupId     = "/spaces/groupOne";
+
+  String                               groupIdRef  = "*:" + groupId;
+
+  String                               managerRef  = "manager:" + groupId;
+
+  String                               redactorRef = "redactor:" + groupId;
+
+  String                               publisherRef = "publisher:" + groupId;
 
   @BeforeEach
   void setUp() throws RepositoryException {
@@ -81,7 +91,7 @@ class RestrictContentCreationSpaceListenerTest {
                                                                                          nodeHierarchyCreator,
                                                                                          sessionProviderService);
 
-    List<AccessControlEntry> permissionEntries = new ArrayList<>();
+    permissionEntries.clear();
     permissionEntries.add(new AccessControlEntry("root", "read"));
     permissionEntries.add(new AccessControlEntry("root", "add_node"));
     permissionEntries.add(new AccessControlEntry("root", "set_property"));
@@ -103,6 +113,10 @@ class RestrictContentCreationSpaceListenerTest {
     Space space = new Space();
     space.setGroupId(groupId);
     space.setRedactors(new String[] { "root" });
+
+    List<AccessControlEntry> entries = new ArrayList<>(permissionEntries);
+    entries.add(new AccessControlEntry(groupIdRef, "add_node"));
+    when(acl.getPermissionEntries()).thenReturn(entries);
     when(groupNode.getACL()).thenReturn(acl);
 
     SpaceLifeCycleEvent event = new SpaceLifeCycleEvent(space, userId, SpaceLifeCycleEvent.Type.ADD_REDACTOR_USER);
@@ -119,6 +133,9 @@ class RestrictContentCreationSpaceListenerTest {
     Space space = new Space();
     space.setGroupId(groupId);
 
+    List<AccessControlEntry> entries = new ArrayList<>(permissionEntries);
+    entries.add(new AccessControlEntry(groupIdRef, PermissionType.READ));
+    when(acl.getPermissionEntries()).thenReturn(entries);
     when(groupNode.getACL()).thenReturn(acl);
 
     SpaceLifeCycleEvent event = new SpaceLifeCycleEvent(space, userId, SpaceLifeCycleEvent.Type.REMOVE_REDACTOR_USER);

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/listener/RestrictContentCreationSpaceListenerTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/listener/RestrictContentCreationSpaceListenerTest.java
@@ -18,6 +18,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
@@ -73,6 +74,9 @@ class RestrictContentCreationSpaceListenerTest {
     when(session.itemExists(anyString())).thenReturn(true);
     when(session.getItem(anyString())).thenReturn(groupNode);
     when(systemSessionProvider.getSession(anyString(), any())).thenReturn(session);
+    NodeIterator nodeIterator = mock(NodeIterator.class);
+    when(nodeIterator.hasNext()).thenReturn(false);
+    when(groupNode.getNodes()).thenReturn(nodeIterator);
     this.restrictContentCreationSpaceListener = new RestrictContentCreationSpaceListener(repositoryService,
                                                                                          nodeHierarchyCreator,
                                                                                          sessionProviderService);


### PR DESCRIPTION
Prior to this change, only redactors or managers in a space can manage documents. This change will expands permissions so that publishers, even if they are not redactors, can now create, edit and delete documents.