### PR TITLE
fix: Download document - Infinit loading if selected files include sumlink file - EXO-85989

### DIFF
--- a/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
+++ b/documents-storage-jcr/src/main/java/org/exoplatform/documents/storage/jcr/util/JCRDocumentsUtil.java
@@ -966,6 +966,14 @@ public class JCRDocumentsUtil {
     if (node == null) {
       return;
     }
+    if (node.isNodeType(NodeTypeConstants.EXO_SYMLINK)) {
+      String sourceID = node.getProperty(NodeTypeConstants.EXO_SYMLINK_UUID).getString();
+      Node sourceNode = getNodeByIdentifier(node.getSession(), sourceID);
+      if (sourceNode != null) {
+        createFile(sourceNode, getPathWithTitles(node), getPathWithTitles(sourceNode), tempFolderPath, parentNode);
+      }
+      return;
+    }
     Node jrcNode = node.getNode("jcr:content");
     InputStream inputStream = jrcNode.getProperty("jcr:data").getStream();
     String path = "";


### PR DESCRIPTION
Before this change, select a symlink file without any folder and request a zip download caused infinite loading. To fix this, createFile() now resolves exo:symlink nodes to their source node via exo:uuid before reading the content, mirroring the existing behavior in createTempFilesAndFolders(). After this change, the zip is downloaded successfully and includes the symlinked file content.