### PR TITLE
Revert WebDav changes

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -17,6 +17,10 @@
 package org.exoplatform.documents.storage.jcr.util;
 
 import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.DOCUMENT_CATEGORY_IDS;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_DATE_MODIFIED;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_LAST_MODIFIED_DATE;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_CONTENT;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_LAST_MODIFIED;
 
 import java.io.*;
 import java.nio.file.Files;
@@ -25,6 +29,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -70,6 +75,8 @@ import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.service.LinkProvider;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
+
+import lombok.SneakyThrows;
 
 public class JCRDocumentsUtil {
   private static final Log                              LOG                           =
@@ -475,29 +482,10 @@ public class JCRDocumentsUtil {
       documentNode.setCreatorUserName(owner);
       documentNode.setCreatorId(getUserIdentityId(identityManager, owner));
     }
-    if (node.hasProperty(NodeTypeConstants.EXO_DATE_MODIFIED)) {
-      Node nodeToModify = node;
-      if (node.isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
-        RepositoryService repositoryService = CommonsUtils.getService(RepositoryService.class);
-        SessionProvider sessionProvider = SessionProvider.createSystemProvider();
-        ManageableRepository repository = repositoryService.getCurrentRepository();
-        Session systemSession = sessionProvider.getSession(repository.getConfiguration().getDefaultWorkspaceName(), repository);
-        String sourceNodeId = node.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString();
-        Node sourceNode = getNodeByIdentifier(systemSession, sourceNodeId);
-        if (sourceNode != null && sourceNode.getProperty(NodeTypeConstants.EXO_DATE_MODIFIED).getDate().compareTo(node.getProperty(NodeTypeConstants.EXO_DATE_MODIFIED).getDate()) > 0) {
-          nodeToModify = sourceNode;
-        }
-      }
-      long modifiedDate = nodeToModify.getProperty(NodeTypeConstants.EXO_DATE_MODIFIED)
-              .getDate()
-              .getTimeInMillis();
-      documentNode.setModifiedDate(modifiedDate);
-      String modifier = nodeToModify.getProperty(NodeTypeConstants.EXO_LAST_MODIFIER).getString();
-      documentNode.setModifierId(getUserIdentityId(identityManager, modifier));
-    } else {
-      documentNode.setModifiedDate(documentNode.getCreatedDate());
-      documentNode.setModifierId(documentNode.getCreatorId());
-    }
+    long lastModifiedDate = getLastModifiedDate(Objects.requireNonNullElse(versionNode, node));
+    documentNode.setModifiedDate(lastModifiedDate == 0l ? documentNode.getCreatedDate() : lastModifiedDate);
+    String modifierUsername = getLastModifier(Objects.requireNonNullElse(versionNode, node));
+    documentNode.setModifierId(modifierUsername == null ? documentNode.getCreatorId() : getUserIdentityId(identityManager, modifierUsername));
     if (node.hasProperty(NodeTypeConstants.DC_DESCRIPTION)) {
       try {
         documentNode.setDescription(node.getProperty(NodeTypeConstants.DC_DESCRIPTION).getString());
@@ -542,6 +530,39 @@ public class JCRDocumentsUtil {
         fileNode.setSizeWithVersions(fileSize);
       }
 
+    }
+  }
+
+  public static long getLastModifiedDate(Node node) throws RepositoryException { // NOSONAR
+    Calendar modifiedCalendar = Stream.of("jcr:content/jcr:lastModified",
+                                          "jcr:content/exo:dateModified",
+                                          "jcr:content/exo:lastModifiedDate",
+                                          "jcr:lastModified",
+                                          "exo:dateModified",
+                                          "exo:lastModifiedDate")
+                                      .filter(p -> hasProperty(node, p))
+                                      .map(p -> getPropertyDate(node, p))
+                                      .findFirst()
+                                      .orElse(null);
+    return modifiedCalendar == null ? 0l : modifiedCalendar.getTimeInMillis();
+  }
+
+  public static String getLastModifierOrCreator(Node node) throws RepositoryException {
+    String lastModifier = getLastModifier(node);
+    if (lastModifier != null) {
+      return lastModifier;
+    } else if (node.hasProperty(NodeTypeConstants.EXO_OWNER)) {
+      return node.getProperty(NodeTypeConstants.EXO_OWNER).getString();
+    } else {
+      return null;
+    }
+  }
+
+  public static String getLastModifier(Node node) throws RepositoryException {
+    if (node.hasProperty(NodeTypeConstants.EXO_LAST_MODIFIER)) {
+      return node.getProperty(NodeTypeConstants.EXO_LAST_MODIFIER).getString();
+    } else {
+      return null;
     }
   }
 
@@ -826,9 +847,10 @@ public class JCRDocumentsUtil {
     String currentVersionName = node.getBaseVersion().getName();
     Node frozen = version.getNode(NodeTypeConstants.JCR_FROZEN_NODE);
     versionFileNode.setTitle(getTitle(node));
-    String userName = frozen.getProperty(NodeTypeConstants.EXO_LAST_MODIFIER).getValue().getString();
-    org.exoplatform.social.core.identity.model.Identity
-        identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, userName);
+    String userName = getLastModifierOrCreator(frozen);
+    org.exoplatform.social.core.identity.model.Identity identity = userName != null ?
+                                                                                    identityManager.getOrCreateUserIdentity(userName) :
+                                                                                    null;
     Profile profile = identity != null ? identity.getProfile() : null;
     String[] summary = node.getVersionHistory().getVersionLabels(version);
     if (summary.length > 0) {
@@ -1124,6 +1146,16 @@ public class JCRDocumentsUtil {
     } else {
       return title;
     }
+  }
+
+  @SneakyThrows
+  private static boolean hasProperty(Node node, String propertyName) {
+    return node.hasProperty(propertyName);
+  }
+
+  @SneakyThrows
+  private static Calendar getPropertyDate(Node node, String propertyName) {
+    return node.getProperty(propertyName).getDate();
   }
 
 }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/cache/elasticsearch/entity/WebDavItemEntity.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/cache/elasticsearch/entity/WebDavItemEntity.java
@@ -81,7 +81,7 @@ public class WebDavItemEntity {
                           boolean file,
                           List<WebDavItemProperty> properties) {
     if (webDavPath.endsWith("/")) {
-      webDavPath = webDavPath.substring(webDavPath.length() - 1);
+      webDavPath = webDavPath.substring(0, webDavPath.length() - 1);
     }
     this.webDavPath = webDavPath;
     this.jcrPath = jcrPath;

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandler.java
@@ -17,7 +17,6 @@
 package org.exoplatform.documents.storage.jcr.webdav.plugin;
 
 import static org.exoplatform.documents.storage.jcr.util.ACLProperties.getReadOnlyACL;
-import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.getPathWithTitles;
 import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.getTitle;
 import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.*;
 import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_CONTENT;
@@ -698,13 +697,7 @@ public class WebdavReadCommandHandler {
 
   @SneakyThrows
   private String getNodeUri(Node node, String identityBaseJcrPath, String identityBaseUri) {
-    String jcrPath = node.getPath();
-    if (node.hasProperty(EXO_TITLE)) {
-      String[] parts = jcrPath.split("/");
-      parts[parts.length - 1] = node.getProperty(EXO_TITLE).getString();
-      jcrPath = Arrays.stream(parts).collect(Collectors.joining("/"));
-    }
-    String nodeRelativePath = jcrPath.replaceFirst(identityBaseJcrPath, "");
+    String nodeRelativePath = node.getPath().replaceFirst(identityBaseJcrPath, "");
     if (StringUtils.isBlank(nodeRelativePath)) {
       return identityBaseUri;
     } else {
@@ -722,8 +715,7 @@ public class WebdavReadCommandHandler {
                                     String identityBaseJcrPath,
                                     long identityId,
                                     String displayName) {
-
-    String nodeRelativePath = getPathWithTitles(node).replaceFirst(identityBaseJcrPath, "");
+    String nodeRelativePath = node.getPath().replaceFirst(identityBaseJcrPath, "");
     if (StringUtils.isBlank(nodeRelativePath)) {
       return String.format("/%s%s%s%s",
                            encodeUrlString(displayName),
@@ -793,25 +785,25 @@ public class WebdavReadCommandHandler {
     }
   }
 
-  private String checkResourceExists(Session session, String path) throws RepositoryException, WebDavException {
-    String[] parts = path.split("/");
-    String jcrPath = "";
-    for (int i = 1; i < parts.length; i++) {
-      String parentPath = jcrPath + "/" + parts[i];
-      if (!session.itemExists(parentPath)) {
-        String cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(parts[i].toLowerCase(), NodeTypeConstants.NT_FILE));
-        parentPath = jcrPath + "/" + cleanName;
-        if (!session.itemExists(parentPath)) {
-          cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanName(parts[i].toLowerCase()));
-          parentPath = jcrPath + "/" + cleanName;
-        }
-        if (!session.itemExists(parentPath)) {
-          throw new WebDavException(HttpStatus.SC_NOT_FOUND,
-                  String.format("Resource with path '%s' not found", jcrPath));
-        }
+  private String checkResourceExists(Session session, String jcrPath) throws RepositoryException, WebDavException {
+    if (!session.itemExists(jcrPath)) {
+      String[] parts = jcrPath.split("/");
+      String fileTitle = parts[parts.length - 1];
+      String cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(fileTitle.toLowerCase(),NodeTypeConstants.NT_FILE));
+      parts[parts.length - 1] = cleanName;
+      jcrPath =  Arrays.stream(parts).collect(Collectors.joining("/"));
+      if (!session.itemExists(jcrPath)) {
+        cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanName(fileTitle.toLowerCase()));
+        parts[parts.length - 1] = cleanName;
+        jcrPath =  Arrays.stream(parts).collect(Collectors.joining("/"));
       }
-      jcrPath = parentPath;
+      if (!session.itemExists(jcrPath)) {
+        throw new WebDavException(HttpStatus.SC_NOT_FOUND,
+                String.format("Resource with path '%s' not found", jcrPath));
+      }
     }
     return jcrPath;
   }
+
+
 }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandler.java
@@ -802,9 +802,6 @@ public class WebdavReadCommandHandler {
         String cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(parts[i].toLowerCase(), NodeTypeConstants.NT_FILE));
         parentPath = jcrPath + "/" + cleanName;
         if (!session.itemExists(parentPath)) {
-          cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanName(parts[i].toLowerCase(), NodeTypeConstants.NT_FOLDER ));
-          parentPath = jcrPath + "/" + cleanName;
-        }if (!session.itemExists(parentPath)) {
           cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanName(parts[i].toLowerCase()));
           parentPath = jcrPath + "/" + cleanName;
         }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandler.java
@@ -17,25 +17,81 @@
 package org.exoplatform.documents.storage.jcr.webdav.plugin;
 
 import static org.exoplatform.documents.storage.jcr.util.ACLProperties.getReadOnlyACL;
-import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.getTitle;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.*;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_DATE_CREATED;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_DATE_MODIFIED;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_HIDDENABLE;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_LAST_MODIFIED_DATE;
 import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_CONTENT;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_CREATED_DATE;
 import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_DATA;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_ENCODING;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_FROZEN_NODE;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_LAST_MODIFIED;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_MIME_TYPE;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_ROOT_VERSION;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.MIX_LOCKABLE;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.MIX_VERSIONABLE;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.NT_FOLDER;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.NT_UNSTRUCTURED;
 import static org.exoplatform.documents.storage.jcr.util.Utils.decodeString;
 import static org.exoplatform.documents.storage.jcr.util.Utils.getStringProperty;
-import static org.exoplatform.documents.storage.jcr.webdav.plugin.PathCommandHandler.*;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.*;
+import static org.exoplatform.documents.storage.jcr.webdav.plugin.PathCommandHandler.IDENTITY_PATHS_FORMAT;
+import static org.exoplatform.documents.storage.jcr.webdav.plugin.PathCommandHandler.LOG;
+import static org.exoplatform.documents.storage.jcr.webdav.plugin.PathCommandHandler.PATHS_CONCAT_FORMAT;
+import static org.exoplatform.documents.storage.jcr.webdav.plugin.PathCommandHandler.PROPERTY_NAMES;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.CHECKEDIN;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.CHECKEDOUT;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.CHILDCOUNT;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.CREATIONDATE;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.CREATION_PATTERN;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.DISPLAYNAME;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.GETCONTENTLENGTH;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.GETCONTENTTYPE;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.GETLASTMODIFIED;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.GET_ETAG;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.HASCHILDREN;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.HREF;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.ISCOLLECTION;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.ISFOLDER;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.ISROOT;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.ISVERSIONED;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.LOCKDISCOVERY;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.MODIFICATION_PATTERN;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.OWNER;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.PARENTNAME;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.PREDECESSORSET;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.RESOURCETYPE;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.SUCCESSORSET;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.SUPPORTEDLOCK;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.SUPPORTEDMETHODSET;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.VERSIONHISTORY;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.VERSIONNAME;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.getIsFolderItemProperty;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.getLockDiscovery;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.getSupportedLock;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.getSupportedMethodSet;
 
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import javax.jcr.*;
+import javax.jcr.Item;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 import javax.jcr.version.Version;
 import javax.jcr.version.VersionIterator;
 import javax.xml.namespace.QName;
@@ -46,7 +102,6 @@ import org.springframework.stereotype.Component;
 
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.documents.storage.jcr.util.ACLProperties;
-import org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil;
 import org.exoplatform.documents.storage.jcr.util.NodeTypeConstants;
 import org.exoplatform.documents.storage.jcr.webdav.model.JcrNamespaceContext;
 import org.exoplatform.documents.webdav.model.WebDavException;
@@ -55,7 +110,6 @@ import org.exoplatform.documents.webdav.model.WebDavItem;
 import org.exoplatform.documents.webdav.model.WebDavItemProperty;
 import org.exoplatform.documents.webdav.model.constant.FileConstants;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
-import org.exoplatform.services.jcr.util.Text;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.manager.IdentityManager;
@@ -157,7 +211,7 @@ public class WebdavReadCommandHandler {
     String mimeType = node.getNode(JCR_CONTENT).getProperty(JCR_MIME_TYPE).getString();
     InputStream inputStream = node.getNode(JCR_CONTENT).getProperty(JCR_DATA).getStream();
 
-    return new WebDavFileDownload(getTitle(node),
+    return new WebDavFileDownload(node.getName(),
                                   inputStream.available(),
                                   lastModifiedDate == null ? 0l : lastModifiedDate.getTimeInMillis(),
                                   mimeType,
@@ -215,7 +269,6 @@ public class WebdavReadCommandHandler {
   @SneakyThrows
   public boolean isFile(Session session, String webDavPath) {
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    jcrPath = checkResourceExists(session, jcrPath);
     if (session.itemExists(jcrPath)) {
       Item item = session.getItem(jcrPath);
       if (item instanceof Node node) {
@@ -275,7 +328,10 @@ public class WebdavReadCommandHandler {
       version = jcrPath.substring(jcrPath.indexOf(VERSION_QUERY_PARAM) + VERSION_QUERY_PARAM.length());
       jcrPath = jcrPath.substring(0, jcrPath.indexOf(VERSION_QUERY_PARAM));
     }
-    jcrPath = checkResourceExists(session, jcrPath);
+    if (!session.itemExists(jcrPath)) {
+      throw new WebDavException(HttpStatus.SC_NOT_FOUND,
+                                String.format("Resource with path '%s' not found", jcrPath));
+    }
     Item item = session.getItem(jcrPath);
     if (!(item instanceof Node node)) {
       throw new WebDavException(HttpStatus.SC_BAD_REQUEST,
@@ -396,7 +452,7 @@ public class WebdavReadCommandHandler {
     if (name.equals(DISPLAYNAME)) {
       return version == null ? new WebDavItemProperty(name,
                                                       String.format("%s%s",
-                                                                    decodeString(getTitle(node)),
+                                                                    decodeString(node.getName()),
                                                                     getNodeIndexSuffix(node))) :
                              new WebDavItemProperty(name, decodeString(version.getName()));
     } else if (VERSIONNAME.equals(name)) {
@@ -784,26 +840,5 @@ public class WebdavReadCommandHandler {
       return identity.getProfile().getFullName();
     }
   }
-
-  private String checkResourceExists(Session session, String jcrPath) throws RepositoryException, WebDavException {
-    if (!session.itemExists(jcrPath)) {
-      String[] parts = jcrPath.split("/");
-      String fileTitle = parts[parts.length - 1];
-      String cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(fileTitle.toLowerCase(),NodeTypeConstants.NT_FILE));
-      parts[parts.length - 1] = cleanName;
-      jcrPath =  Arrays.stream(parts).collect(Collectors.joining("/"));
-      if (!session.itemExists(jcrPath)) {
-        cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanName(fileTitle.toLowerCase()));
-        parts[parts.length - 1] = cleanName;
-        jcrPath =  Arrays.stream(parts).collect(Collectors.joining("/"));
-      }
-      if (!session.itemExists(jcrPath)) {
-        throw new WebDavException(HttpStatus.SC_NOT_FOUND,
-                String.format("Resource with path '%s' not found", jcrPath));
-      }
-    }
-    return jcrPath;
-  }
-
 
 }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavWriteCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavWriteCommandHandler.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import javax.jcr.*;
 import javax.jcr.lock.Lock;
@@ -133,10 +134,6 @@ public class WebdavWriteCommandHandler {
                            List<String> mixinTypes) {
     checkNotRoot(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    String folderName = jcrPath.substring(jcrPath.lastIndexOf("/") + 1);
-    jcrPath = jcrPath.substring(0, jcrPath.lastIndexOf("/"));
-    jcrPath = checkResourceExists(session, jcrPath);
-    jcrPath = jcrPath + "/" + folderName;
     Node node = addNode(session, jcrPath, NT_FOLDER);
     addMixins(node, mixinTypes);
     session.save();
@@ -150,10 +147,13 @@ public class WebdavWriteCommandHandler {
                        InputStream inputStream) {
     checkNotRoot(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    String fileName = jcrPath.substring(jcrPath.lastIndexOf("/") + 1);
-    jcrPath = jcrPath.substring(0, jcrPath.lastIndexOf("/"));
-    jcrPath = checkResourceExists(session, jcrPath);
-    jcrPath = jcrPath + "/" + fileName;
+    if (!session.itemExists(jcrPath)) {
+      String[] parts = jcrPath.split("/");
+      String fileTitle = parts[parts.length - 1];
+      fileTitle = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(fileTitle.toLowerCase(), NodeTypeConstants.NT_FILE));
+      parts[parts.length - 1] = fileTitle;
+      jcrPath = Arrays.stream(parts).collect(Collectors.joining("/"));
+    }
     Node node = session.itemExists(jcrPath) ? (Node) session.getItem(jcrPath) : null;
     Calendar now = Calendar.getInstance();
     if (node == null) {
@@ -284,10 +284,6 @@ public class WebdavWriteCommandHandler {
       }
     }
     forceUnlock((Node) session.getItem(sourceJcrPath));
-    String fileName = targetJcrPath.substring(targetJcrPath.lastIndexOf("/") + 1);
-    targetJcrPath = targetJcrPath.substring(0, targetJcrPath.lastIndexOf("/"));
-    targetJcrPath = checkResourceExists(session, targetJcrPath);
-    targetJcrPath = targetJcrPath + "/" + fileName;
     session.move(sourceJcrPath, targetJcrPath);
     session.save();
     Node targetNode = (Node) session.getItem(targetJcrPath);
@@ -520,24 +516,21 @@ public class WebdavWriteCommandHandler {
     }
   }
 
-  private String checkResourceExists(Session session, String path) throws RepositoryException, WebDavException {
-    String[] parts = path.split("/");
-    String jcrPath = "";
-    for (int i = 1; i < parts.length; i++) {
-      String parentPath = jcrPath + "/" + parts[i];
-      if (!session.itemExists(parentPath)) {
-        String cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(parts[i].toLowerCase(), NodeTypeConstants.NT_FILE));
-        parentPath = jcrPath + "/" + cleanName;
-        if (!session.itemExists(parentPath)) {
-          cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanName(parts[i].toLowerCase()));
-          parentPath = jcrPath + "/" + cleanName;
-        }
-        if (!session.itemExists(parentPath)) {
-          throw new WebDavException(HttpStatus.SC_NOT_FOUND,
-                  String.format("Resource with path '%s' not found", jcrPath));
-        }
+  private String checkResourceExists(Session session, String jcrPath) throws RepositoryException, WebDavException {
+    if (!session.itemExists(jcrPath)) {
+      String[] parts = jcrPath.split("/");
+      String fileTitle = parts[parts.length - 1];
+      String cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(fileTitle.toLowerCase(),NodeTypeConstants.NT_FILE));
+      parts[parts.length - 1] = cleanName;
+      jcrPath =  Arrays.stream(parts).collect(Collectors.joining("/"));
+      if (!session.itemExists(jcrPath)) {
+        cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(fileTitle.toLowerCase(), NT_FOLDER));
+        parts[parts.length - 1] = cleanName;
+        jcrPath =  Arrays.stream(parts).collect(Collectors.joining("/"));
       }
-      jcrPath = parentPath;
+      if (!session.itemExists(jcrPath)) {
+        throw new WebDavException(HttpStatus.SC_NOT_FOUND, String.format(RESOURCE_WITH_PATH_S_NOT_FOUND, jcrPath));
+      }
     }
     return jcrPath;
   }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavWriteCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavWriteCommandHandler.java
@@ -17,16 +17,40 @@
 package org.exoplatform.documents.storage.jcr.webdav.plugin;
 
 import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.*;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_DATA;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_ENCODING;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_LAST_MODIFIED;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_MIME_TYPE;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.MIX_LOCKABLE;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.MIX_VERSIONABLE;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.NT_FILE;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.NT_FOLDER;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.NT_RESOURCE;
 import static org.exoplatform.documents.storage.jcr.util.Utils.encodeNodeName;
 import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.getStatusDescription;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
+import java.util.Set;
 
-import javax.jcr.*;
+import javax.jcr.AccessDeniedException;
+import javax.jcr.Item;
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.PathNotFoundException;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Workspace;
 import javax.jcr.lock.Lock;
 import javax.jcr.lock.LockException;
 import javax.jcr.version.Version;
@@ -46,8 +70,6 @@ import org.exoplatform.commons.api.settings.data.Context;
 import org.exoplatform.commons.api.settings.data.Scope;
 import org.exoplatform.commons.utils.MimeTypeResolver;
 import org.exoplatform.documents.storage.TrashStorage;
-import org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil;
-import org.exoplatform.documents.storage.jcr.util.NodeTypeConstants;
 import org.exoplatform.documents.webdav.model.WebDavException;
 import org.exoplatform.documents.webdav.model.WebDavItemOrder;
 import org.exoplatform.documents.webdav.model.WebDavItemProperty;
@@ -67,7 +89,6 @@ import org.exoplatform.services.jcr.ext.utils.VersionHistoryUtils;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.jcr.impl.core.SessionImpl;
 import org.exoplatform.services.jcr.impl.core.WorkspaceImpl;
-import org.exoplatform.services.jcr.util.Text;
 import org.exoplatform.services.jcr.webdav.util.InitParamsDefaults;
 import org.exoplatform.services.jcr.webdav.util.PropertyConstants;
 import org.exoplatform.services.jcr.webdav.util.TextUtil;
@@ -147,13 +168,6 @@ public class WebdavWriteCommandHandler {
                        InputStream inputStream) {
     checkNotRoot(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    if (!session.itemExists(jcrPath)) {
-      String[] parts = jcrPath.split("/");
-      String fileTitle = parts[parts.length - 1];
-      fileTitle = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(fileTitle.toLowerCase(), NodeTypeConstants.NT_FILE));
-      parts[parts.length - 1] = fileTitle;
-      jcrPath = Arrays.stream(parts).collect(Collectors.joining("/"));
-    }
     Node node = session.itemExists(jcrPath) ? (Node) session.getItem(jcrPath) : null;
     Calendar now = Calendar.getInstance();
     if (node == null) {
@@ -186,7 +200,7 @@ public class WebdavWriteCommandHandler {
                                                                     List<WebDavItemProperty> propertiesToRemove) throws WebDavException {
     checkNotReadOnly(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    jcrPath = checkResourceExists(session, jcrPath);
+    checkResourceExists(session, jcrPath);
     Node node = (Node) session.getItem(jcrPath);
     Map<String, Collection<WebDavItemProperty>> result = new HashMap<>();
     for (int i = 0; i < propertiesToSave.size(); i++) {
@@ -250,7 +264,7 @@ public class WebdavWriteCommandHandler {
                      String webDavPath) throws WebDavException {
     checkNotReadOnly(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    jcrPath = checkResourceExists(session, jcrPath);
+    checkResourceExists(session, jcrPath);
 
     Node node = (Node) session.getItem(jcrPath);
     forceUnlock(node);
@@ -272,7 +286,7 @@ public class WebdavWriteCommandHandler {
     checkNotRoot(webDavTargetPath);
     String sourceJcrPath = pathCommandHandler.transformToJcrPath(webDavSourcePath);
     String targetJcrPath = pathCommandHandler.transformToJcrPath(webDavTargetPath);
-    sourceJcrPath = checkResourceExists(session, sourceJcrPath);
+    checkResourceExists(session, sourceJcrPath);
     boolean itemExists = session.itemExists(targetJcrPath);
     if (itemExists) {
       if (overwrite) {
@@ -305,7 +319,7 @@ public class WebdavWriteCommandHandler {
     checkNotRoot(webDavTargetPath);
     String sourceJcrPath = pathCommandHandler.transformToJcrPath(webDavSourcePath);
     String targetJcrPath = pathCommandHandler.transformToJcrPath(webDavTargetPath);
-    sourceJcrPath = checkResourceExists(session, sourceJcrPath);
+    checkResourceExists(session, sourceJcrPath);
     boolean itemExists = session.itemExists(targetJcrPath);
     if (itemExists && removeDestination) {
       Item destItem = session.getItem(targetJcrPath);
@@ -323,7 +337,7 @@ public class WebdavWriteCommandHandler {
                                String webDavPath) {
     checkNotReadOnly(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    jcrPath = checkResourceExists(session, jcrPath);
+    checkResourceExists(session, jcrPath);
     Node node = (Node) session.getItem(jcrPath);
     forceUnlock(node);
     if (!node.isNodeType(MIX_VERSIONABLE)) {
@@ -337,7 +351,7 @@ public class WebdavWriteCommandHandler {
                       String webDavPath) {
     checkNotReadOnly(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    jcrPath = checkResourceExists(session, jcrPath);
+    checkResourceExists(session, jcrPath);
     Node node = session.getRootNode().getNode(TextUtil.relativizePath(jcrPath));
     forceUnlock(node);
     node.checkin();
@@ -348,7 +362,7 @@ public class WebdavWriteCommandHandler {
                        String webDavPath) throws WebDavException {
     checkNotReadOnly(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    jcrPath = checkResourceExists(session, jcrPath);
+    checkResourceExists(session, jcrPath);
     Node node = session.getRootNode().getNode(TextUtil.relativizePath(jcrPath));
     node.checkout();
   }
@@ -358,7 +372,7 @@ public class WebdavWriteCommandHandler {
                          String webDavPath) throws WebDavException {
     checkNotReadOnly(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    jcrPath = checkResourceExists(session, jcrPath);
+    checkResourceExists(session, jcrPath);
     Node node = session.getRootNode().getNode(TextUtil.relativizePath(jcrPath));
     Version restoreVersion = node.getBaseVersion();
     node.restore(restoreVersion, true);
@@ -373,7 +387,7 @@ public class WebdavWriteCommandHandler {
                                  String username) {
     checkNotReadOnly(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    jcrPath = checkResourceExists(session, jcrPath);
+    checkResourceExists(session, jcrPath);
     Node node = (Node) session.getItem(jcrPath);
     if (!node.isNodeType(MIX_LOCKABLE) && node.canAddMixin(MIX_LOCKABLE)) {
       node.addMixin(MIX_LOCKABLE);
@@ -403,7 +417,8 @@ public class WebdavWriteCommandHandler {
   @SneakyThrows
   public void unlock(Session session, String webDavPath, List<String> lockTokens) {
     checkNotReadOnly(webDavPath);
-    String jcrPath = checkResourceExists(session, pathCommandHandler.transformToJcrPath(webDavPath));
+    String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
+    checkResourceExists(session, jcrPath);
     try {
       unlockNode(session, jcrPath);
     } catch (Exception e) {
@@ -415,11 +430,12 @@ public class WebdavWriteCommandHandler {
 
   @SneakyThrows
   public void unlockNode(Session session, String jcrPath) {
-    jcrPath = checkResourceExists(session, jcrPath);
-    Node node = (Node) session.getItem(jcrPath);
-    if (node.isLocked()) {
-      node.unlock();
-      session.save();
+    if (session.itemExists(jcrPath)) {
+      Node node = (Node) session.getItem(jcrPath);
+      if (node.isLocked()) {
+        node.unlock();
+        session.save();
+      }
     }
     removeLockTimeout(jcrPath);
   }
@@ -430,7 +446,7 @@ public class WebdavWriteCommandHandler {
                        List<WebDavItemOrder> members) throws WebDavException {
     checkNotReadOnly(webDavPath);
     String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    jcrPath = checkResourceExists(session, jcrPath);
+    checkResourceExists(session, jcrPath);
     Node node = (Node) session.getItem(jcrPath);
 
     for (int i = 0; i < members.size(); i++) {
@@ -516,25 +532,11 @@ public class WebdavWriteCommandHandler {
     }
   }
 
-  private String checkResourceExists(Session session, String jcrPath) throws RepositoryException, WebDavException {
+  private void checkResourceExists(Session session, String jcrPath) throws RepositoryException, WebDavException {
     if (!session.itemExists(jcrPath)) {
-      String[] parts = jcrPath.split("/");
-      String fileTitle = parts[parts.length - 1];
-      String cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(fileTitle.toLowerCase(),NodeTypeConstants.NT_FILE));
-      parts[parts.length - 1] = cleanName;
-      jcrPath =  Arrays.stream(parts).collect(Collectors.joining("/"));
-      if (!session.itemExists(jcrPath)) {
-        cleanName = Text.escapeIllegalJcrChars(JCRDocumentsUtil.cleanNameWithAccents(fileTitle.toLowerCase(), NT_FOLDER));
-        parts[parts.length - 1] = cleanName;
-        jcrPath =  Arrays.stream(parts).collect(Collectors.joining("/"));
-      }
-      if (!session.itemExists(jcrPath)) {
-        throw new WebDavException(HttpStatus.SC_NOT_FOUND, String.format(RESOURCE_WITH_PATH_S_NOT_FOUND, jcrPath));
-      }
+      throw new WebDavException(HttpStatus.SC_NOT_FOUND, String.format(RESOURCE_WITH_PATH_S_NOT_FOUND, jcrPath));
     }
-    return jcrPath;
   }
-
 
   @SneakyThrows
   private void updateContent(Node node,

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtilTest.java
@@ -16,28 +16,38 @@
  */
 package org.exoplatform.documents.storage.jcr.util;
 
-import static org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil.getNodeByIdentifier;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 
-import javax.jcr.*;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.ValueFormatException;
 import javax.jcr.nodetype.NodeType;
 import javax.jcr.version.Version;
 import javax.jcr.version.VersionHistory;
 
-import org.exoplatform.documents.model.TrashElementNode;
-import org.exoplatform.services.jcr.access.PermissionType;
-import org.exoplatform.services.jcr.impl.core.SessionImpl;
-import org.exoplatform.services.organization.Group;
-import org.exoplatform.services.organization.GroupHandler;
-import org.exoplatform.services.organization.OrganizationService;
-import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,13 +59,20 @@ import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.documents.model.AbstractNode;
 import org.exoplatform.documents.model.FileNode;
 import org.exoplatform.documents.model.FileVersion;
+import org.exoplatform.documents.model.TrashElementNode;
 import org.exoplatform.documents.storage.JCRDeleteFileStorage;
 import org.exoplatform.services.jcr.access.AccessControlList;
+import org.exoplatform.services.jcr.access.PermissionType;
 import org.exoplatform.services.jcr.core.ExtendedNode;
 import org.exoplatform.services.jcr.core.ExtendedSession;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
+import org.exoplatform.services.jcr.impl.core.SessionImpl;
 import org.exoplatform.services.jcr.impl.core.value.StringValue;
+import org.exoplatform.services.organization.Group;
+import org.exoplatform.services.organization.GroupHandler;
+import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.spi.SpaceService;
 
@@ -377,11 +394,9 @@ public class JCRDocumentsUtilTest {
     Node frozenNode = mock(Node.class);
     when(version.getNode(NodeTypeConstants.JCR_FROZEN_NODE)).thenReturn(frozenNode);
 
-    Value value = mock(Value.class);
-    when(value.getString()).thenReturn("__system");
-
     Property property= mock(Property.class);
-    when(property.getValue()).thenReturn(value);
+    when(property.getString()).thenReturn("__system");
+    when(frozenNode.hasProperty(NodeTypeConstants.EXO_LAST_MODIFIER)).thenReturn(true);
     when(frozenNode.getProperty(NodeTypeConstants.EXO_LAST_MODIFIER)).thenReturn(property);
 
 

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandlerTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandlerTest.java
@@ -17,10 +17,12 @@
 package org.exoplatform.documents.storage.jcr.webdav.plugin;
 
 import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.DISPLAYNAME;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
@@ -38,16 +40,13 @@ import javax.jcr.version.VersionHistory;
 import javax.jcr.version.VersionIterator;
 import javax.xml.namespace.QName;
 
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import org.exoplatform.commons.utils.ListAccess;
-import org.exoplatform.documents.storage.jcr.util.JCRDocumentsUtil;
 import org.exoplatform.documents.storage.jcr.util.NodeTypeConstants;
 import org.exoplatform.documents.webdav.model.WebDavFileDownload;
 import org.exoplatform.documents.webdav.model.WebDavItem;
@@ -119,12 +118,6 @@ public class WebdavReadCommandHandlerTest {
   private ListAccess<Space>        memberSpacesListAccess;
 
   private WebdavReadCommandHandler handler;
-  private static final MockedStatic<JCRDocumentsUtil> JCR_DOCUMENTS_UTIL = mockStatic(JCRDocumentsUtil.class);
-
-  @AfterClass
-  public static void afterRunBare() throws Exception { // NOSONAR
-    JCR_DOCUMENTS_UTIL.close();
-  }
 
   @Before
   @SneakyThrows
@@ -156,7 +149,6 @@ public class WebdavReadCommandHandlerTest {
     when(spaceService.getMemberSpaces(USERNAME)).thenReturn(memberSpacesListAccess);
     when(node.getPath()).thenReturn(JCR_PATH);
     when(pathCommandHandler.getIdentityBaseJcrPath(WEBDAV_PATH)).thenReturn(IDENTITY_PATH);
-    JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getPathWithTitles(node)).thenReturn(JCR_PATH);
   }
 
   @Test

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/OpenInDesktopMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/OpenInDesktopMenuAction.vue
@@ -42,10 +42,8 @@ export default {
     },
   },
   methods: {
-    openDialog() {    
-      const pathParts = this.file.path.split('/');
-      pathParts.pop();
-      this.$root.$emit('open-in-desktop-dialog', this.protocol, `${pathParts.join('/')}/${this.file.name}`);
+    openDialog() {
+      this.$root.$emit('open-in-desktop-dialog', this.protocol, this.file.path);
     },
   },
 };


### PR DESCRIPTION
Prior to this change, the WebDav Changes introduced lately for forcing to display the Nodes Title rather than the real node names lead to multiple regressions. This change will revert those changes and add a small fix for `WebDavItemEntity` in addition to a change in documents app to display the correct "Last Modified Date" (Same as WebDav).