### PR TITLE
fix: Copy link from doc details drawer doesn't include URL protocol - EXO-86887

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/document-info-drawer/components/DocumentInfoDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/document-info-drawer/components/DocumentInfoDrawer.vue
@@ -622,14 +622,14 @@ export default {
       let path;
       if (this.isFileEditable)  {
         if (this.file?.acl?.canEdit){
-          path =  `${window.location.host}${this.$documentsUtils.getEditorUrl(this.file,null)}`;
+          path =  `${window.location.origin}${this.$documentsUtils.getEditorUrl(this.file,null)}`;
         } else {
-          path =  `${window.location.host}${this.$documentsUtils.getEditorUrl(this.file,'view')}`;
+          path =  `${window.location.origin}${this.$documentsUtils.getEditorUrl(this.file,'view')}`;
         }
       } else if (this.isFileReadable)  {
-        path =  `${window.location.host}${this.$documentsUtils.getEditorUrl(this.file,'view')}`;
+        path =  `${window.location.origin}${this.$documentsUtils.getEditorUrl(this.file,'view')}`;
       } else {
-        path = `${window.location.host}${this.$documentsUtils.getParentFolderUrl(this.file)}?documentPreviewId=${this.fileId}`;
+        path = `${window.location.origin}${this.$documentsUtils.getParentFolderUrl(this.file)}?documentPreviewId=${this.fileId}`;
       }
       const input = document.createElement('input');
       input.value = path;


### PR DESCRIPTION
Prior to this, url generated from the copy link action on the details drawer doesn't include the protocol. This commit fixes this by changing the 'window.location.host' to 'window.location.origin' when generating the link