### PR TITLE
fix: Add placeholder page when the user accesses another user's personal drive -EXO-82012

### DIFF
--- a/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
+++ b/documents-webapp/src/main/resources/locale/portlet/Documents_en.properties
@@ -476,8 +476,10 @@ search.connector.label.files=Documents
 documents.label.viewType.list=List
 documents.label.viewType.cards=Cards
 
-
 documents.bulk.categories.summary1=Add categories to simplify access to documents.
 documents.bulk.categories.summary2=Note: Some may limit user access
 documents.bulk.categories.summary3=
 documents.attach.image.alt=Open document: {0}
+
+documents.restrictedDrive.title=Restricted area
+documents.restrictedDrive.subtitle=This document is personal. You cannot access its drive.

--- a/documents-webapp/src/main/webapp/WEB-INF/conf/documents/portal/portal/global/navigation.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/conf/documents/portal/portal/global/navigation.xml
@@ -51,6 +51,12 @@
           <visibility>SYSTEM</visibility>
           <page-reference>portal::global::download-document</page-reference>
         </node>
+        <node>
+            <name>restricted-drive</name>
+            <label>#{portal.global.restricted-drive}</label>
+            <visibility>SYSTEM</visibility>
+            <page-reference>portal::global::restricted-drive</page-reference>
+        </node>
     </page-nodes>
 </node-navigation>
 

--- a/documents-webapp/src/main/webapp/WEB-INF/conf/documents/portal/portal/global/pages.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/conf/documents/portal/portal/global/pages.xml
@@ -248,4 +248,23 @@
           </section-columns>
         </container>
       </page>
+    <page>
+        <name>restricted-drive</name>
+        <title>restricted-drive</title>
+        <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
+        <edit-permission>manager:/platform/administrators</edit-permission>
+        <container template="system:/groovy/portal/webui/container/UIPageLayout.gtmpl">
+            <section-columns>
+                <column col-span="12">
+                    <portlet-application>
+                        <portlet>
+                            <application-ref>documents-portlet</application-ref>
+                            <portlet-ref>RestrictedDrive</portlet-ref>
+                        </portlet>
+                        <title>Restricted Drive</title>
+                    </portlet-application>
+                </column>
+            </section-columns>
+        </container>
+    </page>
 </page-set>

--- a/documents-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -162,6 +162,31 @@
   </portlet>
 
   <portlet>
+    <name>RestrictedDrive</name>
+    <module>
+      <script>
+        <minify>false</minify>
+        <path>/js/restrictedDrive.bundle.js</path>
+      </script>
+      <depends>
+        <module>commonVueCometponents</module>
+      </depends>
+      <depends>
+        <module>vue</module>
+      </depends>
+      <depends>
+        <module>vuetify</module>
+      </depends>
+      <depends>
+        <module>eXoVueI18n</module>
+      </depends>
+      <depends>
+        <module>extensionRegistry</module>
+      </depends>
+    </module>
+  </portlet>
+
+  <portlet>
     <name>TrashManagement</name>
     <module>
       <script>

--- a/documents-webapp/src/main/webapp/WEB-INF/jsp/restrictedDrive.jsp
+++ b/documents-webapp/src/main/webapp/WEB-INF/jsp/restrictedDrive.jsp
@@ -1,0 +1,27 @@
+<%
+ /*
+  * Copyright (C) 2026 eXo Platform SAS.
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU Affero General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU Affero General Public License for more details.
+  *
+  * You should have received a copy of the GNU Affero General Public License
+  * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+%>
+<div class="VuetifyApp">
+  <div data-app="true"
+    class="v-application transparent v-application--is-ltr theme--light"
+    id="RestrictedDrive">
+    <script type="text/javascript">
+      require(['PORTLET/documents-portlet/RestrictedDrive'], app =>app.init());
+    </script>
+  </div>
+</div>

--- a/documents-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -149,6 +149,25 @@
   </portlet>
 
   <portlet>
+    <portlet-name>RestrictedDrive</portlet-name>
+    <display-name>Restricted Drive</display-name>
+    <portlet-class>org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet</portlet-class>
+    <init-param>
+      <name>portlet-view-dispatched-file-path</name>
+      <value>/WEB-INF/jsp/restrictedDrive.jsp</value>
+    </init-param>
+    <supports>
+      <mime-type>text/html</mime-type>
+    </supports>
+    <supported-locale>en</supported-locale>
+    <resource-bundle>locale.portlet.RestrictedDrive</resource-bundle>
+    <portlet-info>
+      <title>Restricted Drive</title>
+      <keywords>Restricted Drive</keywords>
+    </portlet-info>
+  </portlet>
+
+  <portlet>
     <portlet-name>DocumentGadget</portlet-name>
     <display-name>Document Gadget</display-name>
     <portlet-class>org.exoplatform.documents.portlet.DocumentGadgetPortlet</portlet-class>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileEditNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileEditNameCell.vue
@@ -14,7 +14,10 @@
     @blur="cancelEditNameMode()"
     @keyup="checkInput($event,fileName)"
     @contextmenu.stop.prevent>
-    <div v-if="!cardView" slot="append" class="d-flex">
+    <div
+      v-if="!cardView"
+      slot="append"
+      class="d-flex">
       <v-divider v-if="!isMobile" vertical />
       <v-icon
         class="primary--text ma-1 px-1"

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderCardsView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderCardsView.vue
@@ -89,21 +89,21 @@
             :data-canEdit="canEditFile(file)? 'true': 'false'"
             draggable="true"
             class="card-item flex-shrink-0 mb-3 me-3 pa-0">
-              <documents-item-card            
-                :index="index"
-                :count="filesCount"
-                :key="file.id"
-                :file="file"
-                :files="files"
-                current-view="folder"
-                :select-all-checked="selectAll"
-                :selected-documents="selectedDocuments"
-                @document-selected="handleDocumentSelection"
-                @document-unselected="handleDocumentSelection"
-                height="175px"
-                max-height="175px"
-                width="215px"
-                show-details />
+            <documents-item-card            
+              :index="index"
+              :count="filesCount"
+              :key="file.id"
+              :file="file"
+              :files="files"
+              current-view="folder"
+              :select-all-checked="selectAll"
+              :selected-documents="selectedDocuments"
+              @document-selected="handleDocumentSelection"
+              @document-unselected="handleDocumentSelection"
+              height="175px"
+              max-height="175px"
+              width="215px"
+              show-details />
           </div>
         </v-card>
       </div>

--- a/documents-webapp/src/main/webapp/vue-app/restricted-drive/components/RestrictedDrive.vue
+++ b/documents-webapp/src/main/webapp/vue-app/restricted-drive/components/RestrictedDrive.vue
@@ -1,0 +1,47 @@
+<!--
+
+ Copyright (C) 2026 eXo Platform SAS.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<template>
+  <v-app class="singlePageApplication">
+    <v-card
+      class="restricted-drive application-body py-12 text-center"
+      flat>
+      <v-card-text>
+        <v-icon color="primary" class="fa-7x">fa-door-open</v-icon>
+      </v-card-text>
+      <v-card-text
+        class="text-title"
+        v-sanitized-html="title" />
+      <v-card-text
+        class="text-body"
+        v-sanitized-html="subtitle" />
+    </v-card>
+  </v-app>
+</template>
+<script>
+export default {
+  computed: {
+    title() {
+      return this.$t('documents.restrictedDrive.title');
+    },
+    subtitle() {
+      return this.$t('documents.restrictedDrive.subtitle');
+    },
+  },
+};
+</script>

--- a/documents-webapp/src/main/webapp/vue-app/restricted-drive/initComponents.js
+++ b/documents-webapp/src/main/webapp/vue-app/restricted-drive/initComponents.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2026 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import RestrictedDrive from './components/RestrictedDrive.vue';
+
+const components = {
+  'documents-restricted-drive': RestrictedDrive,
+};
+
+for (const key in components) {
+  Vue.component(key, components[key]);
+}

--- a/documents-webapp/src/main/webapp/vue-app/restricted-drive/main.js
+++ b/documents-webapp/src/main/webapp/vue-app/restricted-drive/main.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+*/
+import './initComponents.js';
+
+// get overrided components if exists
+if (extensionRegistry) {
+  const components = extensionRegistry.loadComponents('RestrictedDrive');
+  if (components && components.length > 0) {
+    components.forEach(cmp => {
+      Vue.component(cmp.componentName, cmp.componentOptions);
+    });
+  }
+}
+
+const appId = 'RestrictedDrive';
+
+//getting language of the PLF
+const lang = eXo?.env?.portal?.language || 'en';
+
+//should expose the locale ressources as REST API
+const url = `/documents-portlet/i18n/locale.portlet.Documents?lang=${lang}`;
+
+export function init() {
+  exoi18n.loadLanguageAsync(lang, url).then(i18n => {
+    // init Vue app when locale ressources are ready
+    Vue.createApp({
+      template: `<documents-restricted-drive id="${appId}" />`,
+      vuetify: Vue.prototype.vuetifyOptions,
+      i18n
+    }, `#${appId}`, 'Restricted Drive');
+  });
+}

--- a/documents-webapp/webpack.prod.js
+++ b/documents-webapp/webpack.prod.js
@@ -51,6 +51,7 @@ module.exports = {
     documentsPwaExtension: './src/main/webapp/vue-app/documents-pwa-extension/main.js',
     documentGadget: './src/main/webapp/vue-app/document-gadget/main.js',
     filesSearch: './src/main/webapp/vue-app/files-search/main.js',
+    restrictedDrive: './src/main/webapp/vue-app/restricted-drive/main.js',
   },
   output: {
     path: path.join(__dirname, 'target/documents-portlet/'),


### PR DESCRIPTION
Before this change, a user creates a document in his personal drive, then attaches it to an article in a space. Another user who is a member of the same space goes to the location of the first user's document, which is restricted because it is located in his personal drive. This change corrects this behavior and displays a placeholder page to the second user to indicate that he does not have access to this drive.