### PR TITLE
fix: Avoid using SessionProviderService in Async Jobs - EXO-87829

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/service/DocumentFileServiceImpl.java
@@ -100,8 +100,6 @@ public class DocumentFileServiceImpl implements DocumentFileService {
 
   private NodeHierarchyCreator   nodeHierarchyCreator;
 
-  private SessionProviderService sessionProviderService;
-
   private static final String    DEFAULT_GROUPS_HOME_PATH = "/Groups";
 
   private static final String    GROUPS_PATH_ALIAS        = "groupsPath";
@@ -137,7 +135,6 @@ public class DocumentFileServiceImpl implements DocumentFileService {
     this.imageThumbnailService = imageThumbnailService;
     this.repositoryService = repositoryService;
     this.nodeHierarchyCreator = nodeHierarchyCreator;
-    this.sessionProviderService = sessionProviderService;
   }
 
   @Override
@@ -865,11 +862,10 @@ public class DocumentFileServiceImpl implements DocumentFileService {
     if (space == null) {
       return;
     }
-    SessionProvider sessionProvider = null;
+    Session session = null;
     try {
       ManageableRepository repository = repositoryService.getCurrentRepository();
-      sessionProvider = sessionProviderService.getSystemSessionProvider(null);
-      Session session = sessionProvider.getSession(repository.getConfiguration().getDefaultWorkspaceName(), repository);
+      session = repository.getSystemSession(repository.getConfiguration().getDefaultWorkspaceName());
       Node spaceRootNode = getGroupNode(session, space.getGroupId());
       if (spaceRootNode != null) {
         synchronizeNodePermissions(space, targetRedactionalMode, spaceRootNode);
@@ -880,8 +876,8 @@ public class DocumentFileServiceImpl implements DocumentFileService {
     } catch (Exception e) {
       LOG.error("Error updating permissions of space width id '{}'", space.getId(), e);
     } finally {
-      if (sessionProvider != null) {
-        sessionProvider.close();
+      if (session != null) {
+        session.logout();
       }
     }
   }


### PR DESCRIPTION
Prior to this change, the Space Synchronization Operation was used in the Upgrade Plugin which will retrieve JCR System sessions from a shared location, SessionProviderService. This can lead to have a closed System Session Provider which will cause the migration to not proceed. This change ensures to retrieve the system session from the RepositoryService directly to avoid such an error.