### PR TITLE
fix: Fix Document version history - EXO-87203 (#1903)

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/model/AbstractNode.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/model/AbstractNode.java
@@ -63,6 +63,8 @@ public abstract class AbstractNode {
 
   private boolean        hidden;
 
+  private boolean        version;
+
   public  boolean isFolder(){
     return this instanceof FolderNode;
   }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -2386,11 +2386,23 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         }
       }
       Node content = node.getNode(NodeTypeConstants.JCR_CONTENT);
+      long lastModified = 0;
+      if (node.hasProperty(NodeTypeConstants.EXO_DATE_MODIFIED)) {
+        lastModified = node.getProperty(NodeTypeConstants.EXO_DATE_MODIFIED).getDate().getTimeInMillis();
+      } else if (node.hasProperty(NodeTypeConstants.EXO_DATE_CREATED)) {
+        lastModified = node.getProperty(NodeTypeConstants.EXO_DATE_CREATED).getDate().getTimeInMillis();
+      }
+
+      String mimeType = "";
+      if (content.hasProperty(NodeTypeConstants.JCR_MIME_TYPE)) {
+        mimeType = content.getProperty(NodeTypeConstants.JCR_MIME_TYPE).getString();
+      }
+
       return new FileContent(documentId,
-                             node.getProperty(NodeTypeConstants.EXO_TITLE).getString(),
-                             content.getProperty(NodeTypeConstants.JCR_MIME_TYPE).getString(),
+                             JCRDocumentsUtil.getTitle(node),
+                             mimeType,
                              content.getProperty(NodeTypeConstants.JCR_DATA).getStream(),
-                             node.getProperty(NodeTypeConstants.EXO_DATE_MODIFIED).getDate().getTime());
+                             new Date(lastModified));
     } catch (ItemNotFoundException e) {
       throw new ObjectNotFoundException("Document with id : " + documentId + " isn't found");
     } catch (RepositoryException e) {
@@ -2883,9 +2895,9 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
           node = getNodeByIdentifier(node.getSession(), nodeId);
         }
       }
-      if (node.isNodeType(NodeTypeConstants.NT_FILE) || node.isNodeType(NodeTypeConstants.NT_RESOURCE)) {
+      if (JCRDocumentsUtil.isFile(node)) {
         return toFileNode(identityManager, identity, node, "", spaceService);
-      } else if (node.isNodeType(NodeTypeConstants.NT_FOLDER) || node.isNodeType(NodeTypeConstants.NT_UNSTRUCTURED)) {
+      } else if (JCRDocumentsUtil.isFolder(node)) {
         return toFolderNode(identityManager, identity, node, "", spaceService);
       } else {
         throw new ItemNotFoundException();

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -346,6 +346,11 @@ public class JCRDocumentsUtil {
       } else if (node.isNodeType(NodeTypeConstants.NT_FILE)) {
         Node content = node.getNode(NodeTypeConstants.JCR_CONTENT);
         retrieveFileContentProperties(content, fileNode);
+      } else if (node.isNodeType(NodeTypeConstants.NT_FROZEN_NODE)) {
+        if (node.hasNode(NodeTypeConstants.JCR_CONTENT)) {
+          Node content = node.getNode(NodeTypeConstants.JCR_CONTENT);
+          retrieveFileContentProperties(content, fileNode);
+        }
       } else if (node.isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
         if (StringUtils.isEmpty(fileNode.getSourceID())) {
           String sourceID = node.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString();
@@ -425,6 +430,9 @@ public class JCRDocumentsUtil {
                                             SpaceService spaceService) throws RepositoryException {
     documentNode.setId(((NodeImpl) node).getIdentifier());
     documentNode.setPath(node.getPath());
+    if (node.isNodeType(NodeTypeConstants.NT_FROZEN_NODE)) {
+      documentNode.setVersion(true);
+    }
 
     try {
       Node parent = node.getParent();
@@ -516,6 +524,10 @@ public class JCRDocumentsUtil {
     }
     if (content.hasProperty(NodeTypeConstants.JCR_MIME_TYPE)) {
       fileNode.setMimeType(content.getProperty(NodeTypeConstants.JCR_MIME_TYPE).getString());
+    } else if (content.hasProperty("jcr:frozenPrimaryType") && content.getProperty("jcr:frozenPrimaryType").getString().equals(NodeTypeConstants.NT_RESOURCE)) {
+      if (content.hasProperty(NodeTypeConstants.JCR_MIME_TYPE)) {
+        fileNode.setMimeType(content.getProperty(NodeTypeConstants.JCR_MIME_TYPE).getString());
+      }
     }
     if (content.hasProperty(NodeTypeConstants.JCR_DATA)) {
       long fileSize = content.getProperty(NodeTypeConstants.JCR_DATA).getLength();
@@ -852,7 +864,19 @@ public class JCRDocumentsUtil {
   }
 
   public static boolean isFolder(Node node) throws RepositoryException {
-    return node.isNodeType(NodeTypeConstants.NT_FOLDER) || node.isNodeType(NodeTypeConstants.NT_UNSTRUCTURED);
+    String primaryType = node.getPrimaryNodeType().getName();
+    if (NodeTypeConstants.NT_FROZEN_NODE.equals(primaryType)) {
+      primaryType = node.getProperty("jcr:frozenPrimaryType").getString();
+    }
+    return NodeTypeConstants.NT_FOLDER.equals(primaryType) || NodeTypeConstants.NT_UNSTRUCTURED.equals(primaryType);
+  }
+
+  public static boolean isFile(Node node) throws RepositoryException {
+    String primaryType = node.getPrimaryNodeType().getName();
+    if (NodeTypeConstants.NT_FROZEN_NODE.equals(primaryType)) {
+      primaryType = node.getProperty("jcr:frozenPrimaryType").getString();
+    }
+    return NodeTypeConstants.NT_FILE.equals(primaryType) || NodeTypeConstants.NT_RESOURCE.equals(primaryType);
   }
 
   public static boolean hasEditPermission(Session session, Node node) {

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -422,6 +422,7 @@ public class JCRDocumentsUtilTest {
     NodeImpl mockNode = mock(NodeImpl.class);
     Node contentNode = mock(Node.class);
     Property mockProperty = mock(Property.class);
+    NodeType nodeType = mock(NodeType.class);
 
     when(mockNode.hasProperty(NodeTypeConstants.EXO_TITLE)).thenReturn(true);
     when(mockNode.getProperty(NodeTypeConstants.EXO_TITLE)).thenReturn(mockProperty);
@@ -446,6 +447,8 @@ public class JCRDocumentsUtilTest {
     when(mockProperty.getString()).thenReturn("Test Title").thenReturn("/restore/path").thenReturn("text/plain");
     when(mockNode.getName()).thenReturn("Test Node");
     when(mockNode.isNodeType(NodeTypeConstants.NT_FOLDER)).thenReturn(true);
+    when(mockNode.getPrimaryNodeType()).thenReturn(nodeType);
+    when(nodeType.getName()).thenReturn(NodeTypeConstants.NT_FOLDER);
 
     // Act
     TrashElementNode result = new TrashElementNode();

--- a/documents-webapp/src/main/webapp/vue-app/attachment/components/Attachment.vue
+++ b/documents-webapp/src/main/webapp/vue-app/attachment/components/Attachment.vue
@@ -104,9 +104,11 @@ export default {
     markAttachmentAsViewed(event) {
       const file = event.detail.file;
       const userName = eXo.env.portal.userName;
-      return Vue.prototype.$attachmentService.markAttachmentAsViewed(file.id, userName).then(views => {
-        document.dispatchEvent(new CustomEvent('document-views-updated', {detail: {file: file, views: views}}));
-      });
+      if (file && !file.version) {
+        return Vue.prototype.$attachmentService.markAttachmentAsViewed(file.id, userName).then(views => {
+          document.dispatchEvent(new CustomEvent('document-views-updated', {detail: {file: file, views: views}}));
+        });
+      }
     },
     refreshSupportedDocumentExtensions () {
       this.supportedDocuments = extensionRegistry.loadExtensions('documents', 'supported-document-types');

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/DocumentsMain.vue
@@ -412,7 +412,9 @@ export default {
       }
     },
     markDocumentAsViewed(file) {
-      document.dispatchEvent(new CustomEvent('mark-attachment-as-viewed', {detail: {file: file}}));
+      if (file && !file.version) {
+        document.dispatchEvent(new CustomEvent('mark-attachment-as-viewed', {detail: {file: file}}));
+      }
     },
     getDocumentPublicAccessLink(nodeId) {
       if (window.ClipboardItem && navigator.clipboard.write) {
@@ -1644,12 +1646,12 @@ export default {
               file.downloadUrl =`/rest/jcr/repository/collaboration${attachment.path}?version=${version.versionNumber}`;
               file.path = attachment.path;
               file.mimeType = attachment.mimeType;
-              file.filename = file.name;
+              file.filename = attachment.name;
               file.source = 'documents';
               if (this.isFileReadable(attachment)){
                 this.openFileInEditor(file,'view');
               } else {
-                const versionFile = {'id': file.id,'filename': file.name,'mimetype': attachment.mimeType,'source': 'documents','downloadUrl': file.downloadUrl, 'icon': this.getFileIcon(attachment)};
+                const versionFile = {'id': file.id,'filename': attachment.name,'mimetype': attachment.mimeType,'source': 'documents','downloadUrl': file.downloadUrl, 'icon': this.getFileIcon(attachment)};
                 document.dispatchEvent(new CustomEvent('open-attachments-preview', {detail: {'attachments': [versionFile],'id': file.id }}));
                 return attachment;}
             });


### PR DESCRIPTION
This change will fix the issue where previous versions of a document could not be opened The issue was caused by the JCR storage implementation not recognizing frozen nodes as valid files