### PR TITLE
fix: Renaming folder/document is KO with Firefox - EXO-75976 (#1967)

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileEditNameCell.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/table/cells/DocumentsFileEditNameCell.vue
@@ -84,6 +84,12 @@ export default {
       }
     });
   },
+  mounted() {
+    this.$root.$emit('documents-file-name-edit', true);
+  },
+  beforeDestroy() {
+    this.$root.$emit('documents-file-name-edit', false);
+  },
   methods: {
     editTitle(){
       this.editNameMode=true;

--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderListView.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsFolderListView.vue
@@ -97,10 +97,10 @@
                   :key="item.id">
                   <tr
                     :class="isDocumentSelected(item)? 'v-data-table__selected': ''"
-                    draggable="true"
                     :data-fileId="item.id"
                     :data-isFolder="item.folder? 'true': 'false'"
                     :data-canEdit="canEditFile(item)? 'true': 'false'"
+                    :draggable="!editName"
                     @mouseover="showSelectionInput(item)"
                     @mouseleave="hideSelectionInput(item)"
                     @contextmenu="openContextMenu($event, item)">
@@ -277,6 +277,7 @@ export default {
     showSelectInputTimer: null,
     treeViewExpended: true,
     hoverTable: false,
+    editName: false,
   }),
   computed: {
     isXScreen() {
@@ -360,6 +361,7 @@ export default {
     this.$root.$on('documents-filter', this.updateFilter);
     this.$root.$on('tree-view-expend', this.extendTreeView );
     this.$root.$on('loading-documents', this.setLoading);
+    this.$root.$on('documents-file-name-edit', this.setEditName);
   },
   mounted(){
     this.$documentsUtils.injectSortTooltip(this.$t('documents.sort.tooltip'),'tooltip-marker');
@@ -370,8 +372,12 @@ export default {
     this.$root.$off('tree-view-expend', this.extendTreeView);
     this.$root.$off('openTreeFolderDrawer', this.folderTreeDrawer);
     this.$root.$off('loading-documents', this.setLoading);
+    this.$root.$off('documents-file-name-edit', this.setEditName);
   },
   methods: {
+    setEditName(value) {
+      this.editName = value;
+    },
     extendTreeView(value) {
       this.treeViewExpended = value;
       localStorage.setItem('expendedTreeView', value);


### PR DESCRIPTION
Before this change, clicking inside the text box to rename a document or folder always forced the cursor to the end of the text. To fix this issue, manage the draggable property of the element. disable it (draggable = false) at the beginning of the edit mode to let the browser naturally handle the mouse text insertion, and restore it (draggable = true) once the edit mode is completed or cancelled. After this change, using mouse, cursor is pointing on name elements chosen position.

(cherry picked from commit b4e0993a2b826aa7789a28306c9fa132c5b72418)