### PR TITLE
fix: download document with "+" in name from three-dots menu - EXO-88319

### DIFF
--- a/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DownloadMenuAction.vue
+++ b/documents-webapp/src/main/webapp/vue-app/documents/components/body/actions/DownloadMenuAction.vue
@@ -39,31 +39,21 @@ export default {
           this.$root.$emit('close-file-action-menu');
           return;
         }
-        this.$attachmentService.getAttachmentById(this.file.id)
-          .then(attachment => {
-            this.downloadUrl = attachment.downloadUrl.replaceAll('%', '%25').replaceAll('+', '%2B');
-          })
-          .catch(e => console.error(e))
-          .finally(() => {
-            const urlDownload = this.downloadUrl;
-            const fileName = this.file.name;
-            if (urlDownload.indexOf('/') > 0 && !urlDownload.includes(window.location.hostname)) {
-              return;
-            }
-            const a = document.createElement('a');
-            a.href = urlDownload;
-            a.download = fileName.replace(/\[[0-9]*\]$/g, '');
-            document.body.appendChild(a);
-            a.click();
-            a.remove();
-            document.dispatchEvent(new CustomEvent('download-file', {
-              detail: {
-                'type': 'file',
-                'id': this.file.id,
-                'spaceId': this.spaceId,
-              }
-            }));
-          });
+        const urlDownload = this.$documentsUtils.getDownloadUrl(this.file.id, this.file.lastModified);
+        const fileName = this.file.name;
+        const a = document.createElement('a');
+        a.href = urlDownload;
+        a.download = fileName.replace(/\[[0-9]*\]$/g, '');
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        document.dispatchEvent(new CustomEvent('download-file', {
+          detail: {
+            'type': 'file',
+            'id': this.file.id,
+            'spaceId': this.spaceId,
+          }
+        }));
         if ( this.isMobile ) {
           this.$root.$emit('close-file-action-menu');
         }


### PR DESCRIPTION
Download via the id-based content endpoint (`/v1/documents/content/{id}`) instead of string-patching the WebDAV attachment URL. 
The old code ran `replaceAll('%','%25').replaceAll('+','%2B')` over the whole URL, which double-encoded already-encoded segments and returned a 404 for names containing "+". The id-based URL never carries the file name in its path, so special characters can no longer break the download.