### PR TITLE
fix: Accessibility - The image of Hide/display treeview has no label - EXO-87382

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -1,26 +1,22 @@
 <template>
   <div v-if="documentsBreadcrumbList.length" class="documents-breadcrumb-wrapper">
     <div class="documents-tree-items d-flex align-center">
-      <v-tooltip v-if="!treeViewExpended || isMobile" bottom>
-        <template #activator="{ on, attrs }">
-          <v-btn
-            icon
-            v-bind="attrs"
-            v-on="on"
-            class="me-2 ms-n2"
-            :disabled="disabledIconTree"
-            @click.stop.prevent="openTreeView()">
-            <img
-              src="/social/images/sidebar.svg"
-              class="icon-default-color pb-1"
-              height="20px"
-              width="20px">
-          </v-btn>
-        </template>
-        <span class="caption">
-          {{ $t('documents.tooltip.open.tree') }}
-        </span>
-      </v-tooltip>
+      <v-btn
+        v-if="!treeViewExpended || isMobile"
+        icon
+        v-bind="attrs"
+        v-on="on"
+        class="me-2 ms-n2"
+        :disabled="disabledIconTree"
+        @click.stop.prevent="openTreeView()">
+        <img
+          alt=""
+          :title="$t('documents.tooltip.open.tree')"
+          src="/social/images/sidebar.svg"
+          class="icon-default-color pb-1"
+          height="20px"
+          width="20px">
+      </v-btn>
       <div
         v-if="!isMobile"
         id="breadcrumb-list-items"

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/FolderTreeView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/FolderTreeView.vue
@@ -26,24 +26,19 @@
     <v-card-title class="pa-0 border-bottom-color"> 
       <span v-if="!treeViewExpended" class="text-header">{{ $t('documents.tree.title') }}</span>
       <v-spacer />
-      <v-tooltip bottom>
-        <template #activator="{ on, attrs }">
-          <v-btn
-            icon
-            v-bind="attrs"
-            v-on="on"
-            @click.stop.prevent="$root.$emit('tree-view-expend', false)">
-            <img
-              src="/social/images/sidebar.svg"
-              class="icon-default-color mb-1"
-              height="20px"
-              width="20px">
-          </v-btn>
-        </template>
-        <span class="caption">
-          {{ $t('documents.tooltip.close.tree') }}
-        </span>
-      </v-tooltip>
+      <v-btn
+        icon
+        v-bind="attrs"
+        v-on="on"
+        @click.stop.prevent="$root.$emit('tree-view-expend', false)">
+        <img
+          alt=""
+          :title="$t('documents.tooltip.close.tree')"
+          src="/social/images/sidebar.svg"
+          class="icon-default-color mb-1"
+          height="20px"
+          width="20px">
+      </v-btn>
     </v-card-title>
     <v-card-text class="px-0">
       <document-tree-view


### PR DESCRIPTION
Prior to this fix, the Hide/display treeview button contained an image without an alt property. 
This commit resolves the accessibility issue by adding alt and title properties to the image.