### PR TITLE
fix: include symlink target paths in ES search queries - EXO-67331

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -434,7 +434,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
 
   private List<String> findSymlinkTargetPaths(Session session, String path) throws RepositoryException {
     List<String> targetPaths = new ArrayList<>();
-    String query = "SELECT * FROM nt:base WHERE jcr:path LIKE '" + path + "/%' AND jcr:primaryType = 'exo:symlink'";
+    String query = "SELECT * FROM exo:symlink WHERE jcr:path LIKE '" + path + "/%'";
     Query jcrQuery = session.getWorkspace().getQueryManager().createQuery(query, Query.SQL);
     QueryResult queryResult = jcrQuery.execute();
     NodeIterator nodeIterator = queryResult.getNodes();
@@ -442,17 +442,8 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
     while (nodeIterator.hasNext()) {
       Node symlink = nodeIterator.nextNode();
       try {
-        Node targetNode = getNodeByIdentifier(session, symlink.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString());
-        if (targetNode == null) {
-          continue;
-        }
-        while (targetNode.isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
-          targetNode = getNodeByIdentifier(session, targetNode.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString());
-          if (targetNode == null) {
-            break;
-          }
-        }
-        if (targetNode == null || targetNode.isNodeType(NodeTypeConstants.NT_FILE)) {
+        Node targetNode = resolveSymlinks(session, symlink);
+        if (targetNode == null || !(targetNode.isNodeType(NodeTypeConstants.NT_UNSTRUCTURED) || targetNode.isNodeType(NodeTypeConstants.NT_FOLDER))) {
           continue;
         }
         String targetPath = targetNode.getPath();
@@ -2964,6 +2955,26 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         throw new ItemNotFoundException();
       }
     }
+  }
+
+  private Node resolveSymlinks(Session session, Node symlink) throws RepositoryException {
+    Node targetNode = getNodeByIdentifier(session, symlink.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString());
+    if (targetNode == null) {
+      return null;
+    }
+    List<String> nodeIds = new ArrayList<>();
+    while (targetNode.isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
+      String nodeId = targetNode.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString();
+      if (nodeIds.contains(nodeId)) {
+        break;
+      }
+      nodeIds.add(nodeId);
+      targetNode = getNodeByIdentifier(session, nodeId);
+      if (targetNode == null) {
+        break;
+      }
+    }
+    return targetNode;
   }
 
 }

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorage.java
@@ -320,9 +320,12 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         String sortField = getSortField(filter, false);
         String sortDirection = getSortDirection(filter);
 
+        List<String> paths = new ArrayList<>();
+        paths.add(rootPath);
+        paths.addAll(findSymlinkTargetPaths(session, rootPath));
         Collection<DocumentFileSearchResult> filesSearchList = documentSearchServiceConnector.search(aclIdentity,
                                                                                                      workspace,
-                                                                                                     rootPath,
+                                                                                                     paths,
                                                                                                      filter,
                                                                                                      offset,
                                                                                                      limit,
@@ -382,6 +385,7 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
       sessionProvider = getUserSessionProvider(repositoryService, identity);
       ManageableRepository repository = repositoryService.getCurrentRepository();
       Session session = sessionProvider.getSession(repository.getConfiguration().getDefaultWorkspaceName(), repository);
+      List<String> paths = new ArrayList<>();
       String path = "/";
       if (StringUtils.isNotBlank(filter.getParentFolderId())) {
         Node parent = getNodeByIdentifier(session, filter.getParentFolderId());
@@ -405,9 +409,11 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         }
         path = identityRootNode.getPath();
       }
+      paths.add(path);
+      paths.addAll(findSymlinkTargetPaths(session, path));
       Collection<DocumentFileSearchResult> results = documentSearchServiceConnector.search(identity,
                                                                                            COLLABORATION,
-                                                                                           path,
+                                                                                           paths,
                                                                                            filter,
                                                                                            offset,
                                                                                            limit,
@@ -424,6 +430,41 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
         sessionProvider.close();
       }
     }
+  }
+
+  private List<String> findSymlinkTargetPaths(Session session, String path) throws RepositoryException {
+    List<String> targetPaths = new ArrayList<>();
+    String query = "SELECT * FROM nt:base WHERE jcr:path LIKE '" + path + "/%' AND jcr:primaryType = 'exo:symlink'";
+    Query jcrQuery = session.getWorkspace().getQueryManager().createQuery(query, Query.SQL);
+    QueryResult queryResult = jcrQuery.execute();
+    NodeIterator nodeIterator = queryResult.getNodes();
+    Set<String> seen = new HashSet<>();
+    while (nodeIterator.hasNext()) {
+      Node symlink = nodeIterator.nextNode();
+      try {
+        Node targetNode = getNodeByIdentifier(session, symlink.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString());
+        if (targetNode == null) {
+          continue;
+        }
+        while (targetNode.isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
+          targetNode = getNodeByIdentifier(session, targetNode.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString());
+          if (targetNode == null) {
+            break;
+          }
+        }
+        if (targetNode == null || targetNode.isNodeType(NodeTypeConstants.NT_FILE)) {
+          continue;
+        }
+        String targetPath = targetNode.getPath();
+        if (!seen.contains(targetPath)) {
+          seen.add(targetPath);
+          targetPaths.add(targetPath);
+        }
+      } catch (RepositoryException e) {
+        LOG.debug("Symlink target not found for symlink at {}", symlink.getPath(), e);
+      }
+    }
+    return targetPaths;
   }
 
   @Override
@@ -682,9 +723,13 @@ public class JCRDocumentFileStorage implements DocumentFileStorage {
           String workspace = session.getWorkspace().getName();
           String sortField = getSortField(filter, false);
           String sortDirection = getSortDirection(filter);
+
+          List<String> paths = new ArrayList<>();
+          paths.add(parent.getPath());
+          paths.addAll(findSymlinkTargetPaths(session, parent.getPath()));
           Collection<DocumentFileSearchResult> filesSearchList = documentSearchServiceConnector.search(aclIdentity,
                                                                                                        workspace,
-                                                                                                       parent.getPath(),
+                                                                                                       paths,
                                                                                                        filter,
                                                                                                        offset,
                                                                                                        limit,

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
@@ -185,6 +185,17 @@ public class DocumentSearchServiceConnector {
                                                      int limit,
                                                      String sortField,
                                                      String sortDirection) {
+    return search(userIdentity, workspace, List.of(path), filter, offset, limit, sortField, sortDirection);
+  }
+
+  public Collection<DocumentFileSearchResult> search(Identity userIdentity,
+                                                     String workspace,
+                                                     List<String> paths,
+                                                     DocumentNodeFilter filter,
+                                                     int offset,
+                                                     int limit,
+                                                     String sortField,
+                                                     String sortDirection) {
     if (userIdentity == null) {
       throw new IllegalArgumentException("Viewer identity is mandatory");
     }
@@ -214,7 +225,7 @@ public class DocumentSearchServiceConnector {
         sortField = "_score";
     }
 
-    String esQuery = buildQueryStatement(userIdentity, workspace, path, filter, sortField, sortDirection, false, offset, limit);
+    String esQuery = buildQueryStatement(userIdentity, workspace, paths, filter, sortField, sortDirection, false, offset, limit);
     String jsonResponse = this.client.sendRequest(esQuery, this.index);
     return buildResult(jsonResponse);
   }
@@ -255,12 +266,16 @@ public class DocumentSearchServiceConnector {
   }
 
   public long getTotalSize(Identity userIdentity, String workspace, String path) {
+    return getTotalSize(userIdentity, workspace, List.of(path));
+  }
+
+  public long getTotalSize(Identity userIdentity, String workspace, List<String> paths) {
     if (userIdentity == null) {
       throw new IllegalArgumentException("Viewer identity is mandatory");
     }
     String esQuery = buildQueryStatement(userIdentity,
                                          workspace,
-                                         path,
+                                         paths,
                                          new DocumentTimelineFilter(),
                                          "lastUpdatedDate",
                                          "ASC",
@@ -293,7 +308,7 @@ public class DocumentSearchServiceConnector {
 
   private String buildQueryStatement(Identity userIdentity,
                                      String workspace,
-                                     String path,
+                                     List<String> paths,
                                      DocumentNodeFilter filter,
                                      String sortField,
                                      String sortDirection,
@@ -307,9 +322,6 @@ public class DocumentSearchServiceConnector {
     String termQuery = buildTermQueryStatement(filter.getQuery(), BooleanUtils.isTrue(filter.isExtendedSearch()));
     String favoriteQuery = buildFavoriteQueryStatement(metadataFilters.get(FavoriteService.METADATA_TYPE.getName()));
     String categoryQuery = buildCategoryIdQueryStatement(filter);
-    if (StringUtils.isNotEmpty(path) && !path.endsWith("/")) {
-      path += "/";
-    }
     return retrieveSearchQuery().replace("@term_query@", termQuery)
                                 .replace("@favorite_query@", favoriteQuery)
                                 .replace("@category_query@", categoryQuery)
@@ -317,13 +329,41 @@ public class DocumentSearchServiceConnector {
                                 .replace("@fileTypes_query@", getFileTypesQuery(filter))
                                 .replace("@size_query@", getSizeQuery(filter))
                                 .replace("@date_query@", getDatesQuery(filter))
-                                .replace("@path@", path)
+                                .replace("@path_filter@", buildPathFilter(paths))
                                 .replace("@workspace@", workspace)
                                 .replace("@size_agg@", getSizeAgg(getTotalSize))
                                 .replace("@sort_field@", sortField)
                                 .replace("@sort_direction@", sortDirection)
                                 .replace("@offset@", String.valueOf(offset))
                                 .replace("@limit@", getLimit(limit));
+  }
+
+  private String buildPathFilter(List<String> paths) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{\n");
+    sb.append("  \"bool\": {\n");
+    sb.append("    \"should\": [\n");
+    for (int i = 0; i < paths.size(); i++) {
+      String path = paths.get(i);
+      if (StringUtils.isNotEmpty(path) && !path.endsWith("/")) {
+        path += "/";
+      }
+      if (i > 0) {
+        sb.append(",\n");
+      }
+      sb.append("      {\n");
+      sb.append("        \"prefix\": {\n");
+      sb.append("          \"path\": {\n");
+      sb.append("            \"value\": \"").append(path).append("\"\n");
+      sb.append("          }\n");
+      sb.append("        }\n");
+      sb.append("      }");
+    }
+    sb.append("\n");
+    sb.append("    ]\n");
+    sb.append("  }\n");
+    sb.append("}");
+    return sb.toString();
   }
 
   private String getFileTypesQuery(DocumentNodeFilter filter) {

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnector.java
@@ -360,7 +360,8 @@ public class DocumentSearchServiceConnector {
       sb.append("      }");
     }
     sb.append("\n");
-    sb.append("    ]\n");
+    sb.append("    ],\n");
+    sb.append("    \"minimum_should_match\": 1\n");
     sb.append("  }\n");
     sb.append("}");
     return sb.toString();

--- a/documents-storage-jcr/src/main/resources/documents-search-query.json
+++ b/documents-storage-jcr/src/main/resources/documents-search-query.json
@@ -63,19 +63,7 @@
                   ]
                 }
               },
-              {
-                "bool": {
-                  "should": [
-                    {
-                      "prefix": {
-                        "path": {
-                          "value": "@path@"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
+              @path_filter@
             ]
           }
         }

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/JCRDocumentFileStorageTest.java
@@ -491,7 +491,7 @@ public class JCRDocumentFileStorageTest {
     JCR_DOCUMENTS_UTIL.when(() -> JCRDocumentsUtil.getSortDirection(filter)).thenCallRealMethod();
     jcrDocumentFileStorage.getFolderChildNodes(filter, identity, 0, 0);
     verify(documentSearchServiceConnector,
-           times(1)).search(identity, "collaboration", "/documents/path", filter, 0, 0, "lastUpdatedDate", "ASC");
+           times(1)).search(identity, "collaboration", List.of("/documents/path"), filter, 0, 0, "lastUpdatedDate", "ASC");
 
   }
 

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnectorTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnectorTest.java
@@ -121,6 +121,19 @@ public class DocumentSearchServiceConnectorTest {
     String path = "/Groups/spaces/test/Documents/";
     String sort_field = "title";
     String sort_direction = "ASC";
+    String pathFilter = "{\n" +
+                        "  \"bool\": {\n" +
+                        "    \"should\": [\n" +
+                        "      {\n" +
+                        "        \"prefix\": {\n" +
+                        "          \"path\": {\n" +
+                        "            \"value\": \"" + path + "\"\n" +
+                        "          }\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    ]\n" +
+                        "  }\n" +
+                        "}";
     String expectedQuery = SEARCH_QUERY.replace("@term_query@", SEARCH_QUERY_TERM.replace(QUERY_TAG_TERM, filter.getQuery()))
                                        .replace("@favorite_query@", "")
                                        .replace("@category_query@", "")
@@ -128,7 +141,7 @@ public class DocumentSearchServiceConnectorTest {
                                        .replace("@fileTypes_query@", "")
                                        .replace("@size_query@", "")
                                        .replace("@date_query@", "")
-                                       .replace("@path@", path)
+                                       .replace("@path_filter@", pathFilter)
                                        .replace("@workspace@", WORKSPACE)
                                        .replace("@size_agg@", getSizeAgg(false))
                                        .replace("@sort_field@", sort_field + ".raw")

--- a/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnectorTest.java
+++ b/documents-storage-jcr/src/test/java/org/exoplatform/documents/storage/jcr/search/DocumentSearchServiceConnectorTest.java
@@ -131,7 +131,8 @@ public class DocumentSearchServiceConnectorTest {
                         "          }\n" +
                         "        }\n" +
                         "      }\n" +
-                        "    ]\n" +
+                        "    ],\n" +
+                        "    \"minimum_should_match\": 1\n" +
                         "  }\n" +
                         "}";
     String expectedQuery = SEARCH_QUERY.replace("@term_query@", SEARCH_QUERY_TERM.replace(QUERY_TAG_TERM, filter.getQuery()))


### PR DESCRIPTION
This change will add symlink target path resolution to Elasticsearch document search queries.