### PR TITLE
fix: allow folder creator to be saved as collaborator - EXO-87517

### DIFF
--- a/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
+++ b/documents-services/src/main/java/org/exoplatform/documents/rest/util/EntityBuilder.java
@@ -349,7 +349,11 @@ public class EntityBuilder {
     Map<String, PermissionEntryEntity> map = new HashMap<>();
     List<PermissionEntry> permissions = nodePermission.getPermissions();
     for(PermissionEntry permissionEntry : permissions){
-      if(permissionEntry.getIdentity().getId().equals(String.valueOf(node.getCreatorId()))){
+      // the creator always implicitly gets full access on its own node, so hide that
+      // default grant from the collaborators list. Only when it was narrowed down to
+      // "read" is it the result of the creator being explicitly added as a collaborator.
+      if(permissionEntry.getIdentity().getId().equals(String.valueOf(node.getCreatorId()))
+          && isEditPermission(permissionEntry.getPermission())){
         continue;
       }
       if(identity != null && permissionEntry.getIdentity().getId().equals(identity.getId())){
@@ -405,26 +409,23 @@ public class EntityBuilder {
       String invitedGroupId = null;
 
       for(PermissionEntryEntity permissionEntryEntity : collaborators){
-        Identity ownerId = getOwnerIdentityFromNodePath(node.getPath(), identityManager, spaceService);
-        if(ownerId != null && !ownerId.getId().equals(permissionEntryEntity.getIdentity().getId())) {
-          if (permissionEntryEntity.getIdentity().getProviderId().equals("space")) {
-            toShare.put(Long.valueOf(identityManager.getOrCreateSpaceIdentity(permissionEntryEntity.getIdentity().getRemoteId()).getId()), permissionEntryEntity.getPermission());
+        if (permissionEntryEntity.getIdentity().getProviderId().equals("space")) {
+          toShare.put(Long.valueOf(identityManager.getOrCreateSpaceIdentity(permissionEntryEntity.getIdentity().getRemoteId()).getId()), permissionEntryEntity.getPermission());
+          permissions.add(toPermissionEntry(permissionEntryEntity, identityManager));
+        } else if(permissionEntryEntity.getIdentity().getProviderId().equals("group")){
             permissions.add(toPermissionEntry(permissionEntryEntity, identityManager));
-          } else if(permissionEntryEntity.getIdentity().getProviderId().equals("group")){
-              permissions.add(toPermissionEntry(permissionEntryEntity, identityManager));
-          } else {
-            try {
-              //check if the owner is a space and the destination is a member of this space
-              if (ownerId.isSpace() && spaceService.isMember(spaceService.getSpaceByPrettyName(ownerId.getRemoteId()), permissionEntryEntity.getIdentity().getRemoteId())) {
-                toNotify.put(Long.valueOf(identityManager.getOrCreateUserIdentity(permissionEntryEntity.getIdentity().getRemoteId()).getId()),permissionEntryEntity.getPermission());
-                toShare.put(Long.valueOf(identityManager.getOrCreateUserIdentity(permissionEntryEntity.getIdentity().getRemoteId()).getId()),permissionEntryEntity.getPermission());
-              } else {
-                toShare.put(Long.valueOf(identityManager.getOrCreateUserIdentity(permissionEntryEntity.getIdentity().getRemoteId()).getId()),permissionEntryEntity.getPermission());
-              }
-              permissions.add(toPermissionEntry(permissionEntryEntity, identityManager));
-            } catch (Exception exception) {
-              LOG.error(exception.getMessage(), exception);
+        } else {
+          try {
+            //check if the owner is a space and the destination is a member of this space
+            if (identity.isSpace() && spaceService.isMember(spaceService.getSpaceByPrettyName(identity.getRemoteId()), permissionEntryEntity.getIdentity().getRemoteId())) {
+              toNotify.put(Long.valueOf(identityManager.getOrCreateUserIdentity(permissionEntryEntity.getIdentity().getRemoteId()).getId()),permissionEntryEntity.getPermission());
+              toShare.put(Long.valueOf(identityManager.getOrCreateUserIdentity(permissionEntryEntity.getIdentity().getRemoteId()).getId()),permissionEntryEntity.getPermission());
+            } else {
+              toShare.put(Long.valueOf(identityManager.getOrCreateUserIdentity(permissionEntryEntity.getIdentity().getRemoteId()).getId()),permissionEntryEntity.getPermission());
             }
+            permissions.add(toPermissionEntry(permissionEntryEntity, identityManager));
+          } catch (Exception exception) {
+            LOG.error(exception.getMessage(), exception);
           }
         }
       }

--- a/documents-services/src/test/java/org/exoplatform/documents/rest/util/EntityBuilderTest.java
+++ b/documents-services/src/test/java/org/exoplatform/documents/rest/util/EntityBuilderTest.java
@@ -4,9 +4,13 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
 import java.util.List;
 
+import org.exoplatform.documents.model.FileNode;
+import org.exoplatform.documents.model.PermissionEntry;
 import org.exoplatform.documents.model.PermissionRole;
+import org.exoplatform.documents.service.PublicDocumentAccessService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,6 +25,7 @@ import org.exoplatform.documents.rest.model.PermissionEntryEntity;
 import org.exoplatform.documents.rest.model.Visibility;
 import org.exoplatform.documents.service.DocumentFileService;
 import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
@@ -36,6 +41,9 @@ public class EntityBuilderTest {
 
     @Mock
     private IdentityManager identityManager;
+
+    @Mock
+    private PublicDocumentAccessService publicDocumentAccessService;
 
     @Before
     public void setUp() throws Exception {
@@ -76,9 +84,13 @@ public class EntityBuilderTest {
         nodePermissionEntity.setAllMembersCanEdit(false);
         NodePermission specificCollabotratorsNodePermission = EntityBuilder.toNodePermission(abstractNodeEntity,documentFileService, spaceService, identityManager);
         assertNotNull(specificCollabotratorsNodePermission);
-        assertEquals(PermissionRole.MANAGERS_REDACTORS_PUBLISHERS.name(), specificCollabotratorsNodePermission.getPermissions().get(0).getRole());
-        assertEquals(identity.getRemoteId(), specificCollabotratorsNodePermission.getPermissions().get(0).getIdentity().getRemoteId());
-        assertEquals("edit", specificCollabotratorsNodePermission.getPermissions().get(0).getPermission());
+        assertEquals(2, specificCollabotratorsNodePermission.getPermissions().size());
+        // collaborator entry is processed first
+        assertEquals(PermissionRole.ALL.name(), specificCollabotratorsNodePermission.getPermissions().get(0).getRole());
+        // space-wide managers/redactors permission is appended after collaborators
+        assertEquals(PermissionRole.MANAGERS_REDACTORS_PUBLISHERS.name(), specificCollabotratorsNodePermission.getPermissions().get(1).getRole());
+        assertEquals(identity.getRemoteId(), specificCollabotratorsNodePermission.getPermissions().get(1).getIdentity().getRemoteId());
+        assertEquals("edit", specificCollabotratorsNodePermission.getPermissions().get(1).getPermission());
 
         IdentityEntity useridentityEntity = new IdentityEntity();
         useridentityEntity.setId("1");
@@ -109,5 +121,56 @@ public class EntityBuilderTest {
         // assert to notify destination user
         assertNotNull(nodePermission3);
         assertEquals(Long.valueOf(useridentityEntity.getId()), nodePermission4.getToNotify().keySet().toArray()[0]);
+    }
+
+    @Test
+    public void toNodePermissionEntityShowsCreatorWhenExplicitlyAddedAsReadCollaborator() throws Exception {
+        Space space = new Space();
+        space.setPrettyName("testspace");
+        when(spaceService.getSpaceByGroupId("/spaces/testspace")).thenReturn(space);
+
+        Identity spaceIdentity = mock(Identity.class);
+        when(spaceIdentity.getId()).thenReturn("999");
+        when(spaceIdentity.isSpace()).thenReturn(true);
+        when(identityManager.getOrCreateSpaceIdentity("testspace")).thenReturn(spaceIdentity);
+
+        Identity creatorIdentity = mock(Identity.class);
+        when(creatorIdentity.getId()).thenReturn("42");
+        when(creatorIdentity.getRemoteId()).thenReturn("wilhelmine");
+        when(creatorIdentity.isUser()).thenReturn(true);
+        Profile profile = mock(Profile.class);
+        when(profile.getFullName()).thenReturn("Wilhelmine Abden");
+        when(creatorIdentity.getProfile()).thenReturn(profile);
+
+        FileNode node = new FileNode();
+        node.setId("fileId");
+        node.setPath("/Groups/spaces/testspace");
+        node.setCreatorId(42);
+        when(publicDocumentAccessService.hasDocumentPublicAccess("fileId")).thenReturn(false);
+
+        // Creator explicitly added as a read-only collaborator: the default owner grant is
+        // always full access, so a read-only entry can only come from an explicit choice
+        // and must show up in the collaborators list.
+        PermissionEntry readEntry = new PermissionEntry(creatorIdentity, "read", PermissionRole.ALL.name());
+        node.setAcl(new NodePermission(true, false, false, false, List.of(readEntry), null, null, null));
+        NodePermissionEntity readResult = invokeToNodePermissionEntity(node);
+        assertEquals(1, readResult.getCollaborators().size());
+        assertEquals("wilhelmine", readResult.getCollaborators().get(0).getIdentity().getRemoteId());
+
+        // Creator's implicit full-access owner grant must stay hidden from the collaborators list.
+        PermissionEntry editEntry = new PermissionEntry(creatorIdentity, "add_node,set_property,remove,read", PermissionRole.ALL.name());
+        node.setAcl(new NodePermission(true, true, false, false, List.of(editEntry), null, null, null));
+        NodePermissionEntity editResult = invokeToNodePermissionEntity(node);
+        assertEquals(0, editResult.getCollaborators().size());
+    }
+
+    private NodePermissionEntity invokeToNodePermissionEntity(FileNode node) throws Exception {
+        Method method = EntityBuilder.class.getDeclaredMethod("toNodePermissionEntity",
+                                                               org.exoplatform.documents.model.AbstractNode.class,
+                                                               IdentityManager.class,
+                                                               SpaceService.class,
+                                                               PublicDocumentAccessService.class);
+        method.setAccessible(true);
+        return (NodePermissionEntity) method.invoke(null, node, identityManager, spaceService, publicDocumentAccessService);
     }
 }


### PR DESCRIPTION
This change will removed the owner identity guard in toNodePermission that silently excluded any collaborator matching the folder's path-based owner, preventing the creator from being explicitly saved as a collaborator