### PR TITLE
fix: Close Document Contextual Menu when sub Menu Clicked - EXO-87628

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DocumentActionItem.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DocumentActionItem.vue
@@ -26,7 +26,7 @@
       dense
       link
       class="ps-3"
-      @click.stop.prevent="$emit('click')">
+      @click.stop.prevent="handleClick">
       <v-list-item-icon class="me-2">
         <v-icon
           :class="iconExtraClass"
@@ -88,6 +88,14 @@ export default {
       type: Boolean,
       default: false
     }
-  }
+  },
+  methods: {
+    handleClick() {
+      this.$emit('click');
+      if (!this.isGroup) {
+        this.$root.$emit('close-action-context-menu');
+      }
+    },
+  },
 };
 </script>

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionContextMenu.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/DocumentActionContextMenu.vue
@@ -47,6 +47,7 @@ export default {
     document.addEventListener('contextmenu', this.handleMenuClose);
     this.$root.$on('open-action-context-menu', this.openMenu);
     this.$root.$on('prevent-action-context-menu', this.handlePreventMenu);
+    this.$root.$on('close-action-context-menu', this.handlePreventMenu);
     this.$root.$on('selection-documents-list-updated', this.handleUpdateSelected);
     this.$root.$on('set-action-loading', this.closeMenu);
     this.$root.$on('close-file-action-menu', this.closeMenu);
@@ -54,6 +55,7 @@ export default {
   beforeDestroy() {
     this.$root.$off('open-action-context-menu', this.openMenu);
     this.$root.$off('selection-documents-list-updated', this.handleUpdateSelected);
+    this.$root.$off('close-action-context-menu', this.openMenu);
     this.$root.$off('prevent-action-context-menu', this.handlePreventMenu);
     this.$root.$off('set-action-loading', this.closeMenu);
     this.$root.$off('close-file-action-menu', this.closeMenu);


### PR DESCRIPTION
Prior to this change, when clicking on a sub menu item, the principal menu still remains opened. This change apply a modification on the reusable Menu Item Component to ensure closing the parent menu when a sub menu is clicked.