### PR TITLE
fix: Favorite action should not be displayed in info detail drawer if folder - EXO-84146

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/document-info-drawer/components/DocumentInfoDrawer.vue
+++ b/documents-webapp/src/main/webapp/vue-app/document-info-drawer/components/DocumentInfoDrawer.vue
@@ -16,6 +16,7 @@
         parent-element="div"
         element="div" />
       <documents-favorite-button
+        v-if="!file.folder"
         :id="fileId"
         :file="file"
         :small="false"


### PR DESCRIPTION
This commit hides the favorite icon on the Detail drawer for folders.