### PR TITLE
fix: remove @ from specialChar to prevent false duplicate detection with _ - EXO-86194

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -754,7 +754,7 @@ public class JCRDocumentsUtil {
       oldName = oldName.substring(0,oldName.lastIndexOf(".")) ;
     }
     oldName = oldName.trim();
-    String specialChar = "&#*@.'\"\t\r\n$\\><:;[]/|’";
+    String specialChar = "&#*.'\"\t\r\n$\\><:;[]/|’";
     StringBuilder ret = new StringBuilder();
     for (int i = 0; i < oldName.length(); i++) {
       char currentChar = oldName.charAt(i);


### PR DESCRIPTION
This change will removed @ from the specialChar string. The @ character is valid in JCR node names and is not inherently problematic like [, ], *, | etc.