### PR TITLE
fix: show attached documents in activity update drawer - EXO-87965

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/attachment/components/activity/ActivityComposerAttachments.vue
+++ b/documents-webapp/src/main/webapp/vue-app/attachment/components/activity/ActivityComposerAttachments.vue
@@ -92,6 +92,9 @@ export default {
     document.addEventListener('attachment-removed', this.removeAttachment);
     document.addEventListener('message-composer-opened', this.openComposerChangesReminder);
     document.dispatchEvent(new CustomEvent('activity-composer-ready'));
+    if (this.files?.length) {
+      this.retrieveAttachments();
+    }
   },
   beforeDestroy() {
     document.removeEventListener('open-activity-attachments', this.openAttachmentDrawer);


### PR DESCRIPTION
This change well call retrieveAttachments() on mount when files are already present.