### PR TITLE
feat: Make WebDav handles Files and Folder Titles instead of JCR Names - EXO-87587 - EXO-87588

### DIFF
--- a/documents-api/src/main/java/org/exoplatform/documents/webdav/model/constant/PropertyConstants.java
+++ b/documents-api/src/main/java/org/exoplatform/documents/webdav/model/constant/PropertyConstants.java
@@ -35,7 +35,7 @@ public class PropertyConstants {
   public static final String                  ALLOW_METHODS              =
                                                             "CANCELUPLOAD, CHECKIN, CHECKOUT, COPY, DELETE, GET, HEAD, LOCK, MKCALENDAR, MKCOL, MOVE, OPTIONS, POST, PROPFIND, PROPPATCH, PUT, REPORT, SEARCH, UNCHECKOUT, UNLOCK, UPDATE, VERSION-CONTROL";
 
-  public static final List<String>            ALLOW_METHODS_LIST         = Arrays.stream(ALLOW_METHODS.split(","))                                                                                                                                               // NOSONAR
+  public static final List<String>            ALLOW_METHODS_LIST         = Arrays.stream(ALLOW_METHODS.split(","))                                                                                                                                          // NOSONAR
                                                                                  .map(String::trim)
                                                                                  .toList();
 

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -517,7 +517,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         thisWeek.set(Calendar.DAY_OF_WEEK, Calendar.SUNDAY);
 
         Calendar thisMonth = GregorianCalendar.getInstance();
-        thisMonth.set(Calendar.DAY_OF_MONTH, 0);
+        thisMonth.set(Calendar.DAY_OF_MONTH, 1);
 
         Calendar thisYear = GregorianCalendar.getInstance();
         thisYear.set(Calendar.DAY_OF_YEAR, 0);

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/JcrWebDavService.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/JcrWebDavService.java
@@ -105,7 +105,7 @@ public class JcrWebDavService implements DocumentWebDavService {
   @Override
   @SneakyThrows
   public boolean isFile(String webDavPath) {
-    Session session = getSession();
+    Session session = getSystemSession();
     try {
       return readCommandHandler.isFile(session, webDavPath);
     } finally {
@@ -128,7 +128,7 @@ public class JcrWebDavService implements DocumentWebDavService {
 
   @Override
   public long getLastModifiedDate(String webDavPath, String version) throws WebDavException {
-    Session session = getSession();
+    Session session = getSystemSession();
     try {
       return readCommandHandler.getLastModifiedDate(session,
                                                     webDavPath,
@@ -408,7 +408,7 @@ public class JcrWebDavService implements DocumentWebDavService {
   public void unlockTimedOutNodes() {
     List<String> nodePaths = writeCommandHandler.getOutdatedLockedNodePaths();
     if (CollectionUtils.isNotEmpty(nodePaths)) {
-      Session session = getSession();
+      Session session = getSystemSession();
       nodePaths.forEach(jcrPath -> {
         try {
           writeCommandHandler.unlockNode(session, jcrPath);
@@ -421,6 +421,21 @@ public class JcrWebDavService implements DocumentWebDavService {
         }
       });
     }
+  }
+
+  @SneakyThrows
+  public Session getSession(String username) {
+    ManageableRepository repository = repositoryService.getDefaultRepository();
+    RepositoryContainer repositoryContainer = repositoryService.getRepositoryContainer(REPOSITORY_NAME);
+    WorkspaceContainer workspaceContainer = repositoryContainer.getWorkspaceContainer(repository.getConfiguration()
+                                                                                                .getDefaultWorkspaceName());
+    return newSession(username, repository, workspaceContainer);
+  }
+
+  @SneakyThrows
+  public Session getSystemSession() {
+    ManageableRepository repository = repositoryService.getDefaultRepository();
+    return repository.getSystemSession(repository.getConfiguration().getDefaultWorkspaceName());
   }
 
   @SneakyThrows
@@ -439,21 +454,6 @@ public class JcrWebDavService implements DocumentWebDavService {
       prefixes.put(u, p);
     }
     return new JcrNamespaceContext(prefixes, namespaces);
-  }
-
-  @SneakyThrows
-  protected Session getSession(String username) {
-    ManageableRepository repository = repositoryService.getDefaultRepository();
-    RepositoryContainer repositoryContainer = repositoryService.getRepositoryContainer(REPOSITORY_NAME);
-    WorkspaceContainer workspaceContainer = repositoryContainer.getWorkspaceContainer(repository.getConfiguration()
-                                                                                                .getDefaultWorkspaceName());
-    return newSession(username, repository, workspaceContainer);
-  }
-
-  @SneakyThrows
-  protected Session getSession() {
-    ManageableRepository repository = repositoryService.getDefaultRepository();
-    return repository.getSystemSession(repository.getConfiguration().getDefaultWorkspaceName());
   }
 
   @SneakyThrows

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/WebDavPathMappingObservationService.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/WebDavPathMappingObservationService.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2026 eXo Platform SAS
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <gnu.org/licenses>.
+ */
+package org.exoplatform.documents.storage.jcr.webdav;
+
+import javax.jcr.Session;
+import javax.jcr.observation.ObservationManager;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import org.exoplatform.documents.storage.jcr.webdav.listener.WebDavPathMappingUpdaterAction;
+
+import jakarta.annotation.PostConstruct;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class WebDavPathMappingObservationService {
+
+  @Autowired
+  private WebDavPathMappingService webDavPathMappingService;
+
+  @Autowired
+  private JcrWebDavService         jcrWebDavService;
+
+  @PostConstruct
+  public void init() {
+    addMappingEventListener();
+  }
+
+  @SneakyThrows
+  private void addMappingEventListener() {
+    Session session = jcrWebDavService.getSystemSession();
+    try {
+      ObservationManager observation = session.getWorkspace().getObservationManager();
+      WebDavPathMappingUpdaterAction.SUPPORTED_PATHS.forEach(path -> addMappingEventListener(observation,
+                                                                                             createMappingListenerInstance(),
+                                                                                             path));
+    } finally {
+      session.logout();
+    }
+  }
+
+  @SneakyThrows
+  private void addMappingEventListener(ObservationManager observation,
+                                       WebDavPathMappingUpdaterAction mappingUpdaterAction,
+                                       String path) {
+    log.info("Register WebDAV path mapping listener on '{}'", path);
+    observation.addEventListener(mappingUpdaterAction,
+                                 WebDavPathMappingUpdaterAction.SUPPORTED_EVENT_TYPES,
+                                 path,
+                                 true,
+                                 null,
+                                 WebDavPathMappingUpdaterAction.SUPPORTED_NODE_TYPES.toArray(String[]::new),
+                                 false);
+  }
+
+  private WebDavPathMappingUpdaterAction createMappingListenerInstance() {
+    return new WebDavPathMappingUpdaterAction(webDavPathMappingService,
+                                              jcrWebDavService);
+  }
+}

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/WebDavPathMappingService.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/WebDavPathMappingService.java
@@ -1,0 +1,396 @@
+/**
+ * Copyright (C) 2026 eXo Platform SAS
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <gnu.org/licenses>.
+ */
+package org.exoplatform.documents.storage.jcr.webdav;
+
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_NAME;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_TITLE;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_CONTENT;
+
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.jcr.AccessDeniedException;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import org.exoplatform.documents.storage.jcr.util.Utils;
+import org.exoplatform.documents.storage.jcr.webdav.dao.WebDavPathMappingRepository;
+import org.exoplatform.documents.storage.jcr.webdav.entity.WebDavPathMappingEntity;
+import org.exoplatform.services.jcr.impl.core.NodeImpl;
+import org.exoplatform.services.jcr.util.Text;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class WebDavPathMappingService {
+
+  private static final String         DC_TITLE = "dc:title";
+
+  @Autowired
+  private WebDavPathMappingRepository repository;
+
+  public String findJcrPath(String parentJcrPath, String visibleName) {
+    return repository.findByParentJcrPathAndNormalizedVisibleName(parentJcrPath, WebDavPathMappingEntity.normalize(visibleName))
+                     .map(WebDavPathMappingEntity::getJcrPath)
+                     .orElse(null);
+  }
+
+  public String findVisibleNameByJcrPath(String jcrPath) {
+    return repository.findByJcrPath(jcrPath)
+                     .map(WebDavPathMappingEntity::getVisibleName)
+                     .orElse(null);
+  }
+
+  @SneakyThrows
+  public String findParentVisibleByJcrPath(String jcrPath) {
+    String parentJcrPath = getParentJcrPath(jcrPath);
+    String visibleName = repository.findByJcrPath(parentJcrPath)
+                                   .map(WebDavPathMappingEntity::getVisibleName)
+                                   .orElse(null);
+    if (StringUtils.isNotBlank(visibleName)) {
+      return visibleName;
+    }
+
+    return repository.findByJcrPath(jcrPath)
+                     .map(WebDavPathMappingEntity::getParentWebDavPath)
+                     .map(this::lastDecodedWebDavSegment)
+                     .orElse(null);
+  }
+
+  public String getVisibleName(Node node) throws RepositoryException {
+    String mappedVisibleName = findVisibleNameByJcrPath(node.getPath());
+    if (StringUtils.isNotBlank(mappedVisibleName)) {
+      return mappedVisibleName;
+    }
+    return getPreferredVisibleName(node);
+  }
+
+  public String getParentVisibleNodeName(Node node) throws RepositoryException {
+    try {
+      Node parentNode = node.getParent();
+      String visibleName = findVisibleNameByJcrPath(parentNode.getPath());
+      if (StringUtils.isNotBlank(visibleName)) {
+        return visibleName;
+      }
+      return getVisibleName(parentNode);
+    } catch (AccessDeniedException e) {
+      return findParentVisibleByJcrPath(node.getPath());
+    } catch (RepositoryException e) {
+      String visibleName = findParentVisibleByJcrPath(node.getPath());
+      if (StringUtils.isNotBlank(visibleName)) {
+        return visibleName;
+      }
+      throw e;
+    }
+  }
+
+  @SneakyThrows
+  public String allocateTechnicalName(Session session, String parentJcrPath, String visibleName) {
+    String candidateVisibleName = visibleName;
+    int counter = 1;
+    while (true) {
+      String technicalName = Utils.encodeNodeName(candidateVisibleName);
+      String candidateJcrPath = appendJcrPath(parentJcrPath, technicalName);
+      if (!session.itemExists(candidateJcrPath)) {
+        return technicalName;
+      }
+      candidateVisibleName = addSuffix(visibleName, counter++);
+    }
+  }
+
+  @SneakyThrows
+  public WebDavPathMappingEntity saveMapping(Session session, String webDavPath, String visibleName, Node node) {
+    String normalizedWebDavPath = normalizeWebDavPath(webDavPath);
+    String normalizedVisibleName = WebDavPathMappingEntity.normalize(visibleName);
+    String parentJcrPath = getParentJcrPath(node.getPath());
+    String parentWebDavPath = parentWebDavPath(normalizedWebDavPath);
+
+    Optional<WebDavPathMappingEntity> existingByJcrPath = repository.findByJcrPath(node.getPath());
+    Optional<WebDavPathMappingEntity> existingByVisibleName =
+                                                            repository.findByParentJcrPathAndNormalizedVisibleName(parentJcrPath,
+                                                                                                                   normalizedVisibleName);
+
+    WebDavPathMappingEntity entity = existingByJcrPath.or(() -> existingByVisibleName).orElseGet(WebDavPathMappingEntity::new);
+    entity.setIdentityId(extractIdentityId(normalizedWebDavPath));
+    entity.setParentJcrPath(parentJcrPath);
+    entity.setVisibleName(visibleName);
+    entity.setNormalizedVisibleName(normalizedVisibleName);
+    entity.setWebDavPath(normalizedWebDavPath);
+    entity.setParentWebDavPath(parentWebDavPath);
+    entity.setJcrPath(node.getPath());
+    entity.setNodeIdentifier(((NodeImpl) node).getIdentifier());
+    entity.setTechnicalName(node.getName());
+    entity.setFallbackName(StringUtils.equals(visibleName, node.getName()));
+    entity.setCollisionResolved(false);
+    entity.setId(WebDavPathMappingEntity.buildId(parentJcrPath, normalizedVisibleName));
+    if (StringUtils.isBlank(entity.getCreatedDate())) {
+      entity.setCreatedDate(java.time.Instant.now().toString());
+    }
+    entity.touch();
+
+    if (node.hasProperty(EXO_TITLE)) {
+      node.setProperty(EXO_TITLE, visibleName);
+    }
+    if (node.hasProperty(EXO_NAME)) {
+      node.setProperty(EXO_NAME, node.getName());
+    }
+
+    return repository.save(entity);
+  }
+
+  @SneakyThrows
+  public String getOrCreateWebDavPath(String identityId,
+                                      String identityBaseJcrPath,
+                                      String identityRootWebDavPath,
+                                      Node node,
+                                      String preferredVisibleName) {
+    if (StringUtils.equals(node.getPath(), identityBaseJcrPath)) {
+      return normalizeWebDavPath(identityRootWebDavPath);
+    }
+
+    Optional<WebDavPathMappingEntity> byIdentifier = findByNodeIdentifier(node);
+    if (byIdentifier.isPresent()) {
+      return byIdentifier.get().getWebDavPath();
+    }
+
+    Optional<WebDavPathMappingEntity> byJcrPath = repository.findByJcrPath(node.getPath());
+    if (byJcrPath.isPresent()) {
+      return byJcrPath.get().getWebDavPath();
+    }
+
+    String parentPath = getParentJcrPath(node.getPath());
+    String parentWebDavPath = StringUtils.equals(parentPath, identityBaseJcrPath) ?
+                                                                                  normalizeWebDavPath(identityRootWebDavPath) :
+                                                                                  getOrCreateWebDavPath(identityId,
+                                                                                                        identityBaseJcrPath,
+                                                                                                        identityRootWebDavPath,
+                                                                                                        node.getParent(),
+                                                                                                        getPreferredVisibleName(node.getParent()));
+
+    String requestedVisibleName =
+                                cleanVisibleName(StringUtils.defaultIfBlank(preferredVisibleName, getPreferredVisibleName(node)));
+    String visibleName = allocateVisibleName(parentPath, requestedVisibleName, node.getPath());
+    boolean collisionResolved = !StringUtils.equals(visibleName, requestedVisibleName);
+    String webDavPath = appendWebDavPath(parentWebDavPath, visibleName);
+
+    WebDavPathMappingEntity entity = new WebDavPathMappingEntity(identityId,
+                                                                 parentPath,
+                                                                 visibleName,
+                                                                 webDavPath,
+                                                                 parentWebDavPath,
+                                                                 node.getPath(),
+                                                                 ((NodeImpl) node).getIdentifier(),
+                                                                 node.getName(),
+                                                                 StringUtils.equals(visibleName, node.getName()),
+                                                                 collisionResolved);
+    return repository.save(entity).getWebDavPath();
+  }
+
+  public void deleteMapping(String jcrPath) {
+    repository.findByJcrPath(jcrPath).ifPresent(repository::delete);
+  }
+
+  public void deleteMappingTree(String jcrPath) {
+    if (StringUtils.isBlank(jcrPath)) {
+      return;
+    }
+
+    deleteMapping(jcrPath);
+
+    String descendantsPrefix = StringUtils.removeEnd(jcrPath, "/") + "/";
+    List<WebDavPathMappingEntity> descendants = repository.findByJcrPathStartingWith(descendantsPrefix);
+    if (descendants != null && !descendants.isEmpty()) {
+      repository.deleteAll(descendants);
+    }
+  }
+
+  public void invalidateMapping(String jcrPath) {
+    if (StringUtils.isBlank(jcrPath)) {
+      return;
+    }
+
+    log.debug("Invalidate WebDAV path mapping for JCR path '{}'", jcrPath);
+    deleteMapping(jcrPath);
+  }
+
+  public void invalidateMappingTree(String jcrPath) {
+    if (StringUtils.isBlank(jcrPath)) {
+      return;
+    }
+
+    log.debug("Invalidate WebDAV path mapping tree for JCR path '{}'", jcrPath);
+    deleteMappingTree(jcrPath);
+  }
+
+  public void invalidateParentMappingChildren(String jcrPath) {
+    String parentJcrPath = getParentJcrPath(jcrPath);
+    if (StringUtils.isBlank(parentJcrPath)) {
+      return;
+    }
+
+    log.debug("Invalidate parent WebDAV mapping children for JCR parent path '{}'", parentJcrPath);
+    repository.findByParentJcrPath(parentJcrPath)
+              .forEach(repository::delete);
+  }
+
+  public void invalidateMappingByIdentifier(String identifier) {
+    repository.findByNodeIdentifier(identifier)
+              .ifPresent(repository::delete);
+  }
+
+  public boolean isTitlePropertyPath(String eventPath) {
+    if (StringUtils.isBlank(eventPath)) {
+      return false;
+    }
+
+    return StringUtils.endsWith(eventPath, "/" + EXO_TITLE)
+           || StringUtils.endsWith(eventPath, "/" + JCR_CONTENT + "/" + DC_TITLE);
+  }
+
+  public String getNodePathFromPropertyPath(String propertyPath) {
+    if (StringUtils.isBlank(propertyPath)) {
+      return propertyPath;
+    }
+
+    if (StringUtils.endsWith(propertyPath, "/" + EXO_TITLE)) {
+      return StringUtils.substringBeforeLast(propertyPath, "/");
+    }
+
+    if (StringUtils.endsWith(propertyPath, "/" + JCR_CONTENT + "/" + DC_TITLE)) {
+      return StringUtils.substringBeforeLast(propertyPath, "/" + JCR_CONTENT + "/" + DC_TITLE);
+    }
+
+    return StringUtils.substringBeforeLast(propertyPath, "/");
+  }
+
+  public Optional<WebDavPathMappingEntity> findByNodeIdentifier(Node node) throws RepositoryException {
+    String identifier = ((NodeImpl) node).getIdentifier();
+    return StringUtils.isBlank(identifier) ? Optional.empty() : repository.findByNodeIdentifier(identifier);
+  }
+
+  private String allocateVisibleName(String parentJcrPath, String requestedVisibleName, String targetJcrPath) {
+    String visibleName = requestedVisibleName;
+    int counter = 1;
+    while (true) {
+      Optional<WebDavPathMappingEntity> existing = repository.findByParentJcrPathAndNormalizedVisibleName(parentJcrPath,
+                                                                                                          WebDavPathMappingEntity.normalize(visibleName));
+      if (existing.isEmpty() || StringUtils.equals(existing.get().getJcrPath(), targetJcrPath)) {
+        return visibleName;
+      }
+      visibleName = addSuffix(requestedVisibleName, counter++);
+    }
+  }
+
+  private String getPreferredVisibleName(Node node) throws RepositoryException {
+    String title = null;
+    if (node.hasProperty(EXO_TITLE)) {
+      title = node.getProperty(EXO_TITLE).getString();
+    } else if (node.hasProperty(JCR_CONTENT + "/" + DC_TITLE)) {
+      title = node.getProperty(JCR_CONTENT + "/" + DC_TITLE).getString();
+    }
+    if (StringUtils.isBlank(title)) {
+      title = node.getName();
+    }
+    return cleanVisibleName(title);
+  }
+
+  private String cleanVisibleName(String visibleName) {
+    return StringEscapeUtils.unescapeHtml4(Text.unescapeIllegalJcrChars(StringUtils.defaultString(visibleName)));
+  }
+
+  private String addSuffix(String fileName, int index) {
+    int dotIndex = fileName.lastIndexOf('.');
+    if (dotIndex > 0) {
+      return fileName.substring(0, dotIndex) + " (" + index + ")" + fileName.substring(dotIndex);
+    }
+    return fileName + " (" + index + ")";
+  }
+
+  private String appendJcrPath(String parentJcrPath, String childName) {
+    return StringUtils.removeEnd(parentJcrPath, "/") + "/" + childName;
+  }
+
+  private String appendWebDavPath(String parentWebDavPath, String visibleName) {
+    String encodedVisibleName = encodeUrlString(visibleName);
+    return StringUtils.removeEnd(parentWebDavPath, "/") + "/" + encodedVisibleName;
+  }
+
+  private String encodeUrlString(String s) {
+    return URLEncoder.encode(s, StandardCharsets.UTF_8).replace("+", "%20");
+  }
+
+  private String normalizeWebDavPath(String webDavPath) {
+    if (StringUtils.isBlank(webDavPath) || StringUtils.equals(webDavPath, "/")) {
+      return "/";
+    }
+    String normalized = Arrays.stream(webDavPath.split("/"))
+                              .filter(StringUtils::isNotBlank)
+                              .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
+                              .map(this::encodeUrlString)
+                              .collect(Collectors.joining("/"));
+    return "/" + normalized;
+  }
+
+  private String parentWebDavPath(String webDavPath) {
+    String normalized = StringUtils.removeEnd(normalizeWebDavPath(webDavPath), "/");
+    int index = normalized.lastIndexOf('/');
+    return index <= 0 ? "/" : normalized.substring(0, index);
+  }
+
+  private String extractIdentityId(String webDavPath) {
+    String firstSegment = Arrays.stream(webDavPath.split("/"))
+                                .filter(StringUtils::isNotBlank)
+                                .findFirst()
+                                .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
+                                .orElse(null);
+    if (firstSegment != null && firstSegment.endsWith(")") && firstSegment.contains("(")) {
+      return firstSegment.substring(firstSegment.lastIndexOf('(') + 1, firstSegment.lastIndexOf(')'));
+    }
+    return null;
+  }
+
+  private String getParentJcrPath(String jcrPath) {
+    if (StringUtils.isBlank(jcrPath) || StringUtils.equals(jcrPath, "/")) {
+      return null;
+    }
+
+    int index = jcrPath.lastIndexOf('/');
+    return index <= 0 ? "/" : jcrPath.substring(0, index);
+  }
+
+  private String lastDecodedWebDavSegment(String webDavPath) {
+    return Arrays.stream(StringUtils.defaultString(webDavPath).split("/"))
+                 .filter(StringUtils::isNotBlank)
+                 .reduce((first, second) -> second)
+                 .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
+                 .orElse(null);
+  }
+
+}

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/cache/CachedJcrWebDavService.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/cache/CachedJcrWebDavService.java
@@ -285,7 +285,7 @@ public class CachedJcrWebDavService extends JcrWebDavService {
 
   @SneakyThrows
   private void addCacheEventListener() {
-    Session session = getSession();
+    Session session = getSystemSession();
     try {
       ObservationManager observation = session.getWorkspace().getObservationManager();
       WebDavCacheUpdaterAction.SUPPORTED_PATHS.forEach(path -> addCacheEventListener(observation,

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/cache/elasticsearch/entity/WebDavItemEntity.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/cache/elasticsearch/entity/WebDavItemEntity.java
@@ -85,7 +85,9 @@ public class WebDavItemEntity {
     }
     this.webDavPath = webDavPath;
     this.jcrPath = jcrPath;
-    this.parentWebDavPath = webDavPath.substring(0, webDavPath.lastIndexOf("/"));
+    if (webDavPath.lastIndexOf("/") > 0) {
+      this.parentWebDavPath = webDavPath.substring(0, webDavPath.lastIndexOf("/"));
+    }
     this.identifier = identifier == null ? null : identifier.toASCIIString();
     this.file = file;
     if (properties != null) {

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/dao/WebDavPathMappingRepository.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/dao/WebDavPathMappingRepository.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2026 eXo Platform SAS
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <gnu.org/licenses>.
+ */
+package org.exoplatform.documents.storage.jcr.webdav.dao;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.exoplatform.documents.storage.jcr.webdav.entity.WebDavPathMappingEntity;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WebDavPathMappingRepository extends ElasticsearchRepository<WebDavPathMappingEntity, String> {
+
+  Optional<WebDavPathMappingEntity> findByJcrPath(String jcrPath);
+
+  Optional<WebDavPathMappingEntity> findByNodeIdentifier(String nodeIdentifier);
+
+  Optional<WebDavPathMappingEntity> findByParentJcrPathAndNormalizedVisibleName(String parentJcrPath,
+                                                                                String normalizedVisibleName);
+
+  List<WebDavPathMappingEntity> findByParentJcrPath(String parentJcrPath);
+
+  List<WebDavPathMappingEntity> findByJcrPathStartingWith(String jcrPathPrefix);
+
+  List<WebDavPathMappingEntity> findByParentWebDavPath(String parentWebDavPath);
+
+  Optional<WebDavPathMappingEntity> findByWebDavPath(String webDavPath);
+
+}

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/entity/WebDavPathMappingEntity.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/entity/WebDavPathMappingEntity.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (C) 2026 eXo Platform SAS
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <gnu.org/licenses>.
+ */
+package org.exoplatform.documents.storage.jcr.webdav.entity;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.Locale;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Mapping;
+import org.springframework.data.elasticsearch.annotations.Mapping.Detection;
+import org.springframework.data.elasticsearch.annotations.Setting;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
+
+@Data
+@NoArgsConstructor
+@Document(indexName = "webdav_path_mappings", createIndex = true)
+@Mapping(dateDetection = Detection.FALSE, numericDetection = Detection.FALSE)
+@Setting(replicas = 0, shards = 1)
+public class WebDavPathMappingEntity {
+
+  @Id
+  private String  id;
+
+  @Field(type = FieldType.Keyword)
+  private String  identityId;
+
+  @Field(type = FieldType.Keyword)
+  private String  parentJcrPath;
+
+  @Field(type = FieldType.Keyword)
+  private String  visibleName;
+
+  @Field(type = FieldType.Keyword)
+  private String  normalizedVisibleName;
+
+  @Field(type = FieldType.Keyword)
+  private String  webDavPath;
+
+  @Field(type = FieldType.Keyword)
+  private String  parentWebDavPath;
+
+  @Field(type = FieldType.Keyword)
+  private String  jcrPath;
+
+  @Field(type = FieldType.Keyword)
+  private String  nodeIdentifier;
+
+  @Field(type = FieldType.Keyword)
+  private String  technicalName;
+
+  private boolean fallbackName;
+
+  private boolean collisionResolved;
+
+  private String  createdDate;
+
+  private String  updatedDate;
+
+  public WebDavPathMappingEntity(String identityId, // NOSONAR
+                                 String parentJcrPath,
+                                 String visibleName,
+                                 String webDavPath,
+                                 String parentWebDavPath,
+                                 String jcrPath,
+                                 String nodeIdentifier,
+                                 String technicalName,
+                                 boolean fallbackName,
+                                 boolean collisionResolved) {
+    this.identityId = identityId;
+    this.parentJcrPath = parentJcrPath;
+    this.visibleName = visibleName;
+    this.normalizedVisibleName = normalize(visibleName);
+    this.webDavPath = webDavPath;
+    this.parentWebDavPath = parentWebDavPath;
+    this.jcrPath = jcrPath;
+    this.nodeIdentifier = nodeIdentifier;
+    this.technicalName = technicalName;
+    this.fallbackName = fallbackName;
+    this.collisionResolved = collisionResolved;
+    this.id = buildId(parentJcrPath, this.normalizedVisibleName);
+    this.createdDate = Instant.now().toString();
+    this.updatedDate = this.createdDate;
+  }
+
+  public void touch() {
+    this.updatedDate = Instant.now().toString();
+  }
+
+  public static String normalize(String name) {
+    return StringUtils.defaultString(name).trim().toLowerCase(Locale.ROOT);
+  }
+
+  @SneakyThrows
+  public static String buildId(String parentJcrPath, String normalizedVisibleName) {
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    byte[] hash = digest.digest((StringUtils.defaultString(parentJcrPath) + "::" + StringUtils.defaultString(normalizedVisibleName))
+                                                                                                                         .getBytes(StandardCharsets.UTF_8));
+    return HexFormat.of().formatHex(hash);
+  }
+}

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/listener/WebDavPathMappingUpdaterAction.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/listener/WebDavPathMappingUpdaterAction.java
@@ -1,0 +1,187 @@
+/**
+ * Copyright (C) 2026 eXo Platform SAS
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <gnu.org/licenses>.
+ */
+package org.exoplatform.documents.storage.jcr.webdav.listener;
+
+import static javax.jcr.observation.Event.NODE_ADDED;
+import static javax.jcr.observation.Event.NODE_REMOVED;
+import static javax.jcr.observation.Event.PROPERTY_ADDED;
+import static javax.jcr.observation.Event.PROPERTY_CHANGED;
+import static javax.jcr.observation.Event.PROPERTY_REMOVED;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.NT_FILE;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.NT_FOLDER;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.NT_RESOURCE;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.NT_UNSTRUCTURED;
+import static org.exoplatform.services.jcr.observation.ExtendedEvent.NODE_MOVED;
+import static org.exoplatform.services.jcr.observation.ExtendedEvent.PERMISSION_CHANGED;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.observation.Event;
+import javax.jcr.observation.EventIterator;
+import javax.jcr.observation.EventListener;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.documents.storage.jcr.webdav.JcrWebDavService;
+import org.exoplatform.documents.storage.jcr.webdav.WebDavPathMappingService;
+import org.exoplatform.services.jcr.impl.core.NodeImpl;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+import lombok.SneakyThrows;
+
+public class WebDavPathMappingUpdaterAction implements EventListener {
+
+  public static final List<String> SUPPORTED_NODE_TYPES  = Arrays.asList(NT_RESOURCE,                                // NOSONAR
+                                                                         NT_FILE,
+                                                                         NT_FOLDER,
+                                                                         NT_UNSTRUCTURED);
+
+  public static final List<String> SUPPORTED_PATHS       = Arrays.asList("/Users",                                   // NOSONAR
+                                                                         "/Groups/spaces");
+
+  public static final int          SUPPORTED_EVENT_TYPES = Arrays.asList(NODE_ADDED,                                 // NOSONAR
+                                                                         NODE_REMOVED,
+                                                                         NODE_MOVED,
+                                                                         PROPERTY_ADDED,
+                                                                         PROPERTY_CHANGED,
+                                                                         PROPERTY_REMOVED,
+                                                                         PERMISSION_CHANGED)
+                                                                 .stream()
+                                                                 .reduce(0, (a, b) -> a | b);
+
+  private static final Log         LOG                   = ExoLogger.getLogger(WebDavPathMappingUpdaterAction.class);
+
+  private WebDavPathMappingService webDavPathMappingService;
+
+  private JcrWebDavService         jcrWebDavService;
+
+  public WebDavPathMappingUpdaterAction(WebDavPathMappingService webDavPathMappingService,
+                                        JcrWebDavService jcrWebDavService) {
+    this.webDavPathMappingService = webDavPathMappingService;
+    this.jcrWebDavService = jcrWebDavService;
+  }
+
+  @Override
+  @SneakyThrows
+  public void onEvent(EventIterator eventIterator) {
+    while (eventIterator.hasNext()) {
+      Event event = eventIterator.nextEvent();
+      handleEvent(event);
+    }
+  }
+
+  private void handleEvent(Event event) {
+    try {
+      int eventType = event.getType();
+      String path = event.getPath();
+
+      switch (eventType) {
+      case NODE_REMOVED:
+        handleNodeRemoved(path);
+        break;
+
+      case NODE_MOVED:
+        handleNodeMoved(event, path);
+        break;
+
+      case NODE_ADDED:
+        handleNodeAdded(path);
+        break;
+
+      case PROPERTY_ADDED, PROPERTY_CHANGED, PROPERTY_REMOVED:
+        handlePropertyChanged(path);
+        break;
+
+      case PERMISSION_CHANGED:
+        handlePermissionChanged(path);
+        break;
+
+      default:
+        break;
+      }
+    } catch (Exception e) {
+      LOG.warn("Error while updating WebDAV path mapping from JCR event", e);
+    }
+  }
+
+  private void handleNodeRemoved(String path) {
+    if (StringUtils.isBlank(path)) {
+      return;
+    }
+
+    getWebDavPathMappingService().invalidateMappingTree(path);
+    getWebDavPathMappingService().invalidateParentMappingChildren(path);
+  }
+
+  private void handleNodeAdded(String path) {
+    if (StringUtils.isBlank(path)) {
+      return;
+    }
+    getWebDavPathMappingService().invalidateParentMappingChildren(path);
+  }
+
+  private void handleNodeMoved(Event event, String newPath) throws RepositoryException {
+    String oldPath = event.getPath();
+    if (StringUtils.isNotBlank(oldPath)) {
+      getWebDavPathMappingService().invalidateMappingTree(oldPath);
+      getWebDavPathMappingService().invalidateParentMappingChildren(oldPath);
+    }
+    if (StringUtils.isNotBlank(newPath)) {
+      getWebDavPathMappingService().invalidateMappingTree(newPath);
+      getWebDavPathMappingService().invalidateParentMappingChildren(newPath);
+    }
+    Session session = jcrWebDavService.getSystemSession();
+    try {
+      NodeImpl node = (NodeImpl) session.getItem(newPath);
+      String identifier = node.getIdentifier();
+      webDavPathMappingService.invalidateMappingByIdentifier(identifier);
+    } finally {
+      session.logout();
+    }
+  }
+
+  private void handlePropertyChanged(String propertyPath) {
+    if (StringUtils.isBlank(propertyPath)) {
+      return;
+    }
+
+    if (getWebDavPathMappingService().isTitlePropertyPath(propertyPath)) {
+      String nodePath = getWebDavPathMappingService().getNodePathFromPropertyPath(propertyPath);
+      getWebDavPathMappingService().invalidateMapping(nodePath);
+      getWebDavPathMappingService().invalidateParentMappingChildren(nodePath);
+    }
+  }
+
+  private void handlePermissionChanged(String path) {
+    if (StringUtils.isBlank(path)) {
+      return;
+    }
+    getWebDavPathMappingService().invalidateMapping(path);
+  }
+
+  private WebDavPathMappingService getWebDavPathMappingService() {
+    if (webDavPathMappingService == null) {
+      webDavPathMappingService = ExoContainerContext.getService(WebDavPathMappingService.class);
+    }
+    return webDavPathMappingService;
+  }
+}

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/PathCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/PathCommandHandler.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import javax.jcr.Node;
+import javax.jcr.Session;
 import javax.xml.namespace.QName;
 
 import org.apache.commons.lang3.StringUtils;
@@ -58,6 +59,7 @@ import org.springframework.stereotype.Component;
 
 import org.exoplatform.documents.storage.jcr.util.ACLProperties;
 import org.exoplatform.documents.storage.jcr.util.Utils;
+import org.exoplatform.documents.storage.jcr.webdav.WebDavPathMappingService;
 import org.exoplatform.documents.webdav.model.WebDavException;
 import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
@@ -74,64 +76,65 @@ import lombok.SneakyThrows;
 @Component
 public class PathCommandHandler {
 
-  public static final List<QName>  PROPERTY_NAMES                      =                                               // NOSONAR
-                                                  Arrays.asList(VERSIONNAME,
-                                                                VERSIONHISTORY,
-                                                                DISPLAYNAME,
-                                                                CHECKEDIN,
-                                                                CHECKEDOUT,
-                                                                PREDECESSORSET,
-                                                                SUCCESSORSET,
-                                                                RESOURCETYPE,
-                                                                GETCONTENTLENGTH,
-                                                                GETCONTENTTYPE,
-                                                                CREATIONDATE,
-                                                                GETLASTMODIFIED,
-                                                                GET_ETAG,
-                                                                CHILDCOUNT,
-                                                                HASCHILDREN,
-                                                                ISCOLLECTION,
-                                                                ISFOLDER,
-                                                                ISROOT,
-                                                                PARENTNAME,
-                                                                SUPPORTEDLOCK,
-                                                                LOCKDISCOVERY,
-                                                                ISVERSIONED,
-                                                                SUPPORTEDMETHODSET,
-                                                                ACLProperties.ACL,
-                                                                OWNER);
+  public static final List<QName>    PROPERTY_NAMES                      =                                               // NOSONAR
+                                                    Arrays.asList(VERSIONNAME,
+                                                                  VERSIONHISTORY,
+                                                                  DISPLAYNAME,
+                                                                  CHECKEDIN,
+                                                                  CHECKEDOUT,
+                                                                  PREDECESSORSET,
+                                                                  SUCCESSORSET,
+                                                                  RESOURCETYPE,
+                                                                  GETCONTENTLENGTH,
+                                                                  GETCONTENTTYPE,
+                                                                  CREATIONDATE,
+                                                                  GETLASTMODIFIED,
+                                                                  GET_ETAG,
+                                                                  CHILDCOUNT,
+                                                                  HASCHILDREN,
+                                                                  ISCOLLECTION,
+                                                                  ISFOLDER,
+                                                                  ISROOT,
+                                                                  PARENTNAME,
+                                                                  SUPPORTEDLOCK,
+                                                                  LOCKDISCOVERY,
+                                                                  ISVERSIONED,
+                                                                  SUPPORTEDMETHODSET,
+                                                                  ACLProperties.ACL,
+                                                                  OWNER);
 
-  public static final String       IDENTITY_PATHS_FORMAT               = "%s/%s%s%s%s";
+  public static final String         IDENTITY_PATHS_FORMAT               = "%s/%s%s%s%s";
 
-  public static final String       PATHS_CONCAT_FORMAT                 = "%s/%s";
+  public static final String         PATHS_CONCAT_FORMAT                 = "%s/%s";
 
-  protected static final Log       LOG                                 = ExoLogger.getLogger(PathCommandHandler.class);
+  protected static final Log         LOG                                 = ExoLogger.getLogger(PathCommandHandler.class);
 
-  private static final String      WEBDAV_IDENTITY_JCR_PATH_CACHE_NAME = "webdav.identityJcrBasePath";
+  private static final String        WEBDAV_IDENTITY_JCR_PATH_CACHE_NAME = "webdav.identityJcrBasePath";
 
-  private static final String      WEBDAV_IDENTITY_ID_PATH_CACHE_NAME  = "webdav.identityIdByPath";
+  private static final String        WEBDAV_IDENTITY_ID_PATH_CACHE_NAME  = "webdav.identityIdByPath";
 
-  private static final String      WEBDAV_JCR_PATH_CACHE_NAME          = "webdav.jcrPathByWebDavPath";
+  private static final String        GROUPS_PATH                         = "groupsPath";
 
-  private static final String      GROUPS_PATH                         = "groupsPath";
-
-  private static final String      USERS_PATH                          = "usersPath";
+  private static final String        USERS_PATH                          = "usersPath";
 
   @Autowired
-  protected IdentityManager        identityManager;
+  protected IdentityManager          identityManager;
 
   @Autowired
-  protected SpaceService           spaceService;
+  protected SpaceService             spaceService;
 
   @Autowired
-  protected NodeHierarchyCreator   nodeHierarchyCreator;
+  protected NodeHierarchyCreator     nodeHierarchyCreator;
 
   @Autowired
-  protected SessionProviderService sessionProviderService;
+  protected SessionProviderService   sessionProviderService;
 
-  private String                   usersJcrBasePath;
+  @Autowired
+  protected WebDavPathMappingService webDavPathMappingService;
 
-  private String                   groupsJcrBasePath;
+  private String                     usersJcrBasePath;
+
+  private String                     groupsJcrBasePath;
 
   @SneakyThrows
   @Cacheable(WEBDAV_IDENTITY_JCR_PATH_CACHE_NAME)
@@ -139,6 +142,17 @@ public class PathCommandHandler {
     Long identityId = getIdentityIdFromWebDavPath(webDavPath);
     if (identityId == null) {
       throw new WebDavException(HttpStatus.SC_NOT_FOUND, String.format("Can't read identity id from path: %s", webDavPath));
+    } else {
+      return getIdentityBaseJcrPath(identityId);
+    }
+  }
+
+  @SneakyThrows
+  @Cacheable(WEBDAV_IDENTITY_JCR_PATH_CACHE_NAME)
+  public String getIdentityBaseFromJcrPath(String jcrPath, String username) {
+    Long identityId = getIdentityIdFromJcrPath(jcrPath, username);
+    if (identityId == null) {
+      throw new WebDavException(HttpStatus.SC_NOT_FOUND, String.format("Can't read identity id from path: %s", jcrPath));
     } else {
       return getIdentityBaseJcrPath(identityId);
     }
@@ -211,21 +225,63 @@ public class PathCommandHandler {
     }
   }
 
-  @Cacheable(WEBDAV_JCR_PATH_CACHE_NAME)
-  public String transformToJcrPath(String webDavPath) {
+  @SneakyThrows
+  public String resolveToJcrPath(Session session, String webDavPath) throws WebDavException {
     Long identityId = getIdentityIdFromWebDavPath(webDavPath);
     if (identityId == null) {
       return "/";
-    } else {
-      String identityRelativeJcrPath = getIdentityRelativeJcrPath(webDavPath);
-      if (StringUtils.isBlank(identityRelativeJcrPath)) {
-        return getIdentityBaseJcrPath(identityId);
-      } else {
-        return String.format(PATHS_CONCAT_FORMAT,
-                             getIdentityBaseJcrPath(identityId),
-                             identityRelativeJcrPath);
-      }
     }
+
+    String identityBaseJcrPath = getIdentityBaseJcrPath(identityId);
+    String identityRelativeWebDavPath = getIdentityRelativeWebDavPath(webDavPath);
+    if (StringUtils.isBlank(identityRelativeWebDavPath)) {
+      return identityBaseJcrPath;
+    }
+
+    String currentParentJcrPath = identityBaseJcrPath;
+    for (String visibleSegment : splitDecodedSegments(identityRelativeWebDavPath)) { // NOSONAR
+      String mappedJcrPath = webDavPathMappingService.findJcrPath(currentParentJcrPath, visibleSegment);
+      if (StringUtils.isNotBlank(mappedJcrPath)) {
+        currentParentJcrPath = mappedJcrPath;
+        continue;
+      }
+
+      String legacyChildJcrPath = String.format(PATHS_CONCAT_FORMAT,
+                                                currentParentJcrPath,
+                                                Utils.encodeNodeName(visibleSegment));
+      if (session.itemExists(legacyChildJcrPath)) {
+        currentParentJcrPath = legacyChildJcrPath;
+        continue;
+      }
+
+      throw new WebDavException(HttpStatus.SC_NOT_FOUND,
+                                String.format("No WebDAV mapping found for segment '%s' under '%s'",
+                                              visibleSegment,
+                                              currentParentJcrPath));
+    }
+    return currentParentJcrPath;
+  }
+
+  public String getLastVisibleSegment(String webDavPath) {
+    return Arrays.stream(webDavPath.split("/"))
+                 .filter(StringUtils::isNotBlank)
+                 .reduce((first, second) -> second)
+                 .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
+                 .orElse("");
+  }
+
+  private String getIdentityRelativeWebDavPath(String webDavPath) {
+    return Arrays.stream(webDavPath.split("/"))
+                 .filter(StringUtils::isNotBlank)
+                 .skip(1)
+                 .collect(Collectors.joining("/"));
+  }
+
+  private List<String> splitDecodedSegments(String relativeWebDavPath) {
+    return Arrays.stream(relativeWebDavPath.split("/"))
+                 .filter(StringUtils::isNotBlank)
+                 .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
+                 .toList();
   }
 
   public boolean isIdentityRootWebDavPath(String webDavPath) {

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandler.java
@@ -37,7 +37,6 @@ import static org.exoplatform.documents.storage.jcr.util.Utils.decodeString;
 import static org.exoplatform.documents.storage.jcr.util.Utils.getStringProperty;
 import static org.exoplatform.documents.storage.jcr.webdav.plugin.PathCommandHandler.IDENTITY_PATHS_FORMAT;
 import static org.exoplatform.documents.storage.jcr.webdav.plugin.PathCommandHandler.LOG;
-import static org.exoplatform.documents.storage.jcr.webdav.plugin.PathCommandHandler.PATHS_CONCAT_FORMAT;
 import static org.exoplatform.documents.storage.jcr.webdav.plugin.PathCommandHandler.PROPERTY_NAMES;
 import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.CHECKEDIN;
 import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.CHECKEDOUT;
@@ -73,7 +72,6 @@ import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.
 
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -84,7 +82,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import javax.jcr.Item;
@@ -103,6 +100,7 @@ import org.springframework.stereotype.Component;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.documents.storage.jcr.util.ACLProperties;
 import org.exoplatform.documents.storage.jcr.util.NodeTypeConstants;
+import org.exoplatform.documents.storage.jcr.webdav.WebDavPathMappingService;
 import org.exoplatform.documents.storage.jcr.webdav.model.JcrNamespaceContext;
 import org.exoplatform.documents.webdav.model.WebDavException;
 import org.exoplatform.documents.webdav.model.WebDavFileDownload;
@@ -121,35 +119,39 @@ import lombok.SneakyThrows;
 @Component
 public class WebdavReadCommandHandler {
 
-  private static final String     VERSION_QUERY_PARAM     = "?version=";
+  private static final String      VERSION_QUERY_PARAM     = "?version=";
 
-  private static final String     IDENTITY_ID_PREFIX      = "%20(";
+  private static final String      IDENTITY_ID_PREFIX      = "%20%28";
 
-  private static final String     IDENTITY_ID_SUFFIX      = ")";
+  private static final String      IDENTITY_ID_SUFFIX      = "%29";
 
-  private static final String     EXO_HIDDEN_PROPERTY     = "exo:hidden";
+  private static final String      EXO_HIDDEN_PROPERTY     = "exo:hidden";
 
-  private static final String     WINDOWS_HIDDEN_PROPERTY = "lp1:win32FileAttributes";
+  private static final String      WINDOWS_HIDDEN_PROPERTY = "lp1:win32FileAttributes";
 
-  private static final Set<QName> SEARCH_PROPERTIES       = new HashSet<>(Arrays.asList(DISPLAYNAME,
-                                                                                        RESOURCETYPE,
-                                                                                        CREATIONDATE,
-                                                                                        GETLASTMODIFIED,
-                                                                                        GETCONTENTLENGTH,
-                                                                                        GETCONTENTTYPE));
+  private static final Set<QName>  SEARCH_PROPERTIES       = new HashSet<>(Arrays.asList(DISPLAYNAME,
+                                                                                         RESOURCETYPE,
+                                                                                         CREATIONDATE,
+                                                                                         GETLASTMODIFIED,
+                                                                                         GETCONTENTLENGTH,
+                                                                                         GETCONTENTTYPE));
 
-  private PathCommandHandler      pathCommandHandler;
+  private PathCommandHandler       pathCommandHandler;
 
-  private IdentityManager         identityManager;
+  private IdentityManager          identityManager;
 
-  private SpaceService            spaceService;
+  private SpaceService             spaceService;
+
+  private WebDavPathMappingService webDavPathMappingService;
 
   public WebdavReadCommandHandler(IdentityManager identityManager,
                                   SpaceService spaceService,
-                                  PathCommandHandler pathCommandHandler) {
+                                  PathCommandHandler pathCommandHandler,
+                                  WebDavPathMappingService webDavPathMappingService) {
     this.identityManager = identityManager;
     this.spaceService = spaceService;
     this.pathCommandHandler = pathCommandHandler;
+    this.webDavPathMappingService = webDavPathMappingService;
   }
 
   public WebDavItem get(Session session, // NOSONAR
@@ -190,7 +192,7 @@ public class WebdavReadCommandHandler {
       if (identity == null) {
         throw new WebDavException(HttpStatus.SC_NOT_FOUND, String.format("Can't find an identity Id from path %s", webDavPath));
       } else {
-        return get(getNode(session, pathCommandHandler.transformToJcrPath(webDavPath)),
+        return get(getNode(session, pathCommandHandler.resolveToJcrPath(session, webDavPath)),
                    pathCommandHandler.getIdentityBaseJcrPath(webDavPath),
                    identity.getIdentityId(),
                    identity.getProfile().getFullName(),
@@ -206,12 +208,11 @@ public class WebdavReadCommandHandler {
   public WebDavFileDownload download(Session session,
                                      String webDavPath,
                                      String version) {
-    Node node = getNode(session, pathCommandHandler.transformToJcrPath(webDavPath), version);
+    Node node = getNode(session, pathCommandHandler.resolveToJcrPath(session, webDavPath), version);
     Calendar lastModifiedDate = getLastModifiedDate(node);
     String mimeType = node.getNode(JCR_CONTENT).getProperty(JCR_MIME_TYPE).getString();
     InputStream inputStream = node.getNode(JCR_CONTENT).getProperty(JCR_DATA).getStream();
-
-    return new WebDavFileDownload(node.getName(),
+    return new WebDavFileDownload(getVisibleNodeName(node),
                                   inputStream.available(),
                                   lastModifiedDate == null ? 0l : lastModifiedDate.getTimeInMillis(),
                                   mimeType,
@@ -240,7 +241,7 @@ public class WebdavReadCommandHandler {
   @SneakyThrows
   @SuppressWarnings("unchecked")
   public List<WebDavItem> getVersions(Session session, String webDavPath, Set<QName> requestedPropertyNames, String baseUri) {
-    String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
+    String jcrPath = pathCommandHandler.resolveToJcrPath(session, webDavPath);
     Node node = getNode(session, jcrPath);
     if (node.isNodeType(MIX_VERSIONABLE)) {
       VersionIterator versions = node.getVersionHistory().getAllVersions();
@@ -268,7 +269,7 @@ public class WebdavReadCommandHandler {
 
   @SneakyThrows
   public boolean isFile(Session session, String webDavPath) {
-    String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
+    String jcrPath = pathCommandHandler.resolveToJcrPath(session, webDavPath);
     if (session.itemExists(jcrPath)) {
       Item item = session.getItem(jcrPath);
       if (item instanceof Node node) {
@@ -282,7 +283,7 @@ public class WebdavReadCommandHandler {
   public long getLastModifiedDate(Session session,
                                   String webDavPath,
                                   String version) {
-    String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
+    String jcrPath = pathCommandHandler.resolveToJcrPath(session, webDavPath);
     Node node = getNode(session, jcrPath, version);
     Calendar lastModifiedDate = getLastModifiedDate(node);
     return lastModifiedDate == null ? 0l : lastModifiedDate.getTimeInMillis();
@@ -379,8 +380,14 @@ public class WebdavReadCommandHandler {
     }
     WebDavItem result = new WebDavItem();
     result.setFile(isFile(node));
-    result.setIdentifier(new URI(getNodeUri(node, identityBaseJcrPath, identityBaseUri)));
-    result.setWebDavPath(getRelativeNodeUri(node, identityBaseJcrPath, identityId, displayName));
+    String webDavPath = getMappedWebDavPath(node, identityBaseJcrPath, identityId, displayName);
+    String identityRootWebDavPath = getIdentityRootWebDavPath(identityId, displayName);
+    String identifier = identityBaseUri;
+    if (!StringUtils.equals(webDavPath, identityRootWebDavPath)) {
+      identifier = identityBaseUri + webDavPath.substring(identityRootWebDavPath.length());
+    }
+    result.setIdentifier(new URI(identifier));
+    result.setWebDavPath(webDavPath);
     result.setJcrPath(node.getPath());
     addChildren(result,
                 node,
@@ -452,7 +459,7 @@ public class WebdavReadCommandHandler {
     if (name.equals(DISPLAYNAME)) {
       return version == null ? new WebDavItemProperty(name,
                                                       String.format("%s%s",
-                                                                    decodeString(node.getName()),
+                                                                    getVisibleNodeName(node),
                                                                     getNodeIndexSuffix(node))) :
                              new WebDavItemProperty(name, decodeString(version.getName()));
     } else if (VERSIONNAME.equals(name)) {
@@ -541,9 +548,10 @@ public class WebdavReadCommandHandler {
     } else if (name.equals(ISFOLDER)) {
       return new WebDavItemProperty(name, isFolder(node) ? "1" : "0");
     } else if (name.equals(ISROOT)) {
-      return new WebDavItemProperty(name, node.getPath().equals("/") ? "1" : "0");
+      String identityJcrPath = pathCommandHandler.getIdentityBaseFromJcrPath(node.getPath(), node.getSession().getUserID());
+      return new WebDavItemProperty(name, node.getPath().equals("/") || node.getPath().equals(identityJcrPath) ? "1" : "0");
     } else if (name.equals(PARENTNAME)) {
-      return new WebDavItemProperty(name, node.getParent().getName());
+      return new WebDavItemProperty(name, getParentVisibleNodeName(node));
     } else if (name.equals(RESOURCETYPE)) {
       if (isFolder(node)) {
         return getIsFolderItemProperty();
@@ -664,7 +672,6 @@ public class WebdavReadCommandHandler {
     }
   }
 
-  @SneakyThrows
   private WebDavItem getWebDavIdentityItem(Session session,
                                            Identity identity,
                                            Set<QName> requestedPropertyNames,
@@ -706,10 +713,10 @@ public class WebdavReadCommandHandler {
     if (session.itemExists(identityBaseJcrPath)) {
       Node identityParentNode = (Node) session.getItem(identityBaseJcrPath);
       identityWebDavItem.setJcrPath(identityParentNode.getPath());
-      identityWebDavItem.setWebDavPath(getRelativeNodeUri(identityParentNode,
-                                                          identityBaseJcrPath,
-                                                          identityId,
-                                                          displayName));
+      identityWebDavItem.setWebDavPath(getMappedWebDavPath(identityParentNode,
+                                                           identityBaseJcrPath,
+                                                           identityId,
+                                                           displayName));
       addProperties(identityWebDavItem,
                     identityParentNode,
                     requestedPropertyNames,
@@ -751,46 +758,28 @@ public class WebdavReadCommandHandler {
     }
   }
 
-  @SneakyThrows
-  private String getNodeUri(Node node, String identityBaseJcrPath, String identityBaseUri) {
-    String nodeRelativePath = node.getPath().replaceFirst(identityBaseJcrPath, "");
-    if (StringUtils.isBlank(nodeRelativePath)) {
-      return identityBaseUri;
-    } else {
-      String encodedNodeRelativePath = Arrays.stream(nodeRelativePath.split("/"))
-                                             .filter(StringUtils::isNotBlank)
-                                             .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
-                                             .map(this::encodeUrlString)
-                                             .collect(Collectors.joining("/"));
-      return String.format(PATHS_CONCAT_FORMAT, identityBaseUri, encodedNodeRelativePath);
-    }
+  private String getIdentityRootWebDavPath(long identityId, String displayName) {
+    return String.format("/%s%s%s%s",
+                         encodeUrlString(displayName),
+                         IDENTITY_ID_PREFIX,
+                         identityId,
+                         IDENTITY_ID_SUFFIX);
   }
 
   @SneakyThrows
-  private String getRelativeNodeUri(Node node,
-                                    String identityBaseJcrPath,
-                                    long identityId,
-                                    String displayName) {
-    String nodeRelativePath = node.getPath().replaceFirst(identityBaseJcrPath, "");
-    if (StringUtils.isBlank(nodeRelativePath)) {
-      return String.format("/%s%s%s%s",
-                           encodeUrlString(displayName),
-                           IDENTITY_ID_PREFIX,
-                           identityId,
-                           IDENTITY_ID_SUFFIX);
-    } else {
-      String encodedNodeRelativePath = Arrays.stream(nodeRelativePath.split("/"))
-                                             .filter(StringUtils::isNotBlank)
-                                             .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
-                                             .map(this::encodeUrlString)
-                                             .collect(Collectors.joining("/"));
-      return String.format("/%s%s%s%s/%s",
-                           encodeUrlString(displayName),
-                           IDENTITY_ID_PREFIX,
-                           identityId,
-                           IDENTITY_ID_SUFFIX,
-                           encodedNodeRelativePath);
+  private String getMappedWebDavPath(Node node,
+                                     String identityBaseJcrPath,
+                                     long identityId,
+                                     String displayName) {
+    String identityRootWebDavPath = getIdentityRootWebDavPath(identityId, displayName);
+    if (StringUtils.equals(node.getPath(), identityBaseJcrPath)) {
+      return identityRootWebDavPath;
     }
+    return webDavPathMappingService.getOrCreateWebDavPath(String.valueOf(identityId),
+                                                          identityBaseJcrPath,
+                                                          identityRootWebDavPath,
+                                                          node,
+                                                          getVisibleNodeName(node));
   }
 
   private Identity getIdentityFromWebDavPath(String webDavPath) {
@@ -839,6 +828,14 @@ public class WebdavReadCommandHandler {
     } else {
       return identity.getProfile().getFullName();
     }
+  }
+
+  private String getVisibleNodeName(Node node) throws RepositoryException {
+    return webDavPathMappingService.getVisibleName(node);
+  }
+
+  private String getParentVisibleNodeName(Node node) throws RepositoryException {
+    return webDavPathMappingService.getParentVisibleNodeName(node);
   }
 
 }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavWriteCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavWriteCommandHandler.java
@@ -16,7 +16,10 @@
  */
 package org.exoplatform.documents.storage.jcr.webdav.plugin;
 
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.*;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_NAME;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_SORTABLE;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_TITLE;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_CONTENT;
 import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_DATA;
 import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_ENCODING;
 import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_LAST_MODIFIED;
@@ -70,6 +73,7 @@ import org.exoplatform.commons.api.settings.data.Context;
 import org.exoplatform.commons.api.settings.data.Scope;
 import org.exoplatform.commons.utils.MimeTypeResolver;
 import org.exoplatform.documents.storage.TrashStorage;
+import org.exoplatform.documents.storage.jcr.webdav.WebDavPathMappingService;
 import org.exoplatform.documents.webdav.model.WebDavException;
 import org.exoplatform.documents.webdav.model.WebDavItemOrder;
 import org.exoplatform.documents.webdav.model.WebDavItemProperty;
@@ -102,46 +106,52 @@ import lombok.SneakyThrows;
 @Component
 public class WebdavWriteCommandHandler {
 
-  protected static final Log      LOG                            = ExoLogger.getLogger(WebdavWriteCommandHandler.class);
+  protected static final Log       LOG                            = ExoLogger.getLogger(WebdavWriteCommandHandler.class);
 
-  private static final Set<QName> READ_ONLY_PROPS                = Collections.singleton(PropertyConstants.JCR_DATA);
+  private static final Set<QName>  READ_ONLY_PROPS                = Collections.singleton(PropertyConstants.JCR_DATA);
 
-  private static final Set<QName> NON_REMOVING_PROPS             = new HashSet<>(Arrays.asList(PropertyConstants.CREATIONDATE,
-                                                                                               PropertyConstants.DISPLAYNAME,
-                                                                                               PropertyConstants.GETCONTENTLANGUAGE,
-                                                                                               PropertyConstants.GETCONTENTLENGTH,
-                                                                                               PropertyConstants.GETCONTENTTYPE,
-                                                                                               PropertyConstants.GETLASTMODIFIED,
-                                                                                               PropertyConstants.JCR_DATA));
+  private static final Set<QName>  NON_REMOVING_PROPS             = new HashSet<>(Arrays.asList(PropertyConstants.CREATIONDATE,
+                                                                                                PropertyConstants.DISPLAYNAME,
+                                                                                                PropertyConstants.GETCONTENTLANGUAGE,
+                                                                                                PropertyConstants.GETCONTENTLENGTH,
+                                                                                                PropertyConstants.GETCONTENTTYPE,
+                                                                                                PropertyConstants.GETLASTMODIFIED,
+                                                                                                PropertyConstants.JCR_DATA));
 
-  private static final String     RESOURCE_WITH_PATH_S_NOT_FOUND = "Resource with path '%s' not found";
+  private static final String      RESOURCE_WITH_PATH_S_NOT_FOUND = "Resource with path '%s' not found";
 
-  private static final Context    LOCK_CONTEXT                   = Context.GLOBAL.id("WebDav");
+  private static final String      PATH_AND_NAME_PATTERN          = "%s/%s";
 
-  private static final Scope      LOCK_SCOPE                     = Scope.APPLICATION.id("WebDavLock");
+  private static final Context     LOCK_CONTEXT                   = Context.GLOBAL.id("WebDav");
 
-  private MimeTypeResolver        mimeTypeResolver               = new MimeTypeResolver();
+  private static final Scope       LOCK_SCOPE                     = Scope.APPLICATION.id("WebDavLock");
 
-  private RepositoryService       repositoryService;
+  private MimeTypeResolver         mimeTypeResolver               = new MimeTypeResolver();
 
-  private TrashStorage            trashStorage;
+  private RepositoryService        repositoryService;
 
-  private SessionProviderService  sessionProviderService;
+  private TrashStorage             trashStorage;
 
-  private SettingService          settingService;
+  private SessionProviderService   sessionProviderService;
 
-  private PathCommandHandler      pathCommandHandler;
+  private SettingService           settingService;
+
+  private PathCommandHandler       pathCommandHandler;
+
+  private WebDavPathMappingService webDavPathMappingService;
 
   public WebdavWriteCommandHandler(SessionProviderService sessionProviderService,
                                    RepositoryService repositoryService,
                                    TrashStorage trashStorage,
                                    SettingService settingService,
-                                   PathCommandHandler pathCommandHandler) {
+                                   PathCommandHandler pathCommandHandler,
+                                   WebDavPathMappingService webDavPathMappingService) {
     this.sessionProviderService = sessionProviderService;
     this.repositoryService = repositoryService;
     this.trashStorage = trashStorage;
     this.settingService = settingService;
     this.pathCommandHandler = pathCommandHandler;
+    this.webDavPathMappingService = webDavPathMappingService;
   }
 
   @PostConstruct
@@ -154,8 +164,17 @@ public class WebdavWriteCommandHandler {
                            String webDavPath,
                            List<String> mixinTypes) {
     checkNotRoot(webDavPath);
-    String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
+    String parentJcrPath = pathCommandHandler.resolveToJcrPath(session, getParentWebDavPath(webDavPath));
+    String visibleName = pathCommandHandler.getLastVisibleSegment(webDavPath);
+    String technicalName = webDavPathMappingService.allocateTechnicalName(session, parentJcrPath, visibleName);
+    String jcrPath = String.format(PATH_AND_NAME_PATTERN, parentJcrPath, technicalName);
     Node node = addNode(session, jcrPath, NT_FOLDER);
+    if (node.canAddMixin(EXO_SORTABLE)) {
+      node.addMixin(EXO_SORTABLE);
+    }
+    node.setProperty(EXO_NAME, getNodeName(node));
+    node.setProperty(EXO_TITLE, visibleName);
+    webDavPathMappingService.saveMapping(session, webDavPath, visibleName, node);
     addMixins(node, mixinTypes);
     session.save();
   }
@@ -167,8 +186,19 @@ public class WebdavWriteCommandHandler {
                        List<String> mixinTypes,
                        InputStream inputStream) {
     checkNotRoot(webDavPath);
-    String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
-    Node node = session.itemExists(jcrPath) ? (Node) session.getItem(jcrPath) : null;
+    String jcrPath = null;
+    Node node = null;
+    try {
+      jcrPath = pathCommandHandler.resolveToJcrPath(session, webDavPath);
+      if (session.itemExists(jcrPath)) {
+        node = (Node) session.getItem(jcrPath);
+      }
+    } catch (WebDavException e) {
+      String parentJcrPath = pathCommandHandler.resolveToJcrPath(session, getParentWebDavPath(webDavPath));
+      String visibleName = pathCommandHandler.getLastVisibleSegment(webDavPath);
+      String technicalName = webDavPathMappingService.allocateTechnicalName(session, parentJcrPath, visibleName);
+      jcrPath = String.format(PATH_AND_NAME_PATTERN, parentJcrPath, technicalName);
+    }
     Calendar now = Calendar.getInstance();
     if (node == null) {
       node = addNode(session, jcrPath, NT_FILE);
@@ -182,8 +212,10 @@ public class WebdavWriteCommandHandler {
       if (node.canAddMixin(EXO_SORTABLE)) {
         node.addMixin(EXO_SORTABLE);
       }
-      node.setProperty(EXO_NAME, node.getName());
-      node.setProperty(EXO_TITLE, node.getName());
+      String visibleName = pathCommandHandler.getLastVisibleSegment(webDavPath);
+      node.setProperty(EXO_NAME, getNodeName(node));
+      node.setProperty(EXO_TITLE, visibleName);
+      webDavPathMappingService.saveMapping(session, webDavPath, visibleName, node);
     } else {
       forceUnlock(node);
       VersionHistoryUtils.createVersion(node);
@@ -199,7 +231,7 @@ public class WebdavWriteCommandHandler {
                                                                     List<WebDavItemProperty> propertiesToSave,
                                                                     List<WebDavItemProperty> propertiesToRemove) throws WebDavException {
     checkNotReadOnly(webDavPath);
-    String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
+    String jcrPath = pathCommandHandler.resolveToJcrPath(session, webDavPath);
     checkResourceExists(session, jcrPath);
     Node node = (Node) session.getItem(jcrPath);
     Map<String, Collection<WebDavItemProperty>> result = new HashMap<>();
@@ -263,7 +295,7 @@ public class WebdavWriteCommandHandler {
   public void delete(Session session,
                      String webDavPath) throws WebDavException {
     checkNotReadOnly(webDavPath);
-    String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
+    String jcrPath = pathCommandHandler.resolveToJcrPath(session, webDavPath);
     checkResourceExists(session, jcrPath);
 
     Node node = (Node) session.getItem(jcrPath);
@@ -271,6 +303,7 @@ public class WebdavWriteCommandHandler {
     if (canRemoveNode(node)) {
       trashStorage.moveToTrash(node,
                                new SessionProvider(((SessionImpl) session).getUserState()));
+      webDavPathMappingService.deleteMapping(jcrPath);
     } else {
       throw new WebDavException(HttpStatus.SC_FORBIDDEN, String.format("Resource with path '%s' can't be removed", jcrPath));
     }
@@ -284,8 +317,11 @@ public class WebdavWriteCommandHandler {
                       boolean overwrite) throws WebDavException {
     checkNotReadOnly(webDavSourcePath);
     checkNotRoot(webDavTargetPath);
-    String sourceJcrPath = pathCommandHandler.transformToJcrPath(webDavSourcePath);
-    String targetJcrPath = pathCommandHandler.transformToJcrPath(webDavTargetPath);
+    String sourceJcrPath = pathCommandHandler.resolveToJcrPath(session, webDavSourcePath);
+    String targetParentJcrPath = pathCommandHandler.resolveToJcrPath(session, getParentWebDavPath(webDavTargetPath));
+    String targetVisibleName = pathCommandHandler.getLastVisibleSegment(webDavTargetPath);
+    String targetTechnicalName = webDavPathMappingService.allocateTechnicalName(session, targetParentJcrPath, targetVisibleName);
+    String targetJcrPath = String.format(PATH_AND_NAME_PATTERN, targetParentJcrPath, targetTechnicalName);
     checkResourceExists(session, sourceJcrPath);
     boolean itemExists = session.itemExists(targetJcrPath);
     if (itemExists) {
@@ -302,10 +338,12 @@ public class WebdavWriteCommandHandler {
     session.save();
     Node targetNode = (Node) session.getItem(targetJcrPath);
     if (targetNode.isNodeType(EXO_SORTABLE)) {
-      targetNode.setProperty(EXO_NAME, targetNode.getName());
-      targetNode.setProperty(EXO_TITLE, targetNode.getName());
-      session.save();
+      targetNode.setProperty(EXO_NAME, getNodeName(targetNode));
+      targetNode.setProperty(EXO_TITLE, targetVisibleName);
     }
+    webDavPathMappingService.deleteMapping(sourceJcrPath);
+    webDavPathMappingService.saveMapping(session, webDavTargetPath, targetVisibleName, targetNode);
+    session.save();
     return itemExists;
   }
 
@@ -317,8 +355,11 @@ public class WebdavWriteCommandHandler {
                    boolean removeDestination) throws WebDavException {
     checkNotRoot(webDavSourcePath);
     checkNotRoot(webDavTargetPath);
-    String sourceJcrPath = pathCommandHandler.transformToJcrPath(webDavSourcePath);
-    String targetJcrPath = pathCommandHandler.transformToJcrPath(webDavTargetPath);
+    String sourceJcrPath = pathCommandHandler.resolveToJcrPath(session, webDavSourcePath);
+    String targetParentJcrPath = pathCommandHandler.resolveToJcrPath(session, getParentWebDavPath(webDavTargetPath));
+    String targetVisibleName = pathCommandHandler.getLastVisibleSegment(webDavTargetPath);
+    String targetTechnicalName = webDavPathMappingService.allocateTechnicalName(session, targetParentJcrPath, targetVisibleName);
+    String targetJcrPath = String.format(PATH_AND_NAME_PATTERN, targetParentJcrPath, targetTechnicalName);
     checkResourceExists(session, sourceJcrPath);
     boolean itemExists = session.itemExists(targetJcrPath);
     if (itemExists && removeDestination) {
@@ -330,13 +371,20 @@ public class WebdavWriteCommandHandler {
     }
     Workspace workspace = session.getWorkspace();
     workspace.copy(sourceJcrPath, targetJcrPath);
+    Node targetNode = (Node) session.getItem(targetJcrPath);
+    if (targetNode.isNodeType(EXO_SORTABLE)) {
+      targetNode.setProperty(EXO_NAME, getNodeName(targetNode));
+      targetNode.setProperty(EXO_TITLE, targetVisibleName);
+    }
+    webDavPathMappingService.saveMapping(session, webDavTargetPath, targetVisibleName, targetNode);
+    session.save();
   }
 
   @SneakyThrows
   public void enableVersioning(Session session,
                                String webDavPath) {
     checkNotReadOnly(webDavPath);
-    String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
+    String jcrPath = pathCommandHandler.resolveToJcrPath(session, webDavPath);
     checkResourceExists(session, jcrPath);
     Node node = (Node) session.getItem(jcrPath);
     forceUnlock(node);
@@ -350,7 +398,7 @@ public class WebdavWriteCommandHandler {
   public void checkin(Session session,
                       String webDavPath) {
     checkNotReadOnly(webDavPath);
-    String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
+    String jcrPath = pathCommandHandler.resolveToJcrPath(session, webDavPath);
     checkResourceExists(session, jcrPath);
     Node node = session.getRootNode().getNode(TextUtil.relativizePath(jcrPath));
     forceUnlock(node);
@@ -361,7 +409,7 @@ public class WebdavWriteCommandHandler {
   public void checkout(Session session,
                        String webDavPath) throws WebDavException {
     checkNotReadOnly(webDavPath);
-    String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
+    String jcrPath = pathCommandHandler.resolveToJcrPath(session, webDavPath);
     checkResourceExists(session, jcrPath);
     Node node = session.getRootNode().getNode(TextUtil.relativizePath(jcrPath));
     node.checkout();
@@ -371,7 +419,7 @@ public class WebdavWriteCommandHandler {
   public void uncheckout(Session session,
                          String webDavPath) throws WebDavException {
     checkNotReadOnly(webDavPath);
-    String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
+    String jcrPath = pathCommandHandler.resolveToJcrPath(session, webDavPath);
     checkResourceExists(session, jcrPath);
     Node node = session.getRootNode().getNode(TextUtil.relativizePath(jcrPath));
     Version restoreVersion = node.getBaseVersion();
@@ -386,7 +434,7 @@ public class WebdavWriteCommandHandler {
                                  boolean bodyIsEmpty,
                                  String username) {
     checkNotReadOnly(webDavPath);
-    String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
+    String jcrPath = pathCommandHandler.resolveToJcrPath(session, webDavPath);
     checkResourceExists(session, jcrPath);
     Node node = (Node) session.getItem(jcrPath);
     if (!node.isNodeType(MIX_LOCKABLE) && node.canAddMixin(MIX_LOCKABLE)) {
@@ -417,7 +465,7 @@ public class WebdavWriteCommandHandler {
   @SneakyThrows
   public void unlock(Session session, String webDavPath, List<String> lockTokens) {
     checkNotReadOnly(webDavPath);
-    String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
+    String jcrPath = pathCommandHandler.resolveToJcrPath(session, webDavPath);
     checkResourceExists(session, jcrPath);
     try {
       unlockNode(session, jcrPath);
@@ -445,7 +493,7 @@ public class WebdavWriteCommandHandler {
                        String webDavPath,
                        List<WebDavItemOrder> members) throws WebDavException {
     checkNotReadOnly(webDavPath);
-    String jcrPath = pathCommandHandler.transformToJcrPath(webDavPath);
+    String jcrPath = pathCommandHandler.resolveToJcrPath(session, webDavPath);
     checkResourceExists(session, jcrPath);
     Node node = (Node) session.getItem(jcrPath);
 
@@ -554,7 +602,7 @@ public class WebdavWriteCommandHandler {
                                   .trim();
       mediaType = mediaTypeParts[0].trim();
     }
-    String resolvedMimeType = mimeTypeResolver.getMimeType(node.getName());
+    String resolvedMimeType = mimeTypeResolver.getMimeType(getVisibleNodeName(node));
     if (StringUtils.isNotBlank(resolvedMimeType)
         && !StringUtils.equals(resolvedMimeType, mimeTypeResolver.getDefaultMimeType())) {
       handleJcrOperation(() -> content.setProperty(JCR_MIME_TYPE, resolvedMimeType), path);
@@ -600,13 +648,13 @@ public class WebdavWriteCommandHandler {
     while (nodeIter.hasNext()) {
       Node currentNode = nodeIter.nextNode();
       if (new QName("DAV:", "first").equals(member.getPosition())) {
-        return currentNode.getName();
+        return getVisibleNodeName(currentNode);
       } else if (new QName("DAV:", "before").equals(member.getPosition())
                  && previousNode != null
-                 && currentNode.getName().equals(member.getPositionSegment())) {
-        return previousNode.getName();
+                 && getVisibleNodeName(currentNode).equals(member.getPositionSegment())) {
+        return getVisibleNodeName(previousNode);
       } else if (new QName("DAV:", "after").equals(member.getPosition())
-                 && currentNode.getName().equals(member.getPositionSegment())
+                 && getVisibleNodeName(currentNode).equals(member.getPositionSegment())
                  && nodeIter.hasNext()) {
         return nodeIter.nextNode().getName();
       }
@@ -717,6 +765,15 @@ public class WebdavWriteCommandHandler {
     }
   }
 
+  public String getParentWebDavPath(String webDavPath) {
+    if (StringUtils.isBlank(webDavPath) || StringUtils.equals(webDavPath, "/")) {
+      return "/";
+    }
+    String normalizedPath = StringUtils.removeEnd(webDavPath, "/");
+    int index = normalizedPath.lastIndexOf('/');
+    return index <= 0 ? "/" : normalizedPath.substring(0, index);
+  }
+
   private boolean canRemoveNode(Node node) {
     return checkPermission(node, PermissionType.REMOVE);
   }
@@ -742,6 +799,14 @@ public class WebdavWriteCommandHandler {
                path,
                e);
     }
+  }
+
+  private String getNodeName(Node node) throws RepositoryException {
+    return node.getName();
+  }
+
+  private String getVisibleNodeName(Node node) throws RepositoryException {
+    return webDavPathMappingService.getVisibleName(node);
   }
 
   @FunctionalInterface

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/webdav/WebDavPathMappingServiceTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/webdav/WebDavPathMappingServiceTest.java
@@ -1,0 +1,352 @@
+/**
+ * Copyright (C) 2026 eXo Platform SAS
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <gnu.org/licenses>.
+ */
+package org.exoplatform.documents.storage.jcr.webdav;
+
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_NAME;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_TITLE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import javax.jcr.Property;
+import javax.jcr.Session;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.documents.storage.jcr.webdav.dao.WebDavPathMappingRepository;
+import org.exoplatform.documents.storage.jcr.webdav.entity.WebDavPathMappingEntity;
+import org.exoplatform.services.jcr.impl.core.NodeImpl;
+
+import lombok.SneakyThrows;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class WebDavPathMappingServiceTest {
+
+  private static final String         NODE_TITLE_WITH_ACCENT    = "Rapport Équipe.docx";
+
+  private static final String         NODE_TITLE_OTHER          = "Rapport.docx";
+
+  private static final String         NODE_TITLE                = "Rapport Equipe.docx";
+
+  private static final String         NODE_NAME                 = "rapport_equipe.docx";
+
+  private static final String         IDENTITY_ID               = "1";
+
+  private static final String         IDENTITY_BASE_JCR_PATH    = "/Users/john/Private";                   // NOSONAR
+
+  private static final String         IDENTITY_ROOT_WEBDAV_PATH = "/John%20Doe%20%281%29";                     // NOSONAR
+
+  private static final String         PARENT_JCR_PATH           = IDENTITY_BASE_JCR_PATH + "/Documents";
+
+  private static final String         PARENT_WEBDAV_PATH        = IDENTITY_ROOT_WEBDAV_PATH + "/Documents";
+
+  private static final String         JCR_PATH                  = PARENT_JCR_PATH + "/rapport_equipe.docx";
+
+  private static final String         NODE_ID                   = "node-123";
+
+  @Mock
+  private Session                     session;
+
+  @Mock
+  private NodeImpl                    node;
+
+  @Mock
+  private NodeImpl                    parentNode;
+
+  @Mock
+  private NodeImpl                    identityRootNode;
+
+  @Mock
+  private Property                    property;
+
+  @Mock
+  private WebDavPathMappingRepository repository;
+
+  @InjectMocks
+  private WebDavPathMappingService    service;
+
+  @Before
+  @SneakyThrows
+  public void setUp() {
+    when(repository.save(any(WebDavPathMappingEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    when(node.getPath()).thenReturn(JCR_PATH);
+    when(node.getName()).thenReturn(NODE_NAME);
+    when(node.getIdentifier()).thenReturn(NODE_ID);
+    when(node.getParent()).thenReturn(parentNode);
+
+    when(parentNode.getPath()).thenReturn(PARENT_JCR_PATH);
+    when(parentNode.getName()).thenReturn("Documents");
+    when(parentNode.getIdentifier()).thenReturn("parent-node-1");
+    when(parentNode.getParent()).thenReturn(identityRootNode);
+
+    when(identityRootNode.getPath()).thenReturn(IDENTITY_BASE_JCR_PATH);
+    when(identityRootNode.getName()).thenReturn("Private");
+    when(identityRootNode.getIdentifier()).thenReturn("identity-root-node-1");
+  }
+
+  @Test
+  public void testFindJcrPathReturnsMappedPath() {
+    WebDavPathMappingEntity entity = new WebDavPathMappingEntity();
+    entity.setJcrPath(JCR_PATH);
+
+    when(repository.findByParentJcrPathAndNormalizedVisibleName(PARENT_JCR_PATH,
+                                                                "rapport equipe.docx")).thenReturn(Optional.of(entity));
+
+    String result = service.findJcrPath(PARENT_JCR_PATH, NODE_TITLE);
+
+    assertEquals(JCR_PATH, result);
+  }
+
+  @Test
+  public void testFindJcrPathReturnsNullWhenNoMappingExists() {
+    when(repository.findByParentJcrPathAndNormalizedVisibleName(PARENT_JCR_PATH, "missing.docx"))
+                                                                                                 .thenReturn(Optional.empty());
+
+    String result = service.findJcrPath(PARENT_JCR_PATH, "missing.docx");
+
+    assertNull(result);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testAllocateTechnicalNameReturnsFirstAvailableEncodedName() {
+    when(session.itemExists(anyString())).thenReturn(false);
+
+    String result = service.allocateTechnicalName(session, PARENT_JCR_PATH, NODE_TITLE);
+
+    assertEquals(NODE_TITLE, result);
+    verify(session).itemExists(PARENT_JCR_PATH + "/Rapport Equipe.docx");
+  }
+
+  @Test
+  @SneakyThrows
+  public void testAllocateTechnicalNameAddsSuffixWhenTechnicalNameAlreadyExists() {
+    when(session.itemExists(PARENT_JCR_PATH + "/Rapport.docx")).thenReturn(true);
+    when(session.itemExists(PARENT_JCR_PATH + "/Rapport (1).docx")).thenReturn(false);
+
+    String result = service.allocateTechnicalName(session, PARENT_JCR_PATH, NODE_TITLE_OTHER);
+
+    assertEquals("Rapport (1).docx", result);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testSaveMappingCreatesPersistentEntityAndUpdatesTitlePropertiesWhenAvailable() {
+    when(node.hasProperty(EXO_TITLE)).thenReturn(true);
+    when(node.hasProperty(EXO_NAME)).thenReturn(true);
+    when(repository.findByJcrPath(JCR_PATH)).thenReturn(Optional.empty());
+    when(repository.findByParentJcrPathAndNormalizedVisibleName(PARENT_JCR_PATH, "rapport équipe.docx"))
+                                                                                                        .thenReturn(Optional.empty());
+
+    WebDavPathMappingEntity result = service.saveMapping(session,
+                                                         PARENT_WEBDAV_PATH + "/Rapport%20%C3%89quipe.docx",
+                                                         NODE_TITLE_WITH_ACCENT,
+                                                         node);
+
+    assertNotNull(result);
+    assertEquals(IDENTITY_ID, result.getIdentityId());
+    assertEquals(PARENT_JCR_PATH, result.getParentJcrPath());
+    assertEquals(NODE_TITLE_WITH_ACCENT, result.getVisibleName());
+    assertEquals("rapport équipe.docx", result.getNormalizedVisibleName());
+    assertEquals(PARENT_WEBDAV_PATH + "/Rapport%20%C3%89quipe.docx", result.getWebDavPath());
+    assertEquals(PARENT_WEBDAV_PATH, result.getParentWebDavPath());
+    assertEquals(JCR_PATH, result.getJcrPath());
+    assertEquals(NODE_ID, result.getNodeIdentifier());
+    assertEquals(NODE_NAME, result.getTechnicalName());
+    assertFalse(result.isFallbackName());
+    assertFalse(result.isCollisionResolved());
+    assertNotNull(result.getId());
+    assertNotNull(result.getCreatedDate());
+    assertNotNull(result.getUpdatedDate());
+
+    verify(node).setProperty(EXO_TITLE, NODE_TITLE_WITH_ACCENT);
+    verify(node).setProperty(EXO_NAME, NODE_NAME);
+    verify(repository).save(any(WebDavPathMappingEntity.class));
+  }
+
+  @Test
+  @SneakyThrows
+  public void testSaveMappingReusesExistingEntityByJcrPath() {
+    WebDavPathMappingEntity existing = new WebDavPathMappingEntity();
+    existing.setCreatedDate("2025-01-01T00:00:00Z");
+    existing.setJcrPath(JCR_PATH);
+
+    when(repository.findByJcrPath(JCR_PATH)).thenReturn(Optional.of(existing));
+    when(repository.findByParentJcrPathAndNormalizedVisibleName(PARENT_JCR_PATH, "rapport.docx"))
+                                                                                                 .thenReturn(Optional.empty());
+
+    WebDavPathMappingEntity result = service.saveMapping(session,
+                                                         PARENT_WEBDAV_PATH + "/Rapport.docx",
+                                                         NODE_TITLE_OTHER,
+                                                         node);
+
+    assertEquals(existing, result);
+    assertEquals("2025-01-01T00:00:00Z", result.getCreatedDate());
+    assertEquals(NODE_TITLE_OTHER, result.getVisibleName());
+  }
+
+  @Test
+  public void testDeleteMappingDeletesExistingMapping() {
+    WebDavPathMappingEntity entity = new WebDavPathMappingEntity();
+    when(repository.findByJcrPath(JCR_PATH)).thenReturn(Optional.of(entity));
+
+    service.deleteMapping(JCR_PATH);
+
+    verify(repository).delete(entity);
+  }
+
+  @Test
+  public void testDeleteMappingIgnoresMissingMapping() {
+    when(repository.findByJcrPath(JCR_PATH)).thenReturn(Optional.empty());
+
+    service.deleteMapping(JCR_PATH);
+
+    verify(repository, never()).delete(any(WebDavPathMappingEntity.class));
+  }
+
+  @Test
+  @SneakyThrows
+  public void testGetOrCreateWebDavPathReturnsIdentityRootForIdentityBaseNode() {
+    String result = service.getOrCreateWebDavPath(IDENTITY_ID,
+                                                  IDENTITY_BASE_JCR_PATH,
+                                                  IDENTITY_ROOT_WEBDAV_PATH,
+                                                  identityRootNode,
+                                                  "Private");
+
+    assertEquals(IDENTITY_ROOT_WEBDAV_PATH, result);
+    verify(repository, never()).save(any(WebDavPathMappingEntity.class));
+  }
+
+  @Test
+  @SneakyThrows
+  public void testGetOrCreateWebDavPathReturnsExistingMappingByNodeIdentifier() {
+    WebDavPathMappingEntity existing = new WebDavPathMappingEntity();
+    existing.setWebDavPath(PARENT_WEBDAV_PATH + "/Existing.docx");
+
+    when(repository.findByNodeIdentifier(NODE_ID)).thenReturn(Optional.of(existing));
+
+    String result = service.getOrCreateWebDavPath(IDENTITY_ID,
+                                                  IDENTITY_BASE_JCR_PATH,
+                                                  IDENTITY_ROOT_WEBDAV_PATH,
+                                                  node,
+                                                  "Ignored.docx");
+
+    assertEquals(PARENT_WEBDAV_PATH + "/Existing.docx", result);
+    verify(repository, never()).save(any(WebDavPathMappingEntity.class));
+  }
+
+  @Test
+  @SneakyThrows
+  public void testGetOrCreateWebDavPathReturnsExistingMappingByJcrPathWhenNoIdentifierMappingExists() {
+    WebDavPathMappingEntity existing = new WebDavPathMappingEntity();
+    existing.setWebDavPath(PARENT_WEBDAV_PATH + "/ByJcr.docx");
+
+    when(repository.findByNodeIdentifier(NODE_ID)).thenReturn(Optional.empty());
+    when(repository.findByJcrPath(JCR_PATH)).thenReturn(Optional.of(existing));
+
+    String result = service.getOrCreateWebDavPath(IDENTITY_ID,
+                                                  IDENTITY_BASE_JCR_PATH,
+                                                  IDENTITY_ROOT_WEBDAV_PATH,
+                                                  node,
+                                                  "Ignored.docx");
+
+    assertEquals(PARENT_WEBDAV_PATH + "/ByJcr.docx", result);
+    verify(repository, never()).save(any(WebDavPathMappingEntity.class));
+  }
+
+  @Test
+  @SneakyThrows
+  public void testGetOrCreateWebDavPathCreatesParentAndChildMappingsWithVisibleNames() {
+    when(repository.findByNodeIdentifier(anyString())).thenReturn(Optional.empty());
+    when(repository.findByJcrPath(anyString())).thenReturn(Optional.empty());
+    when(repository.findByParentJcrPathAndNormalizedVisibleName(anyString(), anyString())).thenReturn(Optional.empty());
+
+    when(parentNode.hasProperty(EXO_TITLE)).thenReturn(true);
+    when(parentNode.getProperty(EXO_TITLE)).thenReturn(property);
+    when(property.getString()).thenReturn("Documents Partagés");
+
+    String result = service.getOrCreateWebDavPath(IDENTITY_ID,
+                                                  IDENTITY_BASE_JCR_PATH,
+                                                  IDENTITY_ROOT_WEBDAV_PATH,
+                                                  node,
+                                                  NODE_TITLE_WITH_ACCENT);
+
+    assertEquals(IDENTITY_ROOT_WEBDAV_PATH + "/Documents%20Partag%C3%A9s/Rapport%20%C3%89quipe.docx", result);
+
+    ArgumentCaptor<WebDavPathMappingEntity> captor = ArgumentCaptor.forClass(WebDavPathMappingEntity.class);
+    verify(repository, org.mockito.Mockito.times(2)).save(captor.capture());
+
+    WebDavPathMappingEntity parentMapping = captor.getAllValues().get(0);
+    WebDavPathMappingEntity childMapping = captor.getAllValues().get(1);
+
+    assertEquals("Documents Partagés", parentMapping.getVisibleName());
+    assertEquals(IDENTITY_ROOT_WEBDAV_PATH + "/Documents%20Partag%C3%A9s", parentMapping.getWebDavPath());
+
+    assertEquals(NODE_TITLE_WITH_ACCENT, childMapping.getVisibleName());
+    assertEquals(result, childMapping.getWebDavPath());
+    assertEquals(PARENT_JCR_PATH, childMapping.getParentJcrPath());
+    assertEquals(JCR_PATH, childMapping.getJcrPath());
+  }
+
+  @Test
+  @SneakyThrows
+  public void testGetOrCreateWebDavPathResolvesVisibleNameCollision() {
+    WebDavPathMappingEntity collision = new WebDavPathMappingEntity();
+    collision.setJcrPath(PARENT_JCR_PATH + "/other.docx");
+
+    when(repository.findByNodeIdentifier(anyString())).thenReturn(Optional.empty());
+    when(repository.findByJcrPath(anyString())).thenReturn(Optional.empty());
+    when(repository.findByParentJcrPathAndNormalizedVisibleName(eq(IDENTITY_BASE_JCR_PATH), anyString()))
+                                                                                                         .thenReturn(Optional.empty());
+    when(repository.findByParentJcrPathAndNormalizedVisibleName(PARENT_JCR_PATH, "rapport.docx"))
+                                                                                                 .thenReturn(Optional.of(collision));
+    when(repository.findByParentJcrPathAndNormalizedVisibleName(PARENT_JCR_PATH, "rapport (1).docx"))
+                                                                                                     .thenReturn(Optional.empty());
+
+    String result = service.getOrCreateWebDavPath(IDENTITY_ID,
+                                                  IDENTITY_BASE_JCR_PATH,
+                                                  IDENTITY_ROOT_WEBDAV_PATH,
+                                                  node,
+                                                  NODE_TITLE_OTHER);
+
+    assertEquals(PARENT_WEBDAV_PATH + "/Rapport%20%281%29.docx", result);
+
+    ArgumentCaptor<WebDavPathMappingEntity> captor = ArgumentCaptor.forClass(WebDavPathMappingEntity.class);
+    verify(repository, org.mockito.Mockito.times(2)).save(captor.capture());
+
+    WebDavPathMappingEntity childMapping = captor.getAllValues().get(1);
+    assertEquals("Rapport (1).docx", childMapping.getVisibleName());
+    assertTrue(childMapping.isCollisionResolved());
+  }
+}

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/webdav/plugin/PathCommandHandlerTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/webdav/plugin/PathCommandHandlerTest.java
@@ -20,10 +20,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import javax.jcr.Node;
+import javax.jcr.Session;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -32,6 +35,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import org.exoplatform.documents.storage.jcr.webdav.WebDavPathMappingService;
 import org.exoplatform.documents.webdav.model.WebDavException;
 import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
@@ -46,39 +50,47 @@ import lombok.SneakyThrows;
 @RunWith(MockitoJUnitRunner.class)
 public class PathCommandHandlerTest {
 
-  private static final String    IDENTITY_PATH = "/(123)";
+  private static final String      IDENTITY_PATH      = "/(123)";              // NOSONAR
 
-  private static final String    USER1         = "user1";
+  private static final String      USER1              = "user1";
 
-  @Mock
-  private IdentityManager        identityManager;
-
-  @Mock
-  private SpaceService           spaceService;
+  private static final String      USER_BASE_JCR_PATH = "/users/user1/Private";// NOSONAR
 
   @Mock
-  private NodeHierarchyCreator   nodeHierarchyCreator;
+  private IdentityManager          identityManager;
 
   @Mock
-  private SessionProviderService sessionProviderService;
+  private SpaceService             spaceService;
 
   @Mock
-  private Identity               identity;
+  private NodeHierarchyCreator     nodeHierarchyCreator;
 
   @Mock
-  private Node                   userNode;
+  private SessionProviderService   sessionProviderService;
 
   @Mock
-  private Node                   privateNode;
+  private WebDavPathMappingService webDavPathMappingService;
 
   @Mock
-  private Space                  space;
+  private Session                  session;
 
   @Mock
-  private SessionProvider        sessionProvider;
+  private Identity                 identity;
+
+  @Mock
+  private Node                     userNode;
+
+  @Mock
+  private Node                     privateNode;
+
+  @Mock
+  private Space                    space;
+
+  @Mock
+  private SessionProvider          sessionProvider;
 
   @InjectMocks
-  private PathCommandHandler     handler;
+  private PathCommandHandler       handler;
 
   @Before
   @SneakyThrows
@@ -86,19 +98,18 @@ public class PathCommandHandlerTest {
     when(sessionProviderService.getSystemSessionProvider(null)).thenReturn(sessionProvider);
     when(nodeHierarchyCreator.getUserNode(sessionProvider, USER1)).thenReturn(userNode);
     when(userNode.getNode("Private")).thenReturn(privateNode);
-    when(privateNode.getPath()).thenReturn("/users/user1/Private");
+    when(privateNode.getPath()).thenReturn(USER_BASE_JCR_PATH);
     when(nodeHierarchyCreator.getJcrPath("groupsPath")).thenReturn("/groups");
     when(nodeHierarchyCreator.getJcrPath("usersPath")).thenReturn("/users");
   }
 
   @Test
   public void testGetIdentityBaseJcrPathByWebDavPathUser() {
-    when(identityManager.getIdentity(123L)).thenReturn(identity);
-    when(identity.isUser()).thenReturn(true);
-    when(identity.getRemoteId()).thenReturn(USER1);
+    mockUserIdentity(123L);
 
     String result = handler.getIdentityBaseJcrPath(IDENTITY_PATH);
-    assertEquals("/users/user1/Private", result);
+
+    assertEquals(USER_BASE_JCR_PATH, result);
   }
 
   @Test(expected = WebDavException.class)
@@ -117,6 +128,7 @@ public class PathCommandHandlerTest {
     when(space.getGroupId()).thenReturn("/spaces/spacePretty");
 
     String result = handler.getIdentityBaseJcrPath("/(456)");
+
     assertEquals("/groups/spaces/spacePretty/Documents", result);
   }
 
@@ -139,6 +151,7 @@ public class PathCommandHandlerTest {
     when(spaceIdentity.getIdentityId()).thenReturn(999L);
 
     Long id = handler.getIdentityIdFromJcrPath("/groups/spaces/space1/doc", "userX");
+
     assertEquals(Long.valueOf(999L), id);
   }
 
@@ -149,6 +162,7 @@ public class PathCommandHandlerTest {
     when(userIdentity.getIdentityId()).thenReturn(111L);
 
     Long id = handler.getIdentityIdFromJcrPath("/users/user1/doc", USER1);
+
     assertEquals(Long.valueOf(111L), id);
   }
 
@@ -168,23 +182,60 @@ public class PathCommandHandlerTest {
   }
 
   @Test
-  public void testTransformToJcrPathNoIdentityId() {
-    assertEquals("/", handler.transformToJcrPath("/"));
+  @SneakyThrows
+  public void testResolveToJcrPathNoIdentityId() {
+    assertEquals("/", handler.resolveToJcrPath(session, "/"));
   }
 
   @Test
-  public void testTransformToJcrPathWithRelativePath() {
-    when(identityManager.getIdentity(123L)).thenReturn(identity);
-    when(identity.isUser()).thenReturn(true);
-    when(identity.getRemoteId()).thenReturn(USER1);
+  @SneakyThrows
+  public void testResolveToJcrPathWithMappedSegment() {
+    mockUserIdentity(123L);
+    when(webDavPathMappingService.findJcrPath(USER_BASE_JCR_PATH, "Rapport Équipe.docx"))
+                                                                                         .thenReturn(USER_BASE_JCR_PATH +
+                                                                                             "/technical-report");
 
-    String path = handler.transformToJcrPath("/folder(123)/subdir");
-    assertTrue(path.contains("subdir"));
+    String path = handler.resolveToJcrPath(session, "/John%20Doe%20(123)/Rapport%20%C3%89quipe.docx");
+
+    assertEquals(USER_BASE_JCR_PATH + "/technical-report", path);
+  }
+
+  @Test
+  @SneakyThrows
+  public void testResolveToJcrPathWithLegacyFallback() {
+    mockUserIdentity(123L);
+    when(webDavPathMappingService.findJcrPath(eq(USER_BASE_JCR_PATH), anyString())).thenReturn(null);
+    when(session.itemExists(USER_BASE_JCR_PATH + "/subdir")).thenReturn(true);
+
+    String path = handler.resolveToJcrPath(session, "/John%20Doe%20(123)/subdir");
+
+    assertEquals(USER_BASE_JCR_PATH + "/subdir", path);
+  }
+
+  @Test(expected = WebDavException.class)
+  @SneakyThrows
+  public void testResolveToJcrPathNotFoundWhenNoMappingAndNoLegacyPath() {
+    mockUserIdentity(123L);
+    when(webDavPathMappingService.findJcrPath(eq(USER_BASE_JCR_PATH), anyString())).thenReturn(null);
+    when(session.itemExists(anyString())).thenReturn(false);
+
+    handler.resolveToJcrPath(session, "/John%20Doe%20(123)/missing");
+  }
+
+  @Test
+  public void testGetLastVisibleSegment() {
+    assertEquals("Rapport Équipe.docx", handler.getLastVisibleSegment("/John%20Doe%20(123)/Rapport%20%C3%89quipe.docx"));
   }
 
   @Test
   public void testIsIdentityRootWebDavPath() {
     assertTrue(handler.isIdentityRootWebDavPath(IDENTITY_PATH));
     assertFalse(handler.isIdentityRootWebDavPath("/(123)/subdir"));
+  }
+
+  private void mockUserIdentity(long identityId) {
+    when(identityManager.getIdentity(identityId)).thenReturn(identity);
+    when(identity.isUser()).thenReturn(true);
+    when(identity.getRemoteId()).thenReturn(USER1);
   }
 }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandlerTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavReadCommandHandlerTest.java
@@ -21,8 +21,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
@@ -48,6 +50,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.documents.storage.jcr.util.NodeTypeConstants;
+import org.exoplatform.documents.storage.jcr.webdav.WebDavPathMappingService;
 import org.exoplatform.documents.webdav.model.WebDavFileDownload;
 import org.exoplatform.documents.webdav.model.WebDavItem;
 import org.exoplatform.social.core.identity.model.Identity;
@@ -61,11 +64,13 @@ import lombok.SneakyThrows;
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class WebdavReadCommandHandlerTest {
 
-  private static final String      IDENTITY_PATH            = "/Users/r/root/Private";
+  private static final String      IDENTITY_PATH            = "/Users/r/root/Private";                    // NOSONAR
 
-  private static final String      JCR_RELATIVE_PATH        = "/path/to/file";
+  private static final String      JCR_RELATIVE_PATH        = "/path/to/file";                            // NOSONAR
 
-  private static final String      WEBDAV_PATH              = "/John Doe (1)" + JCR_RELATIVE_PATH;
+  private static final String      WEBDAV_PATH              = "/John%20Doe%20%281%29" + JCR_RELATIVE_PATH;// NOSONAR
+
+  private static final String      ENCODED_WEBDAV_PATH      = "/John%20Doe%20%281%29" + JCR_RELATIVE_PATH;// NOSONAR
 
   private static final String      JCR_PATH                 = IDENTITY_PATH + JCR_RELATIVE_PATH;
 
@@ -83,6 +88,9 @@ public class WebdavReadCommandHandlerTest {
 
   @Mock
   private PathCommandHandler       pathCommandHandler;
+
+  @Mock
+  private WebDavPathMappingService webDavPathMappingService;
 
   @Mock
   private Session                  session;
@@ -122,15 +130,24 @@ public class WebdavReadCommandHandlerTest {
   @Before
   @SneakyThrows
   public void setUp() {
-    handler = new WebdavReadCommandHandler(identityManager, spaceService, pathCommandHandler);
+    handler = new WebdavReadCommandHandler(identityManager, spaceService, pathCommandHandler, webDavPathMappingService);
 
-    when(pathCommandHandler.transformToJcrPath(anyString())).thenReturn("/jcr/path");
+    when(pathCommandHandler.resolveToJcrPath(eq(session), anyString())).thenReturn(JCR_PATH);
+    when(pathCommandHandler.isIdentityRootWebDavPath(WEBDAV_PATH)).thenReturn(false);
+    when(pathCommandHandler.getIdentityIdFromWebDavPath(WEBDAV_PATH)).thenReturn(1L);
+    when(pathCommandHandler.getIdentityBaseJcrPath(WEBDAV_PATH)).thenReturn(IDENTITY_PATH);
+    when(pathCommandHandler.getIdentityBaseJcrPath(1L)).thenReturn(IDENTITY_PATH);
+
     when(session.itemExists(anyString())).thenReturn(true);
-    when(session.getItem("/jcr/path")).thenReturn(node);
+    when(session.getItem(JCR_PATH)).thenReturn(node);
+    when(session.getItem(IDENTITY_PATH)).thenReturn(node);
 
-    when(node.isNodeType(anyString())).thenReturn(false); // default
-    when(node.getName()).thenReturn("path");
+    when(node.isNodeType(anyString())).thenReturn(false);
+    when(node.getName()).thenReturn("file");
+    when(node.getPath()).thenReturn(JCR_PATH);
+    when(node.hasNodes()).thenReturn(false);
     when(node.getNode("jcr:content")).thenReturn(contentNode);
+    when(node.hasProperty(anyString())).thenReturn(false);
     when(contentNode.hasProperty(anyString())).thenReturn(true);
     when(contentNode.getProperty(anyString())).thenReturn(property);
     when(property.getString()).thenReturn("text/plain");
@@ -142,13 +159,22 @@ public class WebdavReadCommandHandlerTest {
     when(property.getDate()).thenReturn(cal);
 
     when(identity.getProfile()).thenReturn(profile);
-    when(profile.getFullName()).thenReturn("John Doe");
     when(identity.getIdentityId()).thenReturn(1L);
+    when(identity.getId()).thenReturn("1");
+    when(profile.getFullName()).thenReturn("John Doe");
     when(identityManager.getIdentity(anyLong())).thenReturn(identity);
     when(identityManager.getOrCreateUserIdentity(USERNAME)).thenReturn(identity);
     when(spaceService.getMemberSpaces(USERNAME)).thenReturn(memberSpacesListAccess);
-    when(node.getPath()).thenReturn(JCR_PATH);
-    when(pathCommandHandler.getIdentityBaseJcrPath(WEBDAV_PATH)).thenReturn(IDENTITY_PATH);
+
+    when(webDavPathMappingService.getVisibleName(any(Node.class))).thenReturn("file");
+    when(webDavPathMappingService.getParentVisibleNodeName(any(Node.class))).thenReturn("path");
+
+    when(webDavPathMappingService.getOrCreateWebDavPath(eq("1"),
+                                                        eq(IDENTITY_PATH),
+                                                        eq("/John%20Doe%20%281%29"),
+                                                        any(Node.class),
+                                                        anyString()))
+                                                                     .thenReturn(ENCODED_WEBDAV_PATH);
   }
 
   @Test
@@ -158,7 +184,7 @@ public class WebdavReadCommandHandlerTest {
                                         "/",
                                         REQUESTED_PROPERTY_NAMES,
                                         false,
-                                        5,
+                                        0,
                                         BASE_URI,
                                         USERNAME);
     assertNotNull(webDavItem);
@@ -171,17 +197,17 @@ public class WebdavReadCommandHandlerTest {
 
   @Test
   @SneakyThrows
-  public void testGetWithNodePath() {
+  public void testGetWithNodePathUsesMappedWebDavPath() {
     WebDavItem webDavItem = handler.get(session,
                                         WEBDAV_PATH,
                                         REQUESTED_PROPERTY_NAMES,
                                         false,
-                                        5,
+                                        0,
                                         BASE_URI,
                                         USERNAME);
     assertNotNull(webDavItem);
     assertEquals(JCR_PATH, webDavItem.getJcrPath());
-    assertEquals(WEBDAV_PATH.replace(" ", "%20"), webDavItem.getWebDavPath());
+    assertEquals(ENCODED_WEBDAV_PATH, webDavItem.getWebDavPath());
     assertFalse(webDavItem.isFile());
     assertNotNull(webDavItem.getIdentifier());
   }
@@ -231,7 +257,7 @@ public class WebdavReadCommandHandlerTest {
     when(node.isNodeType(NodeTypeConstants.MIX_VERSIONABLE)).thenReturn(true);
     when(node.getVersionHistory()).thenReturn(versionHistory);
     when(versionHistory.getAllVersions()).thenReturn(versionIterator);
-    when(versionIterator.hasNext()).thenReturn(false); // no versions
+    when(versionIterator.hasNext()).thenReturn(false);
     List<WebDavItem> result = handler.getVersions(session, WEBDAV_PATH, Collections.emptySet(), BASE_URI);
     assertNotNull(result);
   }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavWriteCommandHandlerTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavWriteCommandHandlerTest.java
@@ -20,15 +20,16 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.Collections;
 
 import javax.jcr.Node;
+import javax.jcr.Property;
 import javax.jcr.lock.Lock;
 import javax.jcr.version.Version;
 
@@ -39,8 +40,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.documents.storage.TrashStorage;
+import org.exoplatform.documents.storage.jcr.webdav.WebDavPathMappingService;
+import org.exoplatform.documents.webdav.model.WebDavException;
 import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.access.PermissionType;
 import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
@@ -52,7 +57,19 @@ import lombok.SneakyThrows;
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class WebdavWriteCommandHandlerTest {
 
-  private static final String       JCR_PATH = "/jcr/path";
+  private static final String       JCR_CONTENT        = "jcr:content";
+
+  private static final String       JCR_PATH           = "/jcr/path";                 // NOSONAR
+
+  private static final String       PARENT_JCR_PATH    = "/jcr";                      // NOSONAR
+
+  private static final String       WEBDAV_FILE_PATH   = "/John%20Doe%20%281%29/New%20File.txt";// NOSONAR
+
+  private static final String       WEBDAV_PARENT_PATH = "/John%20Doe%20%281%29";     // NOSONAR
+
+  private static final String       VISIBLE_NAME       = "New File.txt";
+
+  private static final String       TECHNICAL_NAME     = "New_File.txt";
 
   @Mock
   private RepositoryService         repositoryService;
@@ -64,7 +81,13 @@ public class WebdavWriteCommandHandlerTest {
   private TrashStorage              trashStorage;
 
   @Mock
+  private SettingService            settingService;
+
+  @Mock
   private PathCommandHandler        pathCommandHandler;
+
+  @Mock
+  private WebDavPathMappingService  webDavPathMappingService;
 
   @Mock
   private SessionImpl               session;
@@ -73,10 +96,16 @@ public class WebdavWriteCommandHandlerTest {
   private NodeImpl                  node;
 
   @Mock
-  private ConversationState         conversationState;
+  private NodeImpl                  parentNode;
 
   @Mock
-  private Node                      destNode;
+  private Node                      contentNode;
+
+  @Mock
+  private Property                  property;
+
+  @Mock
+  private ConversationState         conversationState;
 
   @Mock
   private Lock                      lock;
@@ -90,41 +119,89 @@ public class WebdavWriteCommandHandlerTest {
   @Before
   @SneakyThrows
   public void setUp() {
-    // Common stubs
-    when(pathCommandHandler.transformToJcrPath(anyString())).thenReturn(JCR_PATH);
+    when(pathCommandHandler.resolveToJcrPath(eq(session), eq(JCR_PATH))).thenReturn(JCR_PATH);
+    when(pathCommandHandler.resolveToJcrPath(eq(session), eq(WEBDAV_PARENT_PATH))).thenReturn(PARENT_JCR_PATH);
+    when(pathCommandHandler.getLastVisibleSegment(anyString())).thenReturn(VISIBLE_NAME);
+    when(webDavPathMappingService.allocateTechnicalName(eq(session), eq(PARENT_JCR_PATH), anyString())).thenReturn(TECHNICAL_NAME);
+
     when(session.itemExists(anyString())).thenReturn(true);
     when(session.getItem(JCR_PATH)).thenReturn(node);
+    when(session.getItem(PARENT_JCR_PATH)).thenReturn(parentNode);
+    when(session.getItem(PARENT_JCR_PATH + "/" + TECHNICAL_NAME)).thenReturn(node);
+
+    when(parentNode.addNode(TECHNICAL_NAME, "nt:file")).thenReturn(node);
+    when(parentNode.addNode(TECHNICAL_NAME, "nt:folder")).thenReturn(node);
+
     when(node.getSession()).thenReturn(session);
-    when(node.getPath()).thenReturn(JCR_PATH);
-    when(node.getName()).thenReturn(Arrays.asList(JCR_PATH.split("/")).getLast());
+    when(node.getPath()).thenReturn(PARENT_JCR_PATH + "/" + TECHNICAL_NAME);
+    when(node.getName()).thenReturn(TECHNICAL_NAME);
+    when(node.getParent()).thenReturn(parentNode);
+    when(node.hasNode(JCR_CONTENT)).thenReturn(false);
+    when(node.addNode(JCR_CONTENT, "nt:resource")).thenReturn(contentNode);
+    when(node.getNode(JCR_CONTENT)).thenReturn(contentNode);
+    when(node.canAddMixin(anyString())).thenReturn(false);
+    when(node.isLocked()).thenReturn(false);
+    when(node.isNodeType(anyString())).thenReturn(false);
+    when(node.setProperty(anyString(), anyString())).thenReturn(property);
+
+    when(contentNode.setProperty(anyString(), anyString())).thenReturn(property);
+    when(contentNode.setProperty(anyString(), any(InputStream.class))).thenReturn(property);
+    when(contentNode.setProperty(eq("jcr:lastModified"), any(java.util.Calendar.class))).thenReturn(property);
   }
 
   @Test
   @SneakyThrows
-  public void testSaveFile() {
-    when(node.addNode("file", "nt:file")).thenReturn(destNode);
-    when(destNode.addNode("jcr:content", "nt:resource")).thenReturn(destNode);
-    when(destNode.setProperty(eq("jcr:data"), any(InputStream.class))).thenReturn(null);
-    handler.saveFile(session, JCR_PATH, "text/plain", Collections.emptyList(), new ByteArrayInputStream("data".getBytes()));
+  public void testSaveFileCreatesMappingForNewVisiblePath() {
+    when(pathCommandHandler.resolveToJcrPath(eq(session), eq(WEBDAV_FILE_PATH)))
+                                                                                .thenThrow(new WebDavException(404, "missing"));
+    when(webDavPathMappingService.getVisibleName(node)).thenReturn(TECHNICAL_NAME);
+    handler.saveFile(session,
+                     WEBDAV_FILE_PATH,
+                     "text/plain",
+                     Collections.emptyList(),
+                     new ByteArrayInputStream("data".getBytes()));
+
+    verify(parentNode).addNode(TECHNICAL_NAME, "nt:file");
+    verify(node).setProperty("exo:title", VISIBLE_NAME);
+    verify(webDavPathMappingService).saveMapping(session, WEBDAV_FILE_PATH, VISIBLE_NAME, node);
     verify(session, atLeastOnce()).save();
   }
 
   @Test
   @SneakyThrows
-  public void testDelete() {
-    when(session.getUserState()).thenReturn(conversationState);
-    handler.delete(session, JCR_PATH);
-    verify(trashStorage).moveToTrash(eq(node), any(SessionProvider.class));
+  public void testCreateFolderCreatesMappingForVisiblePath() {
+    handler.createFolder(session, WEBDAV_FILE_PATH, Collections.emptyList());
+
+    verify(parentNode).addNode(TECHNICAL_NAME, "nt:folder");
+    verify(node).setProperty("exo:title", VISIBLE_NAME);
+    verify(webDavPathMappingService).saveMapping(session, WEBDAV_FILE_PATH, VISIBLE_NAME, node);
     verify(session).save();
   }
 
   @Test
   @SneakyThrows
-  public void testEnableVersioning() {
-    when(node.isNodeType("mix:versionable")).thenReturn(false);
-    handler.enableVersioning(session, JCR_PATH);
-    verify(node).addMixin("mix:versionable");
+  public void testDeleteDeletesPathMapping() {
+    when(session.getUserState()).thenReturn(conversationState);
+    when(node.getPath()).thenReturn(JCR_PATH);
+    doNothing().when(node).checkPermission(PermissionType.REMOVE);
+
+    handler.delete(session, JCR_PATH);
+
+    verify(trashStorage).moveToTrash(eq(node), any(SessionProvider.class));
+    verify(webDavPathMappingService).deleteMapping(JCR_PATH);
     verify(session).save();
   }
 
+  @Test
+  @SneakyThrows
+  public void testEnableVersioningUsesResolvedJcrPath() {
+    when(node.getPath()).thenReturn(JCR_PATH);
+    when(node.isNodeType("mix:versionable")).thenReturn(false);
+
+    handler.enableVersioning(session, JCR_PATH);
+
+    verify(pathCommandHandler).resolveToJcrPath(session, JCR_PATH);
+    verify(node).addMixin("mix:versionable");
+    verify(session).save();
+  }
 }

--- a/documents-webdav-webapp/src/main/java/org/exoplatform/documents/webdav/plugin/impl/SearchWebDavHandler.java
+++ b/documents-webdav-webapp/src/main/java/org/exoplatform/documents/webdav/plugin/impl/SearchWebDavHandler.java
@@ -32,6 +32,7 @@ import org.springframework.util.MimeTypeUtils;
 import org.exoplatform.documents.webdav.model.WebDavException;
 import org.exoplatform.documents.webdav.model.WebDavItem;
 import org.exoplatform.documents.webdav.model.WebDavItemProperty;
+import org.exoplatform.documents.webdav.model.constant.PropertyConstants;
 import org.exoplatform.documents.webdav.plugin.WebDavHttpMethodPlugin;
 import org.exoplatform.documents.webdav.util.PropertyWriteUtil;
 
@@ -45,12 +46,12 @@ public class SearchWebDavHandler extends WebDavHttpMethodPlugin {
   private static final Set<QName> REQUESTED_PROPERTIES = new HashSet<>();
 
   static {
-    REQUESTED_PROPERTIES.add(new QName("DAV:", "displayname"));
-    REQUESTED_PROPERTIES.add(new QName("DAV:", "resourcetype"));
-    REQUESTED_PROPERTIES.add(new QName("DAV:", "creationdate"));
-    REQUESTED_PROPERTIES.add(new QName("DAV:", "getlastmodified"));
-    REQUESTED_PROPERTIES.add(new QName("DAV:", "getcontentlength"));
-    REQUESTED_PROPERTIES.add(new QName("DAV:", "getcontenttype"));
+    REQUESTED_PROPERTIES.add(PropertyConstants.DISPLAYNAME);
+    REQUESTED_PROPERTIES.add(PropertyConstants.RESOURCETYPE);
+    REQUESTED_PROPERTIES.add(PropertyConstants.CREATIONDATE);
+    REQUESTED_PROPERTIES.add(PropertyConstants.GETLASTMODIFIED);
+    REQUESTED_PROPERTIES.add(PropertyConstants.GETCONTENTLENGTH);
+    REQUESTED_PROPERTIES.add(PropertyConstants.GETCONTENTTYPE);
   }
 
   public SearchWebDavHandler() {


### PR DESCRIPTION
This change improves the UX of JCR by making exposing the pretty Title Name of Files and Folders rather than the JCR technical names.
The mapping between pretty names and JCR Paths is preserved in a ES index as persistent Mapping cache.