### PR TITLE
fix: File Read Vulnerability in Import Zip - EXO-87158

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/bulkactions/ActionThread.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/bulkactions/ActionThread.java
@@ -24,6 +24,9 @@ import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.*;
 
 import javax.jcr.Node;
@@ -64,6 +67,12 @@ public class ActionThread implements Runnable {
   private static final String            ZIP_PREFIX          = "downloadzip";
 
   private static final String            TEMP_DIRECTORY_PATH = "java.io.tmpdir";
+
+  private static final int               BUFFER_SIZE          = 8192;
+
+  private static final int               UNIX_FILE_TYPE_MASK  = 0170000;
+
+  private static final int               UNIX_SYMLINK_FLAG    = 0120000;
 
   public static final String             NT_FILE                = "nt:file";
 
@@ -295,29 +304,138 @@ public class ActionThread implements Runnable {
   }
 
   public static void fixAndExtractZip(File zipFile, File outputDir) throws IOException {
-    if (!outputDir.exists()) outputDir.mkdirs();
+    if (!outputDir.exists() && !outputDir.mkdirs()) {
+      throw new IOException("Cannot create ZIP extraction directory: " + outputDir);
+    }
+
     try (ZipFile zip = new ZipFile(zipFile)) {
       List<FileHeader> headers = zip.getFileHeaders();
       for (FileHeader header : headers) {
         byte[] rawBytes = header.getFileName().getBytes(StandardCharsets.ISO_8859_1);
         String fixedName = pickBestEncoding(rawBytes);
-        File outFile = new File(outputDir, fixedName);
-        if (header.isDirectory()) {
-          if (!outFile.exists()) outFile.mkdirs();
-        } else {
-          File parent = outFile.getParentFile();
-          if (parent != null && !parent.exists()) parent.mkdirs();
-
-          try (InputStream is = zip.getInputStream(header);
-               OutputStream os = new FileOutputStream(outFile)) {
-            byte[] buffer = new byte[4096];
-            int len;
-            while ((len = is.read(buffer)) != -1) {
-              os.write(buffer, 0, len);
-            }
-          }
-        }
+        extractZipEntry(zip, header, outputDir, fixedName);
       }
+    }
+
+    ensureNoSymlinks(outputDir);
+  }
+
+  private static void safeExtractZip(File zipFile, File outputDir, Charset charset) throws IOException {
+    if (!outputDir.exists() && !outputDir.mkdirs()) {
+      throw new IOException("Cannot create ZIP extraction directory: " + outputDir);
+    }
+
+    try (ZipFile zip = new ZipFile(zipFile)) {
+      zip.setCharset(charset);
+      List<FileHeader> headers = zip.getFileHeaders();
+      for (FileHeader header : headers) {
+        extractZipEntry(zip, header, outputDir, header.getFileName());
+      }
+    }
+
+    ensureNoSymlinks(outputDir);
+  }
+
+  private static void extractZipEntry(ZipFile zip, FileHeader header, File outputDir, String entryName) throws IOException {
+    if (isSymlink(header)) {
+      throw new SecurityException("ZIP archive contains symbolic links: " + entryName);
+    }
+
+    File outFile = validateZipEntry(outputDir, entryName);
+    Path outPath = outFile.toPath();
+
+    if (header.isDirectory()) {
+      Files.createDirectories(outPath);
+      ensureNoSymlinks(outFile);
+      return;
+    }
+
+    File parent = outFile.getParentFile();
+    if (parent != null) {
+      Files.createDirectories(parent.toPath());
+      ensureNoSymlinks(parent);
+    }
+
+    if (Files.exists(outPath, LinkOption.NOFOLLOW_LINKS)) {
+      throw new SecurityException("Duplicate or unsafe ZIP entry: " + entryName);
+    }
+
+    try (InputStream is = zip.getInputStream(header);
+         OutputStream os = Files.newOutputStream(outPath, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
+      byte[] buffer = new byte[BUFFER_SIZE];
+      int len;
+      while ((len = is.read(buffer)) != -1) {
+        os.write(buffer, 0, len);
+      }
+    }
+  }
+
+  private static File validateZipEntry(File destinationDir, String entryName) throws IOException {
+    if (StringUtils.isBlank(entryName) || entryName.indexOf('\0') >= 0) {
+      throw new SecurityException("ZIP entry has an invalid name");
+    }
+
+    String normalizedName = entryName.replace('\\', '/');
+    if (normalizedName.startsWith("/") || normalizedName.startsWith("../") || normalizedName.contains("/../")) {
+      throw new SecurityException("ZIP entry outside target directory: " + entryName);
+    }
+
+    Path destinationPath = destinationDir.toPath().toAbsolutePath().normalize();
+    Path targetPath = destinationPath.resolve(normalizedName).normalize();
+    if (!targetPath.startsWith(destinationPath)) {
+      throw new SecurityException("ZIP entry outside target directory: " + entryName);
+    }
+
+    File targetFile = targetPath.toFile();
+    String destDirPath = destinationDir.getCanonicalPath();
+    String targetCanonicalPath = targetFile.getCanonicalPath();
+    if (!targetCanonicalPath.equals(destDirPath) && !targetCanonicalPath.startsWith(destDirPath + File.separator)) {
+      throw new SecurityException("ZIP entry outside target directory: " + entryName);
+    }
+
+    return targetFile;
+  }
+
+  private static boolean isSymlink(FileHeader header) {
+    byte[] attributes = header.getExternalFileAttributes();
+    if (attributes == null || attributes.length < 4) {
+      return false;
+    }
+
+    int littleEndianAttributes = ((attributes[0] & 0xff))
+        | ((attributes[1] & 0xff) << 8)
+        | ((attributes[2] & 0xff) << 16)
+        | ((attributes[3] & 0xff) << 24);
+    int bigEndianAttributes = ((attributes[3] & 0xff))
+        | ((attributes[2] & 0xff) << 8)
+        | ((attributes[1] & 0xff) << 16)
+        | ((attributes[0] & 0xff) << 24);
+
+    return isUnixSymlink(littleEndianAttributes) || isUnixSymlink(bigEndianAttributes);
+  }
+
+  private static boolean isUnixSymlink(int externalAttributes) {
+    int unixMode = (externalAttributes >>> 16) & 0xffff;
+    return (unixMode & UNIX_FILE_TYPE_MASK) == UNIX_SYMLINK_FLAG;
+  }
+
+  private static void ensureNoSymlinks(File root) throws IOException {
+    if (root == null || !root.exists()) {
+      return;
+    }
+
+    Path rootPath = root.toPath();
+    if (Files.isSymbolicLink(rootPath)) {
+      throw new SecurityException("ZIP archive contains symbolic links");
+    }
+
+    File[] files = root.listFiles();
+    if (files == null) {
+      return;
+    }
+
+    for (File file : files) {
+      ensureNoSymlinks(file);
     }
   }
 
@@ -475,11 +593,8 @@ public class ActionThread implements Runnable {
       brodcastEvent();
       String zipFilePath = uploadService.getUploadResource(actionData.getActionId()).getStoreLocation();
       List<String> files = new ArrayList<>();
-      try (ZipFile zip = new ZipFile(zipFilePath)) {
-        zip.setCharset(StandardCharsets.UTF_8);
-        zip.extractAll(tempFolder);
-        listFiles(new File(tempFolder), files);
-      }
+      safeExtractZip(new File(zipFilePath), new File(tempFolder), StandardCharsets.UTF_8);
+      listFiles(new File(tempFolder), files);
       if (files.isEmpty() || files.stream().anyMatch(s -> s.indexOf('�') >= 0)) {
         fixedTempFolder = tempFolder + "_fixed";
         fixAndExtractZip(new File(zipFilePath), new File(fixedTempFolder));
@@ -491,13 +606,21 @@ public class ActionThread implements Runnable {
       actionData.setStatus(ActionStatus.CREATING_DOCUMENTS.name());
       brodcastEvent();
       createItems(fixedTempFolder.isEmpty() ? tempFolder : fixedTempFolder);
+    } catch (SecurityException e) {
+      actionData.setStatus(ActionStatus.CANNOT_UNZIP_FILE.name());
+      log.error("Security: malicious ZIP archive import attempt detected", e);
+      brodcastEvent();
     } catch (Exception e) {
       actionData.setStatus(ActionStatus.CANNOT_UNZIP_FILE.name());
       log.error("Cannot unzip the zip file", e);
       brodcastEvent();
     } finally {
-      cleanFiles(new File(tempFolder));
-      cleanFiles(new File(fixedTempFolder));
+      if (StringUtils.isNotBlank(tempFolder)) {
+        cleanFiles(new File(tempFolder));
+      }
+      if (StringUtils.isNotBlank(fixedTempFolder)) {
+        cleanFiles(new File(fixedTempFolder));
+      }
       bulkStorageActionService.removeActionData(actionData);
     }
   }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/bulkactions/ActionThreadZipSecurityTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/bulkactions/ActionThreadZipSecurityTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (C) 2022 eXo Platform SAS.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see<http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.documents.storage.jcr.bulkactions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import net.lingala.zip4j.model.FileHeader;
+
+class ActionThreadZipSecurityTest {
+
+  @TempDir
+  Path tempDir;
+
+  @Test
+  void fixAndExtractZipExtractsRegularFilesInsideDestination() throws Exception {
+    Path zip = tempDir.resolve("regular.zip");
+    Path outputDir = tempDir.resolve("output");
+
+    createZip(zip,
+              new ZipItem("folder/document.txt", "hello"),
+              new ZipItem("root.txt", "world"));
+
+    ActionThread.fixAndExtractZip(zip.toFile(), outputDir.toFile());
+
+    assertEquals("hello", Files.readString(outputDir.resolve("folder/document.txt"), StandardCharsets.UTF_8));
+    assertEquals("world", Files.readString(outputDir.resolve("root.txt"), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void fixAndExtractZipRejectsDotDotTraversalEntries() throws Exception {
+    Path zip = tempDir.resolve("traversal.zip");
+    Path outputDir = tempDir.resolve("output");
+    Path outsideFile = tempDir.resolve("evil.txt");
+
+    createZip(zip, new ZipItem("../evil.txt", "owned"));
+
+    assertThrows(SecurityException.class, () -> ActionThread.fixAndExtractZip(zip.toFile(), outputDir.toFile()));
+    assertFalse(Files.exists(outsideFile), "Traversal entry must not be written outside the extraction directory");
+  }
+
+  @Test
+  void fixAndExtractZipRejectsNestedDotDotTraversalEntries() throws Exception {
+    Path zip = tempDir.resolve("nested-traversal.zip");
+    Path outputDir = tempDir.resolve("output");
+
+    createZip(zip, new ZipItem("safe/../../evil.txt", "owned"));
+
+    assertThrows(SecurityException.class, () -> ActionThread.fixAndExtractZip(zip.toFile(), outputDir.toFile()));
+    assertFalse(Files.exists(tempDir.resolve("evil.txt")));
+  }
+
+  @Test
+  void validateZipEntryRejectsAbsoluteUnixPath() throws Exception {
+    SecurityException exception = assertThrows(SecurityException.class,
+        () -> invokeValidateZipEntry(tempDir.toFile(), "/etc/passwd"));
+
+    assertTrue(exception.getMessage().contains("outside target directory"));
+  }
+
+  @Test
+  void validateZipEntryRejectsNullByte() throws Exception {
+    SecurityException exception = assertThrows(SecurityException.class,
+        () -> invokeValidateZipEntry(tempDir.toFile(), "safe.txt\0evil"));
+
+    assertTrue(exception.getMessage().contains("invalid name"));
+  }
+
+  @Test
+  void validateZipEntryAcceptsNormalRelativePath() throws Exception {
+    File target = invokeValidateZipEntry(tempDir.toFile(), "folder/file.txt");
+
+    assertEquals(tempDir.resolve("folder/file.txt").normalize().toFile(), target);
+  }
+
+  @Test
+  void isSymlinkDetectsUnixSymlinkAttributes() throws Exception {
+    FileHeader header = new FileHeader();
+    setExternalFileAttributes(header, unixModeAttributes(0120777));
+
+    assertTrue(invokeIsSymlink(header));
+  }
+
+  @Test
+  void isSymlinkDoesNotFlagRegularUnixFileAttributes() throws Exception {
+    FileHeader header = new FileHeader();
+    setExternalFileAttributes(header, unixModeAttributes(0100644));
+
+    assertFalse(invokeIsSymlink(header));
+  }
+
+  @Test
+  void ensureNoSymlinksRejectsExistingSymlinkInExtractionTree() throws Exception {
+    assumeTrue(supportsSymlinks(), "Symbolic links are not supported in this environment");
+
+    Path outputDir = tempDir.resolve("output");
+    Files.createDirectories(outputDir.resolve("folder"));
+    Files.writeString(tempDir.resolve("target.txt"), "secret", StandardCharsets.UTF_8);
+    Files.createSymbolicLink(outputDir.resolve("folder/link.txt"), tempDir.resolve("target.txt"));
+
+    assertThrows(SecurityException.class, () -> invokeEnsureNoSymlinks(outputDir.toFile()));
+  }
+
+  @Test
+  void fixAndExtractZipDoesNotOverwriteExistingDestinationFile() throws Exception {
+    Path zip = tempDir.resolve("duplicate.zip");
+    Path outputDir = tempDir.resolve("output");
+    Files.createDirectories(outputDir);
+    Files.writeString(outputDir.resolve("file.txt"), "existing", StandardCharsets.UTF_8);
+
+    createZip(zip, new ZipItem("file.txt", "from zip"));
+
+    assertThrows(SecurityException.class, () -> ActionThread.fixAndExtractZip(zip.toFile(), outputDir.toFile()));
+    assertEquals("existing", Files.readString(outputDir.resolve("file.txt"), StandardCharsets.UTF_8));
+  }
+
+  private static void createZip(Path zipPath, ZipItem... items) throws IOException {
+    try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zipPath))) {
+      for (ZipItem item : items) {
+        ZipEntry entry = new ZipEntry(item.name());
+        zos.putNextEntry(entry);
+        zos.write(item.content().getBytes(StandardCharsets.UTF_8));
+        zos.closeEntry();
+      }
+    }
+  }
+
+  private static File invokeValidateZipEntry(File destinationDir, String entryName) throws Exception {
+    Method method = ActionThread.class.getDeclaredMethod("validateZipEntry", File.class, String.class);
+    method.setAccessible(true);
+    return invoke(method, null, destinationDir, entryName);
+  }
+
+  private static boolean invokeIsSymlink(FileHeader header) throws Exception {
+    Method method = ActionThread.class.getDeclaredMethod("isSymlink", FileHeader.class);
+    method.setAccessible(true);
+    return invoke(method, null, header);
+  }
+
+  private static void invokeEnsureNoSymlinks(File root) throws Exception {
+    Method method = ActionThread.class.getDeclaredMethod("ensureNoSymlinks", File.class);
+    method.setAccessible(true);
+    invoke(method, null, root);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T invoke(Method method, Object target, Object... args) throws Exception {
+    try {
+      return (T) method.invoke(target, args);
+    } catch (InvocationTargetException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof Exception) {
+        throw (Exception) cause;
+      }
+      if (cause instanceof Error) {
+        throw (Error) cause;
+      }
+      throw e;
+    }
+  }
+
+  private static byte[] unixModeAttributes(int unixMode) {
+    int externalAttributes = unixMode << 16;
+    return new byte[] {
+        (byte) (externalAttributes & 0xff),
+        (byte) ((externalAttributes >>> 8) & 0xff),
+        (byte) ((externalAttributes >>> 16) & 0xff),
+        (byte) ((externalAttributes >>> 24) & 0xff)
+    };
+  }
+
+  private static void setExternalFileAttributes(FileHeader header, byte[] attributes) throws Exception {
+    Method setter = FileHeader.class.getMethod("setExternalFileAttributes", byte[].class);
+    setter.invoke(header, (Object) attributes);
+  }
+
+  private boolean supportsSymlinks() {
+    Path target = tempDir.resolve("symlink-target.txt");
+    Path link = tempDir.resolve("symlink-test.txt");
+    try {
+      Files.writeString(target, "test", StandardCharsets.UTF_8);
+      Files.createSymbolicLink(link, target);
+      return Files.isSymbolicLink(link);
+    } catch (UnsupportedOperationException | IOException | SecurityException e) {
+      return false;
+    } finally {
+      deleteIfExists(link);
+      deleteIfExists(target);
+    }
+  }
+
+  private static void deleteIfExists(Path path) {
+    try {
+      if (path != null && Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+        if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+          Files.walk(path)
+               .sorted(Comparator.reverseOrder())
+               .forEach(ActionThreadZipSecurityTest::deleteIfExists);
+        } else {
+          Files.deleteIfExists(path);
+        }
+      }
+    } catch (IOException ignored) {
+      // best-effort cleanup for test helper only
+    }
+  }
+
+  private static final class ZipItem {
+    private final String name;
+
+    private final String content;
+
+    private ZipItem(String name, String content) {
+      this.name = name;
+      this.content = content;
+    }
+
+    private String name() {
+      return name;
+    }
+
+    private String content() {
+      return content;
+    }
+  }
+}


### PR DESCRIPTION
Before this change, when using the importZip feature, a File Read Vulnerability allowed reading arbitrary files from the server file system via malicious symbolic links. To fix this problem, ZIP entries are now validated, and the extraction process is immediately aborted if a symbolic link is detected. After this change, any archive containing unsafe entries or symbolic links is entirely rejected, preventing any unauthorized access to files outside the target directory.