### PR TITLE
feat: migrate statistic fields to typed collection API - EXO-87596

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/listener/AnalyticsAddTagListener.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/listener/AnalyticsAddTagListener.java
@@ -1,47 +1,52 @@
 package org.exoplatform.documents.listener;
 
+import java.util.Date;
+import java.util.Set;
+
 import org.apache.commons.lang3.StringUtils;
-import io.meeds.analytics.model.StatisticData;
-import io.meeds.analytics.utils.AnalyticsUtils;
+
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.services.security.Identity;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.metadata.tag.model.TagName;
 import org.exoplatform.social.metadata.tag.model.TagObject;
 
-import java.util.Date;
-import java.util.Set;
+import io.meeds.analytics.model.StatisticData;
 
 public class AnalyticsAddTagListener extends Listener<TagObject, Set<TagName>> {
 
-    private IdentityManager identityManager;
+  private IdentityManager identityManager;
 
-    public AnalyticsAddTagListener(IdentityManager identityManager) {
-        this.identityManager = identityManager;
+  private UserACL         userAcl;
+
+  public AnalyticsAddTagListener(UserACL userAcl,
+                                 IdentityManager identityManager) {
+    this.identityManager = identityManager;
+    this.userAcl = userAcl;
+  }
+
+  @Override
+  public void onEvent(Event<TagObject, Set<TagName>> event) throws Exception {
+    TagObject tagObject = event.getSource();
+    Set<TagName> tagNames = event.getData();
+    long userId = 0;
+    if (ConversationState.getCurrent() != null
+        && !userAcl.isAnonymousUser(ConversationState.getCurrent().getIdentity())) {
+      Identity identity = ConversationState.getCurrent().getIdentity();
+      String currentUser = identity.getUserId();
+      userId = Long.parseLong(identityManager.getOrCreateUserIdentity(currentUser).getId());
     }
-
-
-
-    @Override
-    public void onEvent(Event<TagObject, Set<TagName>> event) throws Exception {
-        TagObject tagObject = event.getSource();
-        Set<TagName> tagNames = event.getData();
-        int numberOfTags = tagNames.size();
-        String currentUser = ConversationState.getCurrent().getIdentity().getUserId();
-        long userId = Long.parseLong(identityManager.getOrCreateUserIdentity(currentUser).getId());
-        StatisticData statisticData = new StatisticData();
-        statisticData.setModule("portal");
-        statisticData.setSubModule("ui");
-        statisticData.setOperation("Add tag");
-        statisticData.setTimestamp(new Date().getTime());
-        statisticData.setUserId(userId);
-        statisticData.addParameter("username", currentUser);
-        statisticData.addParameter("dataType", StringUtils.lowerCase(tagObject.getType()));
-        statisticData.addParameter("spaceId", tagObject.getSpaceId());
-
-        for (int i = 0; i < numberOfTags; i++) {
-            AnalyticsUtils.addStatisticData(statisticData);
-        }
-    }
+    StatisticData statisticData = new StatisticData();
+    statisticData.setModule("portal");
+    statisticData.setSubModule("ui");
+    statisticData.setOperation("Add tag");
+    statisticData.setUserId(userId);
+    statisticData.setSpaceId(tagObject.getSpaceId());
+    statisticData.setTimestamp(new Date().getTime());
+    statisticData.addKeyword("dataType", StringUtils.lowerCase(tagObject.getType()));
+    statisticData.addKeywords("tagName", tagNames);
+  }
 }

--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -638,13 +638,13 @@ public class DocumentFileServiceImpl implements DocumentFileService {
     if (!stats.isEmpty()) {
       StatisticData toStat = stats.get(0);
       documentsSize.setOwnerId(ownerId);
-      documentsSize.setToSize(Long.parseLong(String.valueOf(toStat.getParameters().get("size"))));
+      documentsSize.setToSize(Long.parseLong(String.valueOf(getStatisticParameter(toStat, "size"))));
       documentsSize.setToSizeDate(toStat.getTimestamp());
       documentsSize.setTodaySize(simpleDateFormat.format(new Date())
                                                  .equals(simpleDateFormat.format(new Date(toStat.getTimestamp()))));
       if (stats.size() > 1) {
         StatisticData fromStat = stats.get(stats.size() - 1);
-        documentsSize.setFromSize(Long.parseLong(String.valueOf(fromStat.getParameters().get("size"))));
+        documentsSize.setFromSize(Long.parseLong(String.valueOf(getStatisticParameter(fromStat, "size"))));
         documentsSize.setFromSizeDate(fromStat.getTimestamp());
         LocalDateTime date = LocalDateTime.ofInstant(Instant.ofEpochMilli(fromStat.getTimestamp()), ZoneId.systemDefault());
         long diff = ChronoUnit.DAYS.between(date, to);
@@ -672,7 +672,7 @@ public class DocumentFileServiceImpl implements DocumentFileService {
     }
     if (ownerIdentity.isSpace()) {
       Space space = spaceService.getSpaceByPrettyName(ownerIdentity.getRemoteId());
-      statisticData.addParameter("spaceId", space.getId());
+      statisticData.setSpaceId(space.getSpaceId());
       if (!spaceService.hasAccessPermission(space, currentUserIdentity.getRemoteId())) {
         throw new IllegalAccessException("Current user with identity id : " + userIdentityId
             + " attempts to calculate size of documents of space with identity id " + ownerId + " while it's not a member");
@@ -684,8 +684,8 @@ public class DocumentFileServiceImpl implements DocumentFileService {
     statisticData.setSubModule("Documents");
     statisticData.setOperation("documentsSize");
     statisticData.setTimestamp(new Date().getTime());
-    statisticData.addParameter("ownerId", ownerId);
-    statisticData.addParameter("size", size);
+    statisticData.addKeyword("ownerId", ownerId);
+    statisticData.addLong("size", size);
     AnalyticsUtils.addStatisticData(statisticData);
     DocumentsSize documentsSize = getDocumentsSizeStat(ownerId, userIdentityId);
     documentsSize.setTodaySize(true);
@@ -833,6 +833,20 @@ public class DocumentFileServiceImpl implements DocumentFileService {
   @Override
   public List<Long> getDocumentCategoryIds(long spaceIdentityId, String userName) {
     return documentFileStorage.getDocumentCategoryIds(spaceIdentityId, getAclUserIdentity(userName));
+  }
+
+  private Object getStatisticParameter(StatisticData statisticData, String fieldName) {
+    if (statisticData == null || statisticData.getParameters() == null || StringUtils.isBlank(fieldName)) {
+      return null;
+    }
+    Map<String, Object> parameters = statisticData.getParameters();
+    for (int i = AnalyticsUtils.MAX_ALTERNATIVE_FIELD_COUNT; i >= 1; i--) {
+      String alternativeFieldName = AnalyticsUtils.getAlternativeFieldName(fieldName, i);
+      if (parameters.containsKey(alternativeFieldName)) {
+        return parameters.get(alternativeFieldName);
+      }
+    }
+    return parameters.get(fieldName);
   }
 
   private CategoryLinkService getCategoryLinkService() {


### PR DESCRIPTION
Replace deprecated StatisticData#addParameter usages with explicit typed APIs across product modules.

Use addKeyword/addKeywords for identifiers and labels, addLong for numeric aggregation fields, and typed collection variants where needed. This makes the intended Elasticsearch mapping explicit at producer level and avoids accidental field type changes or unnecessary *_alt mapping creation.