### PR TITLE
feat: Add ContentType Definition in Search Connector - EXO-86376

### DIFF
--- a/documents-webapp/src/main/webapp/WEB-INF/conf/documents/documents-service-configuration.xml
+++ b/documents-webapp/src/main/webapp/WEB-INF/conf/documents/documents-service-configuration.xml
@@ -160,6 +160,9 @@
             <field name="name">
               <string>files</string>
             </field>
+            <field name="contentType">
+              <string>document</string>
+            </field>
             <field name="uri">
               <string><![CDATA[/portal/rest/search/documents/recent?limit={limit}&q={keyword}&sort=relevancy]]></string>
             </field>


### PR DESCRIPTION
This change will allow to define the associated `contentType` for each Search Connector to allow automatic filtering on content types.