### PR TITLE
fix: [WEBDAV] File name containing + can't be imported - EXO-88320

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/cache/CachedJcrWebDavService.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/cache/CachedJcrWebDavService.java
@@ -16,21 +16,13 @@
  */
 package org.exoplatform.documents.storage.jcr.webdav.cache;
 
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.GETLASTMODIFIED;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.MODIFICATION_PATTERN;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.REQUEST_ALL_PROPS;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.*;
 
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import javax.jcr.Session;
@@ -300,11 +292,20 @@ public class CachedJcrWebDavService extends JcrWebDavService {
     }
     String normalized = Arrays.stream(webDavPath.split("/"))
                               .filter(StringUtils::isNotBlank)
-                              .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
+                              .map(CachedJcrWebDavService::decodeUrlString)
                               .map(s -> URLEncoder.encode(s, StandardCharsets.UTF_8)
                                                   .replace("+", "%20"))
                               .collect(Collectors.joining("/"));
     return "/" + normalized;
+  }
+
+  /**
+   * Decodes a raw WebDAV path segment. Unlike {@link URLDecoder#decode(String, java.nio.charset.Charset)},
+   * which implements {@code application/x-www-form-urlencoded} semantics and wrongly turns a literal
+   * '+' into a space, this only unescapes percent-encoded sequences and leaves literal '+' untouched.
+   */
+  private static String decodeUrlString(String s) {
+    return URLDecoder.decode(s.replace("+", "%2B"), StandardCharsets.UTF_8);
   }
 
   private String getParentJcrPath(String jcrPath) {

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/PathCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/PathCommandHandler.java
@@ -16,30 +16,7 @@
  */
 package org.exoplatform.documents.storage.jcr.webdav.plugin;
 
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.CHECKEDIN;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.CHECKEDOUT;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.CHILDCOUNT;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.CREATIONDATE;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.DISPLAYNAME;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.GETCONTENTLENGTH;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.GETCONTENTTYPE;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.GETLASTMODIFIED;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.GET_ETAG;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.HASCHILDREN;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.ISCOLLECTION;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.ISFOLDER;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.ISROOT;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.ISVERSIONED;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.LOCKDISCOVERY;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.OWNER;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.PARENTNAME;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.PREDECESSORSET;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.RESOURCETYPE;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.SUCCESSORSET;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.SUPPORTEDLOCK;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.SUPPORTEDMETHODSET;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.VERSIONHISTORY;
-import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.VERSIONNAME;
+import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.*;
 
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -50,11 +27,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import javax.jcr.AccessDeniedException;
-import javax.jcr.Item;
-import javax.jcr.Node;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
+import javax.jcr.*;
 import javax.jcr.observation.ObservationManager;
 import javax.xml.namespace.QName;
 
@@ -248,7 +221,7 @@ public class PathCommandHandler {
       String[] pathParts = webDavPath.split("/");
       String identityPart = Arrays.stream(pathParts)
                                   .filter(StringUtils::isNotBlank)
-                                  .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
+                                  .map(this::decodeUrlString)
                                   .findFirst()
                                   .orElse(null);
       String identityId = null;
@@ -292,7 +265,7 @@ public class PathCommandHandler {
         Item existingItem = session.getItem(legacyChildJcrPath);
         if (existingItem instanceof Node existingNode) {
           String existingWebDavPath = getOrCreateWebDavPath(existingNode);
-          String decodedExistingWebDavPath = URLDecoder.decode(existingWebDavPath, StandardCharsets.UTF_8);
+          String decodedExistingWebDavPath = decodeUrlString(existingWebDavPath);
           String decodedExistingWebDavPathPrefix = StringUtils.removeEnd(decodedExistingWebDavPath, "/") + "/"; // NOSONAR
           if (webDavPath.startsWith(decodedExistingWebDavPathPrefix)
               || webDavPath.equals(decodedExistingWebDavPath)) {
@@ -314,7 +287,7 @@ public class PathCommandHandler {
     return Arrays.stream(webDavPath.split("/"))
                  .filter(StringUtils::isNotBlank)
                  .reduce((first, second) -> second)
-                 .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
+                 .map(this::decodeUrlString)
                  .orElse("");
   }
 
@@ -516,7 +489,7 @@ public class PathCommandHandler {
   private List<String> splitDecodedSegments(String relativeWebDavPath) {
     return Arrays.stream(relativeWebDavPath.split("/"))
                  .filter(StringUtils::isNotBlank)
-                 .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
+                 .map(this::decodeUrlString)
                  .toList();
   }
 
@@ -524,7 +497,7 @@ public class PathCommandHandler {
     String[] pathParts = webDavPath.split("/");
     return Arrays.stream(pathParts)
                  .filter(StringUtils::isNotBlank)
-                 .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
+                 .map(this::decodeUrlString)
                  .map(Utils::encodeNodeName)
                  .skip(1)
                  .collect(Collectors.joining("/"));
@@ -686,13 +659,22 @@ public class PathCommandHandler {
     return URLEncoder.encode(s, StandardCharsets.UTF_8).replace("+", "%20");
   }
 
+  /**
+   * Decodes a raw WebDAV path segment. Unlike {@link URLDecoder#decode(String, java.nio.charset.Charset)},
+   * which implements {@code application/x-www-form-urlencoded} semantics and wrongly turns a literal
+   * '+' into a space, this only unescapes percent-encoded sequences and leaves literal '+' untouched.
+   */
+  String decodeUrlString(String s) {
+    return URLDecoder.decode(s.replace("+", "%2B"), StandardCharsets.UTF_8);
+  }
+
   private String normalizeWebDavPath(String webDavPath) {
     if (StringUtils.isBlank(webDavPath) || StringUtils.equals(webDavPath, "/")) {
       return "/";
     }
     String normalized = Arrays.stream(webDavPath.split("/"))
                               .filter(StringUtils::isNotBlank)
-                              .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
+                              .map(this::decodeUrlString)
                               .map(this::encodeUrlString)
                               .collect(Collectors.joining("/"));
     return "/" + normalized;
@@ -708,7 +690,7 @@ public class PathCommandHandler {
     String firstSegment = Arrays.stream(webDavPath.split("/"))
                                 .filter(StringUtils::isNotBlank)
                                 .findFirst()
-                                .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
+                                .map(this::decodeUrlString)
                                 .orElse(null);
     if (firstSegment != null && firstSegment.endsWith(")") && firstSegment.contains("(")) {
       return firstSegment.substring(firstSegment.lastIndexOf('(') + 1, firstSegment.lastIndexOf(')'));
@@ -728,7 +710,7 @@ public class PathCommandHandler {
     return Arrays.stream(StringUtils.defaultString(webDavPath).split("/"))
                  .filter(StringUtils::isNotBlank)
                  .reduce((first, second) -> second)
-                 .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
+                 .map(this::decodeUrlString)
                  .orElse(null);
   }
 

--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavWriteCommandHandler.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/webdav/plugin/WebdavWriteCommandHandler.java
@@ -16,46 +16,16 @@
  */
 package org.exoplatform.documents.storage.jcr.webdav.plugin;
 
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_NAME;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_SORTABLE;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.EXO_TITLE;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_CONTENT;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_DATA;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_ENCODING;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_LAST_MODIFIED;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.JCR_MIME_TYPE;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.MIX_LOCKABLE;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.MIX_VERSIONABLE;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.NT_FILE;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.NT_FOLDER;
-import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.NT_RESOURCE;
+import static org.exoplatform.documents.storage.jcr.util.NodeTypeConstants.*;
 import static org.exoplatform.documents.storage.jcr.util.Utils.encodeNodeName;
 import static org.exoplatform.documents.webdav.model.constant.PropertyConstants.getStatusDescription;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 
-import javax.jcr.AccessDeniedException;
-import javax.jcr.Item;
-import javax.jcr.ItemNotFoundException;
-import javax.jcr.Node;
-import javax.jcr.NodeIterator;
-import javax.jcr.PathNotFoundException;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.Workspace;
+import javax.jcr.*;
 import javax.jcr.lock.Lock;
 import javax.jcr.lock.LockException;
 import javax.jcr.version.Version;
@@ -196,7 +166,7 @@ public class WebdavWriteCommandHandler {
     if (session.itemExists(jcrPath)) {
       Node existingNode = (Node) session.getItem(jcrPath);
       String existingNodeWebDavPath = pathCommandHandler.getOrCreateWebDavPath(existingNode);
-      if (StringUtils.equals(URLDecoder.decode(existingNodeWebDavPath, StandardCharsets.UTF_8),
+      if (StringUtils.equals(pathCommandHandler.decodeUrlString(existingNodeWebDavPath),
                              webDavPath)) {
         node = existingNode;
       } else {

--- a/documents-webdav-webapp/src/main/java/org/exoplatform/documents/webdav/plugin/WebDavHttpMethodPlugin.java
+++ b/documents-webdav-webapp/src/main/java/org/exoplatform/documents/webdav/plugin/WebDavHttpMethodPlugin.java
@@ -28,26 +28,11 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import javax.xml.namespace.QName;
-import javax.xml.stream.FactoryConfigurationError;
-import javax.xml.stream.XMLEventReader;
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.*;
 import javax.xml.stream.events.Characters;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
@@ -147,7 +132,7 @@ public abstract class WebDavHttpMethodPlugin {
 
   protected String getResourcePath(HttpServletRequest httpRequest) {
     String resourcePath = Arrays.stream(httpRequest.getRequestURI().substring(getBaseUri(httpRequest).length()).split("/"))
-                                .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
+                                .map(WebDavHttpMethodPlugin::decodePathSegment)
                                 .collect(Collectors.joining("/"));
     return StringUtils.isBlank(resourcePath) ? "/" : resourcePath;
   }
@@ -155,9 +140,18 @@ public abstract class WebDavHttpMethodPlugin {
   @SneakyThrows
   protected URI getResourceUri(HttpServletRequest httpRequest) {
     return new URI(getBaseUrl(httpRequest) + Arrays.stream(getResourcePath(httpRequest).split("/"))
-                                                   .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
                                                    .map(s -> URLEncoder.encode(s, StandardCharsets.UTF_8).replace("+", "%20"))
                                                    .collect(Collectors.joining("/")));
+  }
+
+  /**
+   * Decodes a raw URI path segment. Unlike {@link URLDecoder#decode(String, java.nio.charset.Charset)},
+   * which implements {@code application/x-www-form-urlencoded} semantics and wrongly turns a literal
+   * '+' into a space, this only unescapes percent-encoded sequences and leaves literal '+' untouched,
+   * since '+' has no special meaning in a URI path segment (RFC 3986).
+   */
+  protected static String decodePathSegment(String segment) {
+    return URLDecoder.decode(segment.replace("+", "%2B"), StandardCharsets.UTF_8);
   }
 
   protected String getBaseUrl(HttpServletRequest httpRequest) {
@@ -196,7 +190,7 @@ public abstract class WebDavHttpMethodPlugin {
                                                                  .split(getBaseUri(httpRequest)))
                                               .getLast()
                                               .split("/"))
-                                .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
+                                .map(WebDavHttpMethodPlugin::decodePathSegment)
                                 .collect(Collectors.joining("/"));
     return StringUtils.isBlank(resourcePath) ? "/" : resourcePath;
   }


### PR DESCRIPTION
Prior to this, uploading, renaming, or moving a WebDAV file whose name contained a literal '+' corrupted the name on the server, causing WebDAV clients to fail the operation with a generic read/import error, and the Documents UI to display a different name than the one shown in the WebDAV client.

This is caused by using URLDecoder.decode() to decode WebDAV URI path segments, destination headers, and JCR node names. URLDecoder implements application/x-www-form-urlencoded semantics, where '+' means "space", but a '+' in a URI path segment has no such special meaning (RFC 3986) and most WebDAV clients send it unescaped.

This commit fixes the problem by pre-escaping literal '+' to '%2B' before calling URLDecoder.decode() everywhere a WebDAV path segment or node name is decoded, so percent-encoded sequences still decode correctly while a literal '+' is preserved instead of being turned into a space.