### PR TITLE
fix: folder treeview can't be opened if closed - EXO-88171

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/views/DocumentsBreadcrumb.vue
@@ -1,6 +1,22 @@
 <template>
   <div v-if="documentsBreadcrumbList.length" class="documents-breadcrumb-wrapper">
     <div class="documents-tree-items d-flex align-center">
+      <v-btn
+        v-if="showIcon && (!treeViewExpended || isMobile)"
+        icon
+        v-bind="attrs"
+        v-on="on"
+        class="me-2 ms-n2"
+        :disabled="disabledIconTree"
+        @click.stop.prevent="openTreeView()">
+        <img
+          alt=""
+          :title="$t('documents.tooltip.open.tree')"
+          src="/social/images/sidebar.svg"
+          class="icon-default-color pb-1"
+          height="20px"
+          width="20px">
+      </v-btn>
       <div
         v-if="!isMobile"
         id="breadcrumb-list-items"
@@ -95,6 +111,10 @@ export default {
     move: {
       type: Boolean,
       default: false,
+    },
+    treeViewExpended: {
+      type: String,
+      default: null,
     },
     isMobile: {
       type: Boolean,
@@ -334,6 +354,14 @@ export default {
         this.getFolderPath(folderPath);
       } else {
         this.getDocumentDataFromUrl();
+      }
+    },
+    openTreeView() {
+      if (this.isMobile) {
+        this.$root.$emit('documentsBreadcrumb',this.documentsBreadcrumb);
+        this.$root.$emit('openTreeFolderDrawer',this.showHidden);
+      } else {
+        this.$root.$emit('tree-view-expend', true);
       }
     },
     initDocumentsBreadcrumb() {


### PR DESCRIPTION
Prior to this fix, folder treeview can't be opened if closed . This commit add the open button.

(cherry picked from commit 3c779d9962fc2c9aa55140c44056991bd8a02dbe)