### PR TITLE
fix: Open and copy files with special characters via WebDAV mapped drive - EXO-86918

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/cache/CachedJcrWebDavService.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/cache/CachedJcrWebDavService.java
@@ -20,7 +20,6 @@ import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.
 import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.MODIFICATION_PATTERN;
 import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.REQUEST_ALL_PROPS;
 
-import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
@@ -265,7 +264,6 @@ public class CachedJcrWebDavService extends JcrWebDavService {
   private WebDavItemEntity findCacheEntry(String webDavPath) {
     String id = Arrays.stream(webDavPath.split("/"))
                       .filter(StringUtils::isNotBlank)
-                      .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
                       .map(s -> URLEncoder.encode(s, StandardCharsets.UTF_8)
                                           .replace("+", "%20"))
                       .collect(Collectors.joining("/"));

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/cache/elasticsearch/entity/WebDavItemEntity.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/cache/elasticsearch/entity/WebDavItemEntity.java
@@ -81,7 +81,7 @@ public class WebDavItemEntity {
                           boolean file,
                           List<WebDavItemProperty> properties) {
     if (webDavPath.endsWith("/")) {
-      webDavPath = webDavPath.substring(webDavPath.length() - 1);
+      webDavPath = webDavPath.substring(0, webDavPath.length() - 1);
     }
     this.webDavPath = webDavPath;
     this.jcrPath = jcrPath;

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/PathCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/PathCommandHandler.java
@@ -41,8 +41,7 @@ import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.
 import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.VERSIONHISTORY;
 import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.VERSIONNAME;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -195,7 +194,6 @@ public class PathCommandHandler {
       String[] pathParts = webDavPath.split("/");
       String identityPart = Arrays.stream(pathParts)
                                   .filter(StringUtils::isNotBlank)
-                                  .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
                                   .findFirst()
                                   .orElse(null);
       String identityId = null;
@@ -237,7 +235,6 @@ public class PathCommandHandler {
     String[] pathParts = webDavPath.split("/");
     return Arrays.stream(pathParts)
                  .filter(StringUtils::isNotBlank)
-                 .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
                  .map(Utils::encodeNodeName)
                  .skip(1)
                  .collect(Collectors.joining("/"));

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandler.java
@@ -29,7 +29,6 @@ import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.
 
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -710,7 +709,6 @@ public class WebdavReadCommandHandler {
     } else {
       String encodedNodeRelativePath = Arrays.stream(nodeRelativePath.split("/"))
                                              .filter(StringUtils::isNotBlank)
-                                             .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
                                              .map(this::encodeUrlString)
                                              .collect(Collectors.joining("/"));
       return String.format(PATHS_CONCAT_FORMAT, identityBaseUri, encodedNodeRelativePath);
@@ -733,7 +731,6 @@ public class WebdavReadCommandHandler {
     } else {
       String encodedNodeRelativePath = Arrays.stream(nodeRelativePath.split("/"))
                                              .filter(StringUtils::isNotBlank)
-                                             .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
                                              .map(this::encodeUrlString)
                                              .collect(Collectors.joining("/"));
       return String.format("/%s%s%s%s/%s",
@@ -801,6 +798,10 @@ public class WebdavReadCommandHandler {
       if (!session.itemExists(parentPath)) {
         String cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(parts[i].toLowerCase(), NodeTypeConstants.NT_FILE));
         parentPath = jcrPath + "/" + cleanName;
+        if (!session.itemExists(parentPath)) {
+          cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(parts[i], NodeTypeConstants.NT_FILE));
+          parentPath = jcrPath + "/" + cleanName;
+        }
         if (!session.itemExists(parentPath)) {
           cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanName(parts[i].toLowerCase(), NodeTypeConstants.NT_FOLDER ));
           parentPath = jcrPath + "/" + cleanName;

--- a/documents-webdav-webapp/src/main/java/org/exoplatform/documents/webdav/plugin/WebDavHttpMethodPlugin.java
+++ b/documents-webdav-webapp/src/main/java/org/exoplatform/documents/webdav/plugin/WebDavHttpMethodPlugin.java
@@ -19,12 +19,18 @@ package org.exoplatform.documents.webdav.plugin;
 import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.DAV_ALLPROP_INCLUDE;
 import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.getStatusDescription;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -147,7 +153,7 @@ public abstract class WebDavHttpMethodPlugin {
 
   protected String getResourcePath(HttpServletRequest httpRequest) {
     String resourcePath = Arrays.stream(httpRequest.getRequestURI().substring(getBaseUri(httpRequest).length()).split("/"))
-                                .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
+                                .map(WebDavHttpMethodPlugin::decodeUrlSegment)
                                 .collect(Collectors.joining("/"));
     return StringUtils.isBlank(resourcePath) ? "/" : resourcePath;
   }
@@ -155,7 +161,6 @@ public abstract class WebDavHttpMethodPlugin {
   @SneakyThrows
   protected URI getResourceUri(HttpServletRequest httpRequest) {
     return new URI(getBaseUrl(httpRequest) + Arrays.stream(getResourcePath(httpRequest).split("/"))
-                                                   .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
                                                    .map(s -> URLEncoder.encode(s, StandardCharsets.UTF_8).replace("+", "%20"))
                                                    .collect(Collectors.joining("/")));
   }
@@ -196,7 +201,7 @@ public abstract class WebDavHttpMethodPlugin {
                                                                  .split(getBaseUri(httpRequest)))
                                               .getLast()
                                               .split("/"))
-                                .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
+                                .map(WebDavHttpMethodPlugin::decodeUrlSegment)
                                 .collect(Collectors.joining("/"));
     return StringUtils.isBlank(resourcePath) ? "/" : resourcePath;
   }
@@ -357,6 +362,20 @@ public abstract class WebDavHttpMethodPlugin {
       } else {
         throw e;
       }
+    }
+  }
+
+  private static String decodeUrlSegment(String segment) {
+    String prepared = segment.replace("+", "%2B");
+    String isoString = URLDecoder.decode(prepared, StandardCharsets.ISO_8859_1);
+    byte[] bytes = isoString.getBytes(StandardCharsets.ISO_8859_1);
+    CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder()
+        .onMalformedInput(CodingErrorAction.REPORT)
+        .onUnmappableCharacter(CodingErrorAction.REPORT);
+    try {
+      return decoder.decode(ByteBuffer.wrap(bytes)).toString();
+    } catch (CharacterCodingException e) {
+      return isoString;
     }
   }
 


### PR DESCRIPTION
This change will decode WebDAV path segments with UTF-8 fallback to ISO-8859-1 to handle non-UTF-8 percent-encoded characters