### PR TITLE
fix: Prevent XXE attacks in XML parsing in webdav - EXO-87056

### DIFF
--- a/documents-webdav-webapp/src/main/java/org/exoplatform/documents/webdav/plugin/WebDavHttpMethodPlugin.java
+++ b/documents-webdav-webapp/src/main/java/org/exoplatform/documents/webdav/plugin/WebDavHttpMethodPlugin.java
@@ -302,7 +302,15 @@ public abstract class WebDavHttpMethodPlugin {
     WebDavItemProperty rootProperty = null;
     LinkedList<WebDavItemProperty> curProperty = new LinkedList<>();
     try {
-      XMLInputFactory factory = XMLInputFactory.newInstance(); // NOSONAR
+      XMLInputFactory factory = XMLInputFactory.newInstance();
+      factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+      factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+      factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
+
+      factory.setXMLResolver((publicID, systemID, baseURI, namespace) -> {
+        throw new XMLStreamException("External entities disabled");
+      });
+
       XMLEventReader reader = factory.createXMLEventReader(entityStream);
       XMLEventReader fReader = factory.createFilteredReader(reader,
                                                             event -> !(event.isCharacters()


### PR DESCRIPTION
Before this fix, webdav is vulnerable to XXE attack. this commit Disable DTD processing and external entity resolution in XMLInputFactory to prevent XXE vulnerabilities and unauthorized access to local or remote resources during XML parsing.

Security hardening includes:
- Disable DTD support
- Disable external entities
- Disable automatic entity replacement
- Add a blocking XMLResolver to reject external entity resolution