### PR TITLE
feat: Add Hidden Content Plugin for folders - EXO-86750 - Meeds-io/ai#209

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/plugin/FolderAclPlugin.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/plugin/FolderAclPlugin.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2026 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.documents.plugin;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.documents.service.DocumentFileService;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.security.Identity;
+
+import io.meeds.portal.plugin.AclPlugin;
+
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class FolderAclPlugin implements AclPlugin {
+
+  public static final String  OBJECT_TYPE = "folder";
+
+  private static final Log    LOG         = ExoLogger.getLogger(FolderAclPlugin.class);
+
+  @Autowired
+  private DocumentFileService documentFileService;
+
+  @Autowired
+  private PortalContainer     container;
+
+  @PostConstruct
+  public void init() {
+    container.getComponentInstanceOfType(UserACL.class).addAclPlugin(this);
+  }
+
+  @Override
+  public String getObjectType() {
+    return OBJECT_TYPE;
+  }
+
+  @Override
+  public boolean hasPermission(String objectId,
+                               String permissionType,
+                               Identity identity) {
+    try {
+      return switch (permissionType) {
+      case VIEW_PERMISSION_TYPE: {
+        yield documentFileService.canAccess(objectId, identity);
+      }
+      case EDIT_PERMISSION_TYPE, DELETE_PERMISSION_TYPE: {
+        yield documentFileService.hasEditPermissionOnDocument(objectId, identity);
+      }
+      default:
+        yield false;
+      };
+    } catch (Exception e) {
+      LOG.warn("Error while checking permission '{}' on document '{}' for user '{}'",
+               permissionType,
+               objectId,
+               identity == null ? "" : identity.getUserId());
+      return false;
+    }
+  }
+
+}

--- a/documents-services/src/main/java/org/exoplatform/documents/plugin/FolderContentLinkPlugin.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/plugin/FolderContentLinkPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2025 eXo Platform SAS.
+ * Copyright (C) 2026 eXo Platform SAS.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -20,14 +20,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.documents.model.AbstractNode;
-import org.exoplatform.documents.model.FileNode;
+import org.exoplatform.documents.model.FolderNode;
 import org.exoplatform.documents.service.DocumentFileService;
 import org.exoplatform.services.security.Identity;
 
@@ -35,24 +34,27 @@ import io.meeds.social.cms.model.ContentLinkExtension;
 import io.meeds.social.cms.model.ContentLinkSearchResult;
 import io.meeds.social.cms.plugin.ContentLinkPlugin;
 import io.meeds.social.cms.service.ContentLinkPluginService;
+
 import jakarta.annotation.PostConstruct;
 import lombok.SneakyThrows;
 
 @Component
-public class DocumentContentLinkPlugin implements ContentLinkPlugin {
+public class FolderContentLinkPlugin implements ContentLinkPlugin {
 
-  public static final String                OBJECT_TYPE = DocumentAclPlugin.OBJECT_TYPE;
+  public static final String                OBJECT_TYPE = FolderAclPlugin.OBJECT_TYPE;
 
-  private static final String               TITLE_KEY   = "contentLink.document";
+  private static final String               TITLE_KEY   = "contentLink.folder";
 
-  private static final String               ICON        = "far fa-file-alt";
+  private static final String               ICON        = "far fa-folder";
 
-  private static final String               COMMAND     = "document";
+  private static final String               COMMAND     = "folder";
 
   private static final ContentLinkExtension EXTENSION   = new ContentLinkExtension(OBJECT_TYPE,
                                                                                    TITLE_KEY,
                                                                                    ICON,
-                                                                                   COMMAND);
+                                                                                   COMMAND,
+                                                                                   false,
+                                                                                   true);
 
   @Autowired
   private PortalContainer                   container;
@@ -73,37 +75,18 @@ public class DocumentContentLinkPlugin implements ContentLinkPlugin {
   @Override
   @SneakyThrows
   public List<ContentLinkSearchResult> search(String keyword, Identity identity, Locale locale, int offset, int limit) {
-    List<FileNode> documents = documentFileService.search(keyword,
-                                                          identity,
-                                                          offset,
-                                                          limit);
-    return CollectionUtils.isEmpty(documents) ? Collections.emptyList() :
-                                              documents.stream()
-                                                       .filter(doc -> !doc.getPath().startsWith("/Users"))
-                                                       .map(this::toContentLink)
-                                                       .toList();
+    return Collections.emptyList();
   }
 
   @Override
   public String getContentTitle(String objectId, Locale locale) {
     AbstractNode document = documentFileService.getDocumentById(objectId);
-    return document instanceof FileNode ? document.getName() : null;
+    return document instanceof FolderNode ? document.getName() : null;
   }
 
   @Override
   public boolean isId(String keyword) {
     return StringUtils.isNotBlank(keyword) && keyword.matches("^[0-9a-fA-F]{32}$");
-  }
-
-  private ContentLinkSearchResult toContentLink(AbstractNode document) {
-    if (document == null) {
-      return null;
-    } else {
-      return new ContentLinkSearchResult(OBJECT_TYPE,
-                                         String.valueOf(document.getId()),
-                                         document.getName(),
-                                         EXTENSION.getIcon());
-    }
   }
 
 }

--- a/documents-services/src/main/java/org/exoplatform/documents/plugin/FolderPermanentLinkPlugin.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/plugin/FolderPermanentLinkPlugin.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2025 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.documents.plugin;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.portal.config.UserPortalConfigService;
+import org.exoplatform.services.security.Identity;
+
+import io.meeds.portal.permlink.model.PermanentLinkObject;
+import io.meeds.portal.permlink.plugin.PermanentLinkPlugin;
+import io.meeds.portal.permlink.service.PermanentLinkService;
+
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class FolderPermanentLinkPlugin implements PermanentLinkPlugin {
+
+  public static final String      OBJECT_TYPE = FolderAclPlugin.OBJECT_TYPE;
+
+  public static final String      URL_FORMAT  = "/portal/%s/documents?documentPreviewId=%s";
+
+  @Autowired
+  private UserACL                 userAcl;
+
+  @Autowired
+  private UserPortalConfigService portalConfigService;
+
+  @Autowired
+  private PortalContainer         container;
+
+  @PostConstruct
+  public void init() {
+    container.getComponentInstanceOfType(PermanentLinkService.class).addPlugin(this);
+  }
+
+  @Override
+  public String getObjectType() {
+    return OBJECT_TYPE;
+  }
+
+  @Override
+  public boolean canAccess(PermanentLinkObject object, Identity identity) throws ObjectNotFoundException {
+    return userAcl.hasAccessPermission(OBJECT_TYPE, object.getObjectId(), identity);
+  }
+
+  @Override
+  public String getDirectAccessUrl(PermanentLinkObject object) throws ObjectNotFoundException {
+    return String.format(URL_FORMAT, portalConfigService.getMetaPortal(), object.getObjectId());
+  }
+
+}

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -64,6 +64,7 @@ import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
 import org.exoplatform.services.jcr.ext.utils.VersionHistoryUtils;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
+import org.exoplatform.services.jcr.impl.core.SessionImpl;
 import org.exoplatform.services.jcr.impl.core.query.QueryImpl;
 import org.exoplatform.services.jcr.util.Text;
 import org.exoplatform.services.listener.ListenerService;
@@ -234,7 +235,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     SessionProvider sessionProvider = SessionProvider.createSystemProvider();
     ManageableRepository repository = repositoryService.getCurrentRepository();
     Session systemSession = sessionProvider.getSession(repository.getConfiguration().getDefaultWorkspaceName(), repository);
-    Node node = getNodeById(systemSession, documentId);
+    Node node = getNodeByIdentifier(systemSession, documentId);
     if (node != null) {
       org.exoplatform.social.core.identity.model.Identity ownerIdentity = getOwnerIdentityFromNodePath(node.getPath(),
                                                                                                        identityManager,
@@ -2335,13 +2336,12 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     try {
       ManageableRepository manageableRepository = repositoryService.getCurrentRepository();
       Session session = getUserSessionProvider(repositoryService, identity).getSession(COLLABORATION, manageableRepository);
-      Node node = getNodeByIdentifier(session, documentId);
-      if (node == null) {
+      AbstractNode abstractNode = getDocumentById(session, documentId, identity);
+      if (abstractNode == null) {
         throw new ObjectNotFoundException(String.format("Node with id %s not found", documentId));
-      } else if (node.isNodeType(NodeTypeConstants.NT_UNSTRUCTURED) || node.isNodeType(NodeTypeConstants.NT_FOLDER)) {
-        return toFolderNode(identityManager, identity, node, "", spaceService);
+      }  else {
+        return abstractNode;
       }
-      return toFileNode(identityManager, identity, node, "", spaceService);
     } catch (ItemNotFoundException e) {
       throw new ObjectNotFoundException(String.format("Node with id %s not found", documentId));
     } catch (RepositoryException e) {
@@ -2354,8 +2354,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     try {
       ManageableRepository manageableRepository = repositoryService.getCurrentRepository();
       Session session = sessionProvider.getSession(COLLABORATION, manageableRepository);
-      Node node = session.getNodeByUUID(documentId);
-      return node == null ? null : toFileNode(identityManager, null, node, "", spaceService);
+      return getDocumentById(session, documentId, null);
     } catch (RepositoryException e) {
       return null;
     } finally {
@@ -2865,4 +2864,28 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     String nodePath = node.getPath();
     return StringUtils.startsWith(nodePath, "/Users") && StringUtils.contains(nodePath, "/Private");
   }
+
+  public AbstractNode getDocumentById(Session session, String documentId, Identity identity) throws RepositoryException {
+    Node node = getNodeByIdentifier(session, documentId);
+    if (node == null) {
+      return null;
+    } else {
+      if (node.isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
+        String nodeId = node.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString();
+        if (StringUtils.isEmpty(nodeId)) {
+          throw new ItemNotFoundException();
+        } else {
+          node = getNodeByIdentifier(node.getSession(), nodeId);
+        }
+      }
+      if (node.isNodeType(NodeTypeConstants.NT_FILE) || node.isNodeType(NodeTypeConstants.NT_RESOURCE)) {
+        return toFileNode(identityManager, identity, node, "", spaceService);
+      } else if (node.isNodeType(NodeTypeConstants.NT_FOLDER) || node.isNodeType(NodeTypeConstants.NT_UNSTRUCTURED)) {
+        return toFolderNode(identityManager, identity, node, "", spaceService);
+      } else {
+        throw new ItemNotFoundException();
+      }
+    }
+  }
+
 }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -341,7 +341,9 @@ public class JCRDocumentsUtil {
       fileNode.setDatasource(JCR_DATASOURCE_NAME);
       fileNode.setCloudDriveFile(node.hasProperty("ecd:driveUUID"));
       retrieveFileProperties(identityManager, node, aclIdentity, fileNode, spaceService);
-      if (node.hasNode(NodeTypeConstants.JCR_CONTENT)) {
+      if (node.isNodeType(NodeTypeConstants.NT_RESOURCE)) {
+        retrieveFileContentProperties(node, fileNode);
+      } else if (node.isNodeType(NodeTypeConstants.NT_FILE)) {
         Node content = node.getNode(NodeTypeConstants.JCR_CONTENT);
         retrieveFileContentProperties(content, fileNode);
       } else if (node.isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
@@ -411,7 +413,7 @@ public class JCRDocumentsUtil {
     if (node.hasProperty(NodeTypeConstants.EXO_SYMLINK_UUID)) {
       String targetNodeId = node.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString();
       fileNode.setLinkedFileId(targetNodeId);
-      return getNodeById(session, targetNodeId);
+      return getNodeByIdentifier(session, targetNodeId);
     }
     return node;
   }
@@ -620,14 +622,7 @@ public class JCRDocumentsUtil {
   }
 
   public static Node getNodeById(Session session, String nodeId) {
-    try {
-      return session.getNodeByUUID(nodeId);
-    } catch (PathNotFoundException e) {
-      LOG.info("Node with UUID {} is not found. Ignore search result.", nodeId);
-    } catch (RepositoryException e) {
-      LOG.debug("Error retrieving node with UUID {}. Will attempt to retrieve it by path", nodeId, e);
-    }
-    return null;
+    return getNodeByIdentifier(session, nodeId);
   }
 
   public static Node getNodeByPath(Session session, String nodePath) {

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -151,7 +151,7 @@ public class JCRDocumentsUtilTest {
     NodeImpl fileContent = mock(NodeImpl.class);
     when(file.getName()).thenReturn("document-test.pdf");
     when(file.getIdentifier()).thenReturn("fileIdentifier");
-    when(file.hasNode(NodeTypeConstants.JCR_CONTENT)).thenReturn(true);
+    when(file.isNodeType(NodeTypeConstants.NT_FILE)).thenReturn(true);
     when(file.getNode(NodeTypeConstants.JCR_CONTENT)).thenReturn(fileContent);
     when(fileContent.hasProperty(NodeTypeConstants.DC_DESCRIPTION)).thenReturn(false);
     when(fileContent.hasProperty(NodeTypeConstants.JCR_MIME_TYPE)).thenReturn(true);
@@ -163,14 +163,10 @@ public class JCRDocumentsUtilTest {
 
     // This file inside a folder's symlink will be converted and returned
     NodeImpl fileInFolderSymlink = mock(NodeImpl.class);
-    NodeImpl fileContentSymlink = mock(NodeImpl.class);
     when(fileInFolderSymlink.getName()).thenReturn("second-document-test.pdf");
     when(fileInFolderSymlink.getIdentifier()).thenReturn("fileIdentifierInsideSymlink");
-    when(fileInFolderSymlink.hasNode(NodeTypeConstants.JCR_CONTENT)).thenReturn(true);
+    when(fileInFolderSymlink.isNodeType(NodeTypeConstants.NT_FILE)).thenReturn(true);
     when(fileInFolderSymlink.getNode(NodeTypeConstants.JCR_CONTENT)).thenReturn(fileContent);
-    when(fileContentSymlink.hasProperty(NodeTypeConstants.DC_DESCRIPTION)).thenReturn(false);
-    when(fileContentSymlink.hasProperty(NodeTypeConstants.JCR_MIME_TYPE)).thenReturn(true);
-    when(fileContentSymlink.getProperty(NodeTypeConstants.JCR_MIME_TYPE)).thenReturn(mimeTypeProperty);
     when(fileInFolderSymlink.hasProperty(NodeTypeConstants.JCR_DATA)).thenReturn(false);
     when(fileInFolderSymlink.getACL()).thenReturn(new AccessControlList());
 

--- a/documents-webapp/src/main/resources/locale/portlet/ContentLink_en.properties
+++ b/documents-webapp/src/main/resources/locale/portlet/ContentLink_en.properties
@@ -1,2 +1,2 @@
 contentLink.document=Document
-
+contentLink.folder=Folder


### PR DESCRIPTION
This change will allow to reference a folder using its Id using 'content-link'. This plugin will be hidden in Content Link Drawer and commands menu knowing that the folders aren't searcheable yet (It will need a dedicate ES Index to allow it).